### PR TITLE
Updates to meta.yaml for conda-forge build tests

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -14,6 +14,7 @@ source:
   git_tag: v{{ version }}   # For building from a specific tag
   git_url: https://github.com/UXARRAY/uxarray
   #url: https://github.com/UXARRAY/uxarray/archive/v{{ version }}.tar.gz   # For building from a specific tag's tarball
+  #path: . # for building from a local directory
 
 requirements:
   host:
@@ -31,10 +32,16 @@ test:
     - dask
     - netcdf4
     - pytest
+    - numba
+    - numpy>=1.2,<1.22
+    - scipy>=0.16
+    - xarray
   imports:
     - uxarray
   commands:
-    - pytest test
+    - conda info
+    - conda list
+    - python -m pytest
 
 about:
 #  home: https://


### PR DESCRIPTION
Summary of changes:
- adds the following to the test requirements
    - numba
    - numpy>=1.2,<1.22
    - scipy>=0.16
    - xarray
- adds `conda info` and `conda list` to the test commands section for debugging help in the future
- adds an additional commented out source option for local building and testing

For reference, this was tested only locally after recreating the issues on the conda-forge pipeline on my machine. The errors on the pipeline can be recreated locally by running `conda build .`

We found that conda didn't actually need numpy, numba, or scipy to build the package, but instead the pipeline was only failing on the testing step. Looking at the differences in the development environment where the tests pass and the created testing environment during the build process, these seem to be the minimal changes in order to successfully run the tests during the build process.