### PR TITLE
Fix docs by pinning numpy in requirements.txt 

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,6 +9,9 @@ build:
   os: "ubuntu-20.04"
   tools:
     python: "mambaforge-4.10"
+  jobs:
+    post_install:
+      - pip install numpy==1.22
 
 python:
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,9 +9,6 @@ build:
   os: "ubuntu-20.04"
   tools:
     python: "mambaforge-4.10"
-  jobs:
-    post_install:
-      - pip install numpy==1.22
 
 python:
   install:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 xarray
-numpy==1.22
+numpy>=1.2,<=1.22

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 xarray
+numpy==1.22


### PR DESCRIPTION
This was a weird one. In summary, RTD installs uxarray from source with:

``` bash
python -m pip install --upgrade --upgrade-strategy eager --no-cache-dir .
```

This uninstalls the pinned `numpy=1.22` and replaces it with the newest version of numpy, regardless of the pinning. See this [raw output](https://readthedocs.org/api/v2/build/17384086.txt):
<img width="1411" alt="image" src="https://user-images.githubusercontent.com/38434768/177878599-8d2bd709-2560-4472-a397-43d8da1472dc.png">


This (as far as we could tell) not be changed. We can, however, edit `.readthedocs.yml` to include a `post_install` step that re-installs `numpy==1.22`. 