### PR TITLE
Off integration

### DIFF
--- a/uxarray/get_quadratureDG.py
+++ b/uxarray/get_quadratureDG.py
@@ -1,5 +1,7 @@
 import numpy as np
-from numba import njit
+from numba import njit, config
+
+config.DISABLE_JIT = False
 
 
 @njit

--- a/uxarray/grid.py
+++ b/uxarray/grid.py
@@ -238,35 +238,6 @@ class Grid:
             "nMaxMesh2_face_nodes": "nMaxMesh2_face_nodes"
         }
 
-    def __init_grid_var_attrs__(self):
-        """Initialize attributes for directly accessing Coordinate and Data
-        variables through ugrid conventions.
-
-        Examples
-        ----------
-        Assuming the mesh node coordinates for longitude are stored with an input
-        name of 'mesh_node_x', we store this variable name in the `ds_var_names`
-        dictionary with the key 'Mesh2_node_x'. In order to access it:
-
-        >>> x = grid.ds[grid.ds_var_names["Mesh2_node_x"]]
-
-        With the help of this function, we can directly access it through the
-        use of a standardized name (ugrid convention)
-        >>> x = grid.Mesh2_node_x
-        """
-
-        # Set UGRID standardized attributes
-        for key, value in self.ds_var_names.items():
-            # Present Data Names
-            if self.ds.data_vars is not None:
-                if value in self.ds.data_vars:
-                    setattr(self, key, self.ds[value])
-
-            # Present Coordinate Names
-            if self.ds.coords is not None:
-                if value in self.ds.coords:
-                    setattr(self, key, self.ds[value])
-
     def integrate(self, var_key, quadrature_rule="triangular", order=4):
         """ Integrates over all the faces of the given mesh.
         Parameters
@@ -367,7 +338,7 @@ class Grid:
         >>> x = grid.Mesh2_node_x
         """
 
-        # Set UGRID standardized attribtues
+        # Set UGRID standardized attributes
         for key, value in self.ds_var_names.items():
             # Present Data Names
             if self.ds.data_vars is not None:

--- a/uxarray/helpers.py
+++ b/uxarray/helpers.py
@@ -3,7 +3,9 @@ import xarray as xr
 from pathlib import PurePath
 
 from .get_quadratureDG import get_gauss_quadratureDG, get_tri_quadratureDG
-from numba import njit
+from numba import njit, config
+
+config.DISABLE_JIT = False
 
 
 def parse_grid_type(filepath, **kw):


### PR DESCRIPTION
This PR does two things:

1. When Numba JIT is enabled, debugging and profiling those functions decorated with @njit is disabled. For developer's debugging purposes, added a `config.DISABLE_JIT = False` to two scripts where there are njit decorators. It has no effect when it is false, but when the developer wants to debug those functions, they should set this to True IN THEIR LOCAL, but it should always be False in the `main` branch to enable JIT
2. Just alphabetically ordered the `__init...`, private, and public function groups in grid.py and helpers.py.