### PR TITLE
Fix the upstream CI and Sphinx 5.1.0 issue

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -11,6 +11,5 @@ dependencies:
   - pre_commit
   - pytest
   - pytest-cov
-  - python
   - scipy
   - xarray

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -11,5 +11,6 @@ dependencies:
   - pre_commit
   - pytest
   - pytest-cov
+  - python
   - scipy
   - xarray

--- a/ci/upstream-dev-environment.yml
+++ b/ci/upstream-dev-environment.yml
@@ -3,11 +3,15 @@ channels:
   - conda-forge
 dependencies:
   - netcdf4
+  - numba
+  # pinning the numpy version for numba compatibility
+  - numpy>=1.2, <1.22
   - pathlib
   - python
   - pytest
   - pytest-cov
   - pip
+  - scipy
   - pip:
     - git+https://github.com/pydata/xarray.git
     - git+https://github.com/dask/dask.git

--- a/uxarray/grid.py
+++ b/uxarray/grid.py
@@ -337,7 +337,7 @@ class Grid:
     # use the property keyword for declaration on face_areas property
     @property
     def face_areas(self):
-        """Declare on face_areas as a property."""
+        """Declare face_areas as a property."""
 
         if self._face_areas is None:
             self.compute_face_areas()

--- a/uxarray/grid.py
+++ b/uxarray/grid.py
@@ -337,6 +337,8 @@ class Grid:
     # use the property keyword for declaration on face_areas property
     @property
     def face_areas(self):
+        """Declare on face_areas as a property."""
+
         if self._face_areas is None:
             self.compute_face_areas()
         return self._face_areas

--- a/uxarray/helpers.py
+++ b/uxarray/helpers.py
@@ -106,8 +106,8 @@ def _spherical_to_cartesian_unit_(node, r=6371):
 
     Final output is cartesian coordinates on a sphere of unit radius
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     node: a list consisting of lat and lon
 
     Returns: numpy array


### PR DESCRIPTION
- Add numba and pinned numpy to upstream ci. 
- Remove python from ci
- RTD recently switched to Sphinx 5.1.0, which led to docs build issues with functions without docstrings. Fix that for `face_areas`