### PR TITLE
Add source_grid and source_datasets into Grid attributes

### DIFF
--- a/docs/user_api/uxarray_api.md
+++ b/docs/user_api/uxarray_api.md
@@ -16,10 +16,6 @@ Describes an unstructured grid.
   MaxNumFacesPerNode (max number of faces per node),Two, Three, Four}`
 
 
-- uxarray.Grid.filename: string \
-  Original filename for this uxarray.Grid.
-
-
 - (*) uxarray.Grid.islatlon: boolean \
   A flag indicating the grid is a latitude longitude grid.
 
@@ -32,6 +28,16 @@ Describes an unstructured grid.
 
 - (*) uxarray.Grid.edgedual: uxarray.Grid \
   The edge dual grid.
+
+
+- uxarray.Grid.source_grid: string \
+  The source file for this uxarray.Grid's definition (For
+  diagnostics and reporting purposes).
+
+
+- uxarray.Grid.source_datasets: string \
+  The source file(s) for this uxarray.Grid's corresponding
+  data (For diagnostics and reporting purposes).
 
 
 - (*) uxarray.Grid.vertexdual: uxarray.Grid \

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -37,6 +37,9 @@ class TestDataset(TestCase):
 
         assert (len(ux_ds3.ds.data_vars) == constants.DATAVARS_outCSne30)
 
+        assert (ux_ds1.source_grid == uds1_name)
+        assert (ux_ds1.source_datasets is None)
+
     def test_open_single_dataset(self):
         """Loads one grid and data file using uxarray's open_dataset call."""
 
@@ -44,6 +47,10 @@ class TestDataset(TestCase):
 
         assert (uds3.Mesh2_node_x.size == constants.NNODES_outCSne30)
         assert (len(uds3.ds.data_vars) == constants.DATAVARS_outCSne30 + 1)
+
+        assert (uds3.source_grid == uds3_name)
+        assert (len(uds3.source_datasets) == 1)
+        assert (uds3.source_datasets[0] == uds3_data_name1)
 
     def test_open_multiple_dataset(self):
         """Loads a grid file and two data files of different formats using
@@ -53,6 +60,11 @@ class TestDataset(TestCase):
 
         assert (uds3.Mesh2_node_x.size == constants.NNODES_outCSne30)
         assert (len(uds3.ds.data_vars) == constants.DATAVARS_outCSne30 + 2)
+
+        assert (uds3.source_grid == uds3_name)
+        assert (len(uds3.source_datasets) == 2)
+        assert (uds3.source_datasets[0] == uds3_data_name1)
+        assert (uds3.source_datasets[1] == uds3_data_name2)
 
     def test_open_non_mesh2_write_exodus(self):
         """Loads grid files of different formats using uxarray's open_dataset

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -40,6 +40,9 @@ class TestGrid(TestCase):
         verts = np.array([[0, 0], [2, 0], [0, 2], [2, 2]])
         vgrid = ux.Grid(verts, vertices=True, islatlon=True, concave=False)
 
+        assert (vgrid.source_grid == "From vertices")
+        assert (vgrid.source_datasets is None)
+
         face_filename = current_path / "meshfiles" / "1face.ug"
         vgrid.write(face_filename)
 

--- a/uxarray/grid.py
+++ b/uxarray/grid.py
@@ -64,7 +64,8 @@ class Grid:
         # unpack kwargs
         # sets default values for all kwargs to None
         kwargs_list = [
-            'gridspec', 'vertices', 'islatlon', 'concave', 'mesh_filetype'
+            'gridspec', 'vertices', 'islatlon', 'concave', 'mesh_filetype',
+            'source_grid', 'source_datasets'
         ]
         for key in kwargs_list:
             setattr(self, key, kwargs.get(key, None))
@@ -76,6 +77,8 @@ class Grid:
         if isinstance(dataset, (list, tuple, np.ndarray)):
             self.vertices = dataset
             self.__from_vert__()
+            source_grid = "From vertices",
+            source_datasets = None
 
         # check if initializing from string
         # TODO: re-add gridspec initialization when implemented

--- a/uxarray/grid.py
+++ b/uxarray/grid.py
@@ -77,8 +77,8 @@ class Grid:
         if isinstance(dataset, (list, tuple, np.ndarray)):
             self.vertices = dataset
             self.__from_vert__()
-            source_grid = "From vertices",
-            source_datasets = None
+            self.source_grid = "From vertices"
+            self.source_datasets = None
 
         # check if initializing from string
         # TODO: re-add gridspec initialization when implemented


### PR DESCRIPTION
This PR addresses that tasks mentioned in Issue #40. Namely,

- Adds 'source_grid' and 'source_datasets' attributes into Grid class, for keeping track of source files for diagnostics and reporting purposes only.
- Originally this attribute was anticipated to be named `Grid.filename`, but since there might be multiple files (i.e. grid file and datasets file(s)) and it can be either a file path or URL, I ended up with the names 'source_grid' and 'source_datasets' instead
   - Modified the draft API document to reflect this accordingly
- Adds assertions into the test cases to ensure this behavior works properly
- Updates the docstrings of the `dataset.py` module to fix some forgotten older names and to better reflect the changes of this PR 