### PR TITLE
Updating meta.yaml test requirements

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -28,6 +28,8 @@ test:
   source_files:
     - test
   requires:
+    - dask
+    - netcdf4
     - pytest
   imports:
     - uxarray


### PR DESCRIPTION
Updates in line with what was discussed on Tuesday for testing. Please double check that the new requirements are in the correct locations for the file, and that only the dask and netcdf4 packages are all that needed to be added