### PR TITLE
Add open_dataset to api generation

### DIFF
--- a/docs/user_api/index.rst
+++ b/docs/user_api/index.rst
@@ -16,14 +16,22 @@ Grid Class
    grid.Grid
 
 Grid Methods
---------------
+------------
 .. autosummary::
    :toctree: _autosummary
 
-   grid.Grid.write
    grid.Grid.calculate_total_face_area
-   grid.Grid.integrate
    grid.Grid.compute_face_areas
+   grid.Grid.integrate
+   grid.Grid.write
+
+Reading Data
+------------
+.. autosummary::
+   :toctree: _autosummary
+
+   uxarray.open_dataset
+
 
 Helper Functions
 ----------------

--- a/uxarray/dataset.py
+++ b/uxarray/dataset.py
@@ -25,7 +25,7 @@ def open_dataset(grid_file, *args, **kw):
     Returns
     -------
 
-    object : uxarray Grid
+    object : UXarray Grid
         UXarray Grid object that contains the grid definition and corresponding
         data.
 
@@ -38,6 +38,15 @@ def open_dataset(grid_file, *args, **kw):
     Open grid file along with data
 
     >>> mesh_and_data = ux.open_dataset("grid_filename.g", "grid_filename_vortex.nc")
+
+    Open grid file along with multiple data files (two or more)
+
+    >>> mesh_and_data_2 = ux.open_dataset("grid_filename.g", "grid_filename_vortex_1.nc", "grid_filename_vortex_2.nc")
+
+    Open grid file along with a list of data files
+
+    >>> data_files = ["grid_filename_vortex_1.nc", "grid_filename_vortex_2.nc", "grid_filename_vortex_3.nc"]
+    >>> mesh_and_data = ux.open_dataset("grid_filename.g", *data_files)
     """
     mesh_filetype, dataset = parse_grid_type(grid_file, **kw)
 

--- a/uxarray/dataset.py
+++ b/uxarray/dataset.py
@@ -14,11 +14,11 @@ def open_dataset(grid_file, *args, **kw):
 
     grid_file : string, required
         Grid file is the first argument, which should be the file that
-        houses the unstructured grid definition. It should be comapatible to
+        houses the unstructured grid definition. It should be compatible to
         be opened with xarray.open_dataset (e.g. path to a file in the local
         storage, OpenDAP URL, etc).
     *args : string, optional
-        Data file(s) corresponding to the grid_file. They should be comapatible
+        Data file(s) corresponding to the grid_file. They should be compatible
         to be opened with xarray.open_dataset (e.g. path to a file in the local
         storage, OpenDAP URL, etc).
 
@@ -31,12 +31,12 @@ def open_dataset(grid_file, *args, **kw):
 
     Examples
     --------
-
     Open grid file only
+
     >>> mesh = ux.open_dataset("grid_filename.g")
 
-
     Open grid file along with data
+
     >>> mesh_and_data = ux.open_dataset("grid_filename.g", "grid_filename_vortex.nc")
     """
     mesh_filetype, dataset = parse_grid_type(grid_file, **kw)


### PR DESCRIPTION
Addresses #122 

Summary of changes:
- minor formatting changes in api index file (alphabetization, making underline same length as title)
- Adds section for dataset functions in user api
- adds `open_dataset()` to a toctree in user api
- minor formatting changes to `open_dataset()` docstring for better sphinx generation