### PR TITLE
Add function and tests for encoder function

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -13,4 +13,3 @@ dependencies:
   - pytest-cov
   - scipy
   - xarray
-  - zarr

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -13,3 +13,4 @@ dependencies:
   - pytest-cov
   - scipy
   - xarray
+  - zarr

--- a/docs/internal_api/index.rst
+++ b/docs/internal_api/index.rst
@@ -27,12 +27,12 @@ Grid Helper Modules
    :toctree: ./generated/
 
    _exodus._read_exodus
-   _exodus._write_exodus
+   _exodus._encode_exodus
    _exodus._get_element_type
-   _ugrid._write_ugrid
+   _ugrid._encode_ugrid
    _ugrid._read_ugrid
    _scrip._read_scrip
-   _scrip._write_scrip
+   _scrip._encode_scrip
    _scrip._to_ugrid
    helpers._is_ugrid
    helpers._convert_node_xyz_to_lonlat_rad

--- a/docs/user_api/index.rst
+++ b/docs/user_api/index.rst
@@ -23,8 +23,8 @@ Grid Methods
 
    grid.Grid.calculate_total_face_area
    grid.Grid.compute_face_areas
+   grid.Grid.encode_as
    grid.Grid.integrate
-   grid.Grid.write
 
 Reading Data
 ------------

--- a/docs/user_api/uxarray_api.md
+++ b/docs/user_api/uxarray_api.md
@@ -131,9 +131,9 @@ document, but they could be different.
 - uxarray.Grid.__init__(self, np.float64.list vertices) \
   Create a grid with one face with vertices specified by the given argument.
 
-- uxarray.Grid.write(self, string file, string format) \
-  Write a uxgrid to a file with specified format (UGRID, SCRIP, Exodus,
-  or SHP).
+- uxarray.Grid.encode_as(self, string grid_type) \
+  Encode a `uxarray.Grid` as a `xarray.Dataset`in the specified grid type
+  (UGRID, SCRIP, Exodus, or SHP).
 
 - uxarray.Grid.calculatefaceareas(self) \
   Calculate the area of all faces.

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -65,9 +65,3 @@ class TestDataset(TestCase):
         assert (len(uds3.source_datasets) == 2)
         assert (uds3.source_datasets[0] == uds3_data_name1)
         assert (uds3.source_datasets[1] == uds3_data_name2)
-
-    def test_open_non_mesh2_write_exodus(self):
-        """Loads grid files of different formats using uxarray's open_dataset
-        call."""
-        grid = ux.open_dataset(mesh_name)
-        grid.write("exodus")

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -70,4 +70,4 @@ class TestDataset(TestCase):
         """Loads grid files of different formats using uxarray's open_dataset
         call."""
         grid = ux.open_dataset(mesh_name)
-        grid.write(outmesh, "exodus")
+        grid.write("exodus")

--- a/test/test_exodus.py
+++ b/test/test_exodus.py
@@ -18,7 +18,7 @@ class TestExodus(TestCase):
         exo2_filename = current_path / "meshfiles" / "outCSne8.g"
         tgrid = ux.open_dataset(str(exo2_filename))
         outfile = current_path / "write_test_outCSne8.g"
-        tgrid.write(str(outfile), "exodus")
+        tgrid.write("exodus").to_netcdf(str(outfile))
 
     def test_init_verts(self):
         """Create a uxarray grid from vertices and saves a 1 face exodus
@@ -27,7 +27,7 @@ class TestExodus(TestCase):
         vgrid = ux.Grid(verts)
 
         face_filename = current_path / "meshfiles" / "1face.g"
-        vgrid.write(face_filename, "exodus")
+        vgrid.write("exodus").to_netcdf(str(face_filename))
 
     def test_mixed_exodus(self):
         """Read/write an exodus file with two types of faces (triangle and
@@ -36,6 +36,7 @@ class TestExodus(TestCase):
         exo2_filename = current_path / "meshfiles" / "mixed.exo"
         tgrid = ux.open_dataset(str(exo2_filename))
         outfile = current_path / "write_test_mixed.ug"
-        tgrid.write(str(outfile), "ugrid")
+
+        tgrid.write("ugrid").to_netcdf(str(outfile))
         outfile = current_path / "write_test_mixed.exo"
-        tgrid.write(str(outfile), "exodus")
+        tgrid.write("exodus").to_netcdf(str(outfile))

--- a/test/test_exodus.py
+++ b/test/test_exodus.py
@@ -1,6 +1,5 @@
 import os
 import numpy as np
-import xarray as xr
 
 from unittest import TestCase
 from pathlib import Path
@@ -17,8 +16,6 @@ class TestExodus(TestCase):
 
         exo2_filename = current_path / "meshfiles" / "outCSne8.g"
         tgrid = ux.open_dataset(str(exo2_filename))
-        outfile = current_path / "write_test_outCSne8.g"
-        tgrid.write("exodus").to_netcdf(str(outfile))
 
     def test_init_verts(self):
         """Create a uxarray grid from vertices and saves a 1 face exodus
@@ -26,17 +23,10 @@ class TestExodus(TestCase):
         verts = np.array([[0, 0], [2, 0], [0, 2], [2, 2]])
         vgrid = ux.Grid(verts)
 
-        face_filename = current_path / "meshfiles" / "1face.g"
-        vgrid.write("exodus").to_netcdf(str(face_filename))
+    def test_encode_exodus(self):
+        """Read a UGRID dataset and encode that as an Exodus format."""
 
-    def test_mixed_exodus(self):
-        """Read/write an exodus file with two types of faces (triangle and
-        quadrilaterals) and writes a ugrid file."""
-
-        exo2_filename = current_path / "meshfiles" / "mixed.exo"
+        exo2_filename = current_path / "meshfiles" / "outCSne30.ug"
         tgrid = ux.open_dataset(str(exo2_filename))
-        outfile = current_path / "write_test_mixed.ug"
 
-        tgrid.write("ugrid").to_netcdf(str(outfile))
-        outfile = current_path / "write_test_mixed.exo"
-        tgrid.write("exodus").to_netcdf(str(outfile))
+        tgrid.encode_as("exodus")

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -49,7 +49,7 @@ class TestGrid(TestCase):
         tgrid2.write(str(ug_outfile2), "scrip")
         tgrid3.write(str(ug_outfile3), "scrip")
 
-    def test_write_to_file(selfs):
+    def test_write_to_file(self):
         """Tests that the writer functions create a correctly formatted file
         when correct arguments are used in writer call."""
         # Read in ugrid file to be used in writer funcitons

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -52,7 +52,7 @@ class TestGrid(TestCase):
     def test_write_to_file(self):
         """Tests that the writer functions create a correctly formatted file
         when correct arguments are used in writer call."""
-        # Read in ugrid file to be used in writer funcitons
+        # Read in ugrid file to be used in writer functions
         ug_filename1 = current_path / "meshfiles" / "outCSne30.ug"
         tgrid1 = ux.open_dataset(str(ug_filename1))
 
@@ -62,7 +62,7 @@ class TestGrid(TestCase):
         ugrid_outfile = current_path / "meshfiles" / "test_ugrid_to_netcdf.nc"
 
         # User writer function with encoder argument
-        tgrid1.write(str(scrip_outfile), "scrip", "netcdf")
+        tgrid1.write(str(scrip_outfile), "scrip", 'netcdf')
         tgrid1.write(str(exodus_outfile), "exodus", "netcdf")
         tgrid1.write(str(ugrid_outfile), "ugrid", "netcdf")
 

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -64,21 +64,25 @@ class TestGrid(TestCase):
         to using the dict."""
 
         # Dataset with standard UGRID variable names
-
         # Coordinates
-        xr.testing.assert_equal(self.tgrid1.Mesh2_node_x,
-                                self.tgrid1.ds[self.tgrid1.ds_var_names["Mesh2_node_x"]])
-        xr.testing.assert_equal(self.tgrid1.Mesh2_node_y,
-                                self.tgrid1.ds[self.tgrid1.ds_var_names["Mesh2_node_y"]])
+        xr.testing.assert_equal(
+            self.tgrid1.Mesh2_node_x,
+            self.tgrid1.ds[self.tgrid1.ds_var_names["Mesh2_node_x"]])
+        xr.testing.assert_equal(
+            self.tgrid1.Mesh2_node_y,
+            self.tgrid1.ds[self.tgrid1.ds_var_names["Mesh2_node_y"]])
         # Variables
-        xr.testing.assert_equal(self.tgrid1.Mesh2_face_nodes,
-                                self.tgrid1.ds[self.tgrid1.ds_var_names["Mesh2_face_nodes"]])
+        xr.testing.assert_equal(
+            self.tgrid1.Mesh2_face_nodes,
+            self.tgrid1.ds[self.tgrid1.ds_var_names["Mesh2_face_nodes"]])
 
         # Dimensions
-        xr.testing.assert_equal(self.tgrid1.nMesh2_node,
-                                self.tgrid1.ds[self.tgrid1.ds_var_names["nMesh2_node"]])
-        xr.testing.assert_equal(self.tgrid1.nMesh2_face,
-                                self.tgrid1.ds[self.tgrid1.ds_var_names["nMesh2_face"]])
+        xr.testing.assert_equal(
+            self.tgrid1.nMesh2_node,
+            self.tgrid1.ds[self.tgrid1.ds_var_names["nMesh2_node"]])
+        xr.testing.assert_equal(
+            self.tgrid1.nMesh2_face,
+            self.tgrid1.ds[self.tgrid1.ds_var_names["nMesh2_face"]])
 
         # Dataset with non-standard UGRID variable names
         path = current_path / "meshfiles" / "mesh.nc"

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -62,7 +62,8 @@ class TestGrid(TestCase):
         ugrid_outfile = current_path / "meshfiles" / "test_ugrid_to_netcdf.nc"
 
         # User writer function with encoder argument
-        tgrid1.write(str(scrip_outfile), "scrip", 'netcdf')
+        tgrid1.write(str(scrip_outfile), "scrip", 'netcdf',
+                     mode='w')  # test kwargs work
         tgrid1.write(str(exodus_outfile), "exodus", "netcdf")
         tgrid1.write(str(ugrid_outfile), "ugrid", "netcdf")
 
@@ -79,7 +80,8 @@ class TestGrid(TestCase):
         ugrid_outfile = current_path / "meshfiles" / "test_ugrid_to_zarr.zarr"
 
         # User writer function with encoder argument
-        tgrid1.write(str(scrip_outfile), "scrip", "zarr")
+        tgrid1.write(str(scrip_outfile), "scrip", "zarr",
+                     store=scrip_outfile)  # test kwargs work
         tgrid1.write(str(exodus_outfile), "exodus", "zarr")
         tgrid1.write(str(ugrid_outfile), "ugrid", "zarr")
 

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -45,9 +45,8 @@ class TestGrid(TestCase):
         tgrid2 = ux.open_dataset(str(ug_filename2))
         tgrid3 = ux.open_dataset(str(ug_filename3))
 
-        tgrid1.write(str(ug_outfile1), "scrip",
-                     "netcdf")  # Creates new netcdf file
-        tgrid2.write(str(ug_outfile2), "scrip")  # Does not create new file
+        tgrid1.write(str(ug_outfile1), "scrip")
+        tgrid2.write(str(ug_outfile2), "scrip")
         tgrid3.write(str(ug_outfile3), "scrip")
 
     def test_write_to_file(selfs):

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -12,80 +12,38 @@ current_path = Path(os.path.dirname(os.path.realpath(__file__)))
 
 class TestGrid(TestCase):
 
-    def test_read_ugrid_write_exodus(self):
-        """Reads a ugrid file and writes and exodus file."""
+    ug_filename1 = current_path / "meshfiles" / "outCSne30.ug"
+    ug_filename2 = current_path / "meshfiles" / "outRLL1deg.ug"
+    ug_filename3 = current_path / "meshfiles" / "ov_RLL10deg_CSne4.ug"
 
-        ug_filename1 = current_path / "meshfiles" / "outCSne30.ug"
-        ug_filename2 = current_path / "meshfiles" / "outRLL1deg.ug"
-        ug_filename3 = current_path / "meshfiles" / "ov_RLL10deg_CSne4.ug"
+    tgrid1 = ux.open_dataset(str(ug_filename1))
+    tgrid2 = ux.open_dataset(str(ug_filename2))
+    tgrid3 = ux.open_dataset(str(ug_filename3))
 
-        ug_outfile1 = current_path / "meshfiles" / "outCSne30.exo"
-        ug_outfile2 = current_path / "meshfiles" / "outRLL1deg.g"
-        ug_outfile3 = current_path / "meshfiles" / "ov_RLL10deg_CSne4.g"
+    def test_encode_as(self):
+        """Reads a ugrid file and encodes it as `xarray.Dataset` in various
+        types."""
 
-        tgrid1 = ux.open_dataset(str(ug_filename1))
-        tgrid2 = ux.open_dataset(str(ug_filename2))
-        tgrid3 = ux.open_dataset(str(ug_filename3))
+        self.tgrid1.encode_as("ugrid")
+        self.tgrid2.encode_as("ugrid")
+        self.tgrid3.encode_as("ugrid")
 
-        tgrid1.write("exodus")
-        tgrid2.write("exodus")
-        tgrid3.write("exodus")
+        self.tgrid1.encode_as("exodus")
+        self.tgrid2.encode_as("exodus")
+        self.tgrid3.encode_as("exodus")
 
-    def test_read_ugrid_write_scrip(self):
-        """Reads in augrid file and writes to a scrip file."""
-        ug_filename1 = current_path / "meshfiles" / "outCSne30.ug"
-        ug_filename2 = current_path / "meshfiles" / "outRLL1deg.ug"
-        ug_filename3 = current_path / "meshfiles" / "ov_RLL10deg_CSne4.ug"
+        self.tgrid1.encode_as("scrip")
+        self.tgrid2.encode_as("scrip")
+        self.tgrid3.encode_as("scrip")
 
-        ug_outfile1 = current_path / "meshfiles" / "outCSne30.nc"
-        ug_outfile2 = current_path / "meshfiles" / "outRLL1deg.nc"
-        ug_outfile3 = current_path / "meshfiles" / "ov_RLL10deg_CSne4.nc"
+    def test_open_non_mesh2_write_exodus(self):
+        """Loads grid files of different formats using uxarray's open_dataset
+        call."""
 
-        tgrid1 = ux.open_dataset(str(ug_filename1))
-        tgrid2 = ux.open_dataset(str(ug_filename2))
-        tgrid3 = ux.open_dataset(str(ug_filename3))
+        path = current_path / "meshfiles" / "mesh.nc"
+        grid = ux.open_dataset(path)
 
-        tgrid1.write("scrip")
-        tgrid2.write("scrip")
-        tgrid3.write("scrip")
-
-    def test_write_to_netcdf(self):
-        """Tests that the writer functions create a correctly formatted file
-        when correct arguments are used in writer call."""
-        # Read in ugrid file to be used in writer functions
-        ug_filename1 = current_path / "meshfiles" / "outCSne30.ug"
-        tgrid1 = ux.open_dataset(str(ug_filename1))
-
-        # Create paths for new scrip and exodus files to be stored
-        scrip_outfile = current_path / "meshfiles" / "test_scrip_to_netcdf.nc"
-        exodus_outfile = current_path / "meshfiles" / "test_exodus_to_netcdf.nc"
-        ugrid_outfile = current_path / "meshfiles" / "test_ugrid_to_netcdf.nc"
-
-        # User writer function with encoder argument
-        tgrid1.write("scrip").to_netcdf(str(scrip_outfile))
-
-        tgrid1.write("exodus").to_netcdf(str(exodus_outfile))
-
-        tgrid1.write("ugrid").to_netcdf(str(ugrid_outfile))
-
-    def test_write_to_zarr(self):
-        """Tests that the writer functions create a correctly formatted file
-        when correct arguments are used in writer call."""
-        # Read in ugrid file to be used in writer functions
-        ug_filename1 = current_path / "meshfiles" / "outCSne30.ug"
-        tgrid1 = ux.open_dataset(str(ug_filename1))
-
-        # Create paths for new scrip and exodus files to be stored
-        scrip_outfile = current_path / "meshfiles" / "test_scrip_to_zarr.zarr"
-        exodus_outfile = current_path / "meshfiles" / "test_exodus_to_zarr.zarr"
-        ugrid_outfile = current_path / "meshfiles" / "test_ugrid_to_zarr.zarr"
-
-        # User writer function with encoder argument
-        tgrid1.write("scrip").to_zarr(str(scrip_outfile), mode='w')
-
-        tgrid1.write("exodus").to_zarr(str(exodus_outfile), mode='w')
-
-        tgrid1.write("ugrid").to_zarr(str(ugrid_outfile), mode='w')
+        grid.encode_as("exodus")
 
     def test_init_verts(self):
         """Create a uxarray grid from vertices and saves a ugrid file.
@@ -99,21 +57,22 @@ class TestGrid(TestCase):
         assert (vgrid.source_grid == "From vertices")
         assert (vgrid.source_datasets is None)
 
-        face_filename = current_path / "meshfiles" / "1face.ug"
-        vgrid.write("ugrid")
+        vgrid.encode_as("ugrid")
 
     def test_init_grid_var_attrs(self):
         """Tests to see if accessing variables through set attributes is equal
         to using the dict."""
+
         # Dataset with Variables in UGRID convention
-        path = current_path / "meshfiles" / "outCSne30.ug"
-        grid = ux.open_dataset(path)
-        xr.testing.assert_equal(grid.Mesh2_node_x,
-                                grid.ds[grid.ds_var_names["Mesh2_node_x"]])
-        xr.testing.assert_equal(grid.Mesh2_node_y,
-                                grid.ds[grid.ds_var_names["Mesh2_node_y"]])
-        xr.testing.assert_equal(grid.Mesh2_face_nodes,
-                                grid.ds[grid.ds_var_names["Mesh2_face_nodes"]])
+        xr.testing.assert_equal(
+            self.tgrid1.Mesh2_node_x,
+            self.tgrid1.ds[self.tgrid1.ds_var_names["Mesh2_node_x"]])
+        xr.testing.assert_equal(
+            self.tgrid1.Mesh2_node_y,
+            self.tgrid1.ds[self.tgrid1.ds_var_names["Mesh2_node_y"]])
+        xr.testing.assert_equal(
+            self.tgrid1.Mesh2_face_nodes,
+            self.tgrid1.ds[self.tgrid1.ds_var_names["Mesh2_face_nodes"]])
 
         # Dataset with Variables NOT in UGRID convention
         path = current_path / "meshfiles" / "mesh.nc"
@@ -137,7 +96,7 @@ class TestGrid(TestCase):
             tgrid = ux.open_dataset(str(shp_filename))
 
     def test_read_scrip(self):
-        """Reads a scrip file and write ugrid file."""
+        """Reads a scrip file."""
 
         scrip_8 = current_path / "meshfiles" / "outCSne8.nc"
         ug_30 = current_path / "meshfiles" / "outCSne30.ug"

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -49,7 +49,7 @@ class TestGrid(TestCase):
         tgrid2.write(str(ug_outfile2), "scrip")
         tgrid3.write(str(ug_outfile3), "scrip")
 
-    def test_write_to_file(self):
+    def test_write_to_netcdf(self):
         """Tests that the writer functions create a correctly formatted file
         when correct arguments are used in writer call."""
         # Read in ugrid file to be used in writer functions
@@ -65,6 +65,23 @@ class TestGrid(TestCase):
         tgrid1.write(str(scrip_outfile), "scrip", 'netcdf')
         tgrid1.write(str(exodus_outfile), "exodus", "netcdf")
         tgrid1.write(str(ugrid_outfile), "ugrid", "netcdf")
+
+    def test_write_to_zarr(self):
+        """Tests that the writer functions create a correctly formatted file
+        when correct arguments are used in writer call."""
+        # Read in ugrid file to be used in writer functions
+        ug_filename1 = current_path / "meshfiles" / "outCSne30.ug"
+        tgrid1 = ux.open_dataset(str(ug_filename1))
+
+        # Create paths for new scrip and exodus files to be stored
+        scrip_outfile = current_path / "meshfiles" / "test_scrip_to_zarr.zarr"
+        exodus_outfile = current_path / "meshfiles" / "test_exodus_to_zarr.zarr"
+        ugrid_outfile = current_path / "meshfiles" / "test_ugrid_to_zarr.zarr"
+
+        # User writer function with encoder argument
+        tgrid1.write(str(scrip_outfile), "scrip", "zarr")
+        tgrid1.write(str(exodus_outfile), "exodus", "zarr")
+        tgrid1.write(str(ugrid_outfile), "ugrid", "zarr")
 
     def test_init_verts(self):
         """Create a uxarray grid from vertices and saves a ugrid file.

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -62,14 +62,11 @@ class TestGrid(TestCase):
         ugrid_outfile = current_path / "meshfiles" / "test_ugrid_to_netcdf.nc"
 
         # User writer function with encoder argument
-        scrip = tgrid1.write("scrip")
-        scrip.to_netcdf(str(scrip_outfile))
+        tgrid1.write("scrip").to_netcdf(str(scrip_outfile))
 
-        exodus = tgrid1.write("exodus")
-        exodus.to_netcdf(str(exodus_outfile))
+        tgrid1.write("exodus").to_netcdf(str(exodus_outfile))
 
-        ugrid = tgrid1.write("ugrid")
-        ugrid.to_netcdf(str(ugrid_outfile))
+        tgrid1.write("ugrid").to_netcdf(str(ugrid_outfile))
 
     def test_write_to_zarr(self):
         """Tests that the writer functions create a correctly formatted file
@@ -84,14 +81,11 @@ class TestGrid(TestCase):
         ugrid_outfile = current_path / "meshfiles" / "test_ugrid_to_zarr.zarr"
 
         # User writer function with encoder argument
-        scrip = tgrid1.write("scrip")
-        scrip.to_zarr(str(scrip_outfile), mode='w')
+        tgrid1.write("scrip").to_zarr(str(scrip_outfile), mode='w')
 
-        exodus = tgrid1.write("exodus")
-        exodus.to_zarr(str(exodus_outfile), mode='w')
+        tgrid1.write("exodus").to_zarr(str(exodus_outfile), mode='w')
 
-        ugrid = tgrid1.write("ugrid")
-        ugrid.to_zarr(str(ugrid_outfile), mode='w')
+        tgrid1.write("ugrid").to_zarr(str(ugrid_outfile), mode='w')
 
     def test_init_verts(self):
         """Create a uxarray grid from vertices and saves a ugrid file.

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -80,8 +80,11 @@ class TestGrid(TestCase):
         ugrid_outfile = current_path / "meshfiles" / "test_ugrid_to_zarr.zarr"
 
         # User writer function with encoder argument
-        tgrid1.write(str(scrip_outfile), "scrip", "zarr",
-                     store=scrip_outfile)  # test kwargs work
+        tgrid1.write(str(scrip_outfile),
+                     "scrip",
+                     "zarr",
+                     store=scrip_outfile,
+                     mode="w")  # test kwargs work
         tgrid1.write(str(exodus_outfile), "exodus", "zarr")
         tgrid1.write(str(ugrid_outfile), "ugrid", "zarr")
 

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -45,9 +45,27 @@ class TestGrid(TestCase):
         tgrid2 = ux.open_dataset(str(ug_filename2))
         tgrid3 = ux.open_dataset(str(ug_filename3))
 
-        tgrid1.write(str(ug_outfile1), "scrip")
-        tgrid2.write(str(ug_outfile2), "scrip")
+        tgrid1.write(str(ug_outfile1), "scrip",
+                     "netcdf")  # Creates new netcdf file
+        tgrid2.write(str(ug_outfile2), "scrip")  # Does not create new file
         tgrid3.write(str(ug_outfile3), "scrip")
+
+    def test_write_to_file(selfs):
+        """Tests that the writer functions create a correctly formatted file
+        when correct arguments are used in writer call."""
+        # Read in ugrid file to be used in writer funcitons
+        ug_filename1 = current_path / "meshfiles" / "outCSne30.ug"
+        tgrid1 = ux.open_dataset(str(ug_filename1))
+
+        # Create paths for new scrip and exodus files to be stored
+        scrip_outfile = current_path / "meshfiles" / "test_scrip_to_netcdf.nc"
+        exodus_outfile = current_path / "meshfiles" / "test_exodus_to_netcdf.nc"
+        ugrid_outfile = current_path / "meshfiles" / "test_ugrid_to_netcdf.nc"
+
+        # User writer function with encoder argument
+        tgrid1.write(str(scrip_outfile), "scrip", "netcdf")
+        tgrid1.write(str(exodus_outfile), "exodus", "netcdf")
+        tgrid1.write(str(ugrid_outfile), "ugrid", "netcdf")
 
     def test_init_verts(self):
         """Create a uxarray grid from vertices and saves a ugrid file.

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -80,13 +80,12 @@ class TestGrid(TestCase):
         ugrid_outfile = current_path / "meshfiles" / "test_ugrid_to_zarr.zarr"
 
         # User writer function with encoder argument
-        tgrid1.write(str(scrip_outfile),
-                     "scrip",
-                     "zarr",
-                     store=scrip_outfile,
+        tgrid1.write(str(scrip_outfile), "scrip", "zarr",
                      mode="w")  # test kwargs work
-        tgrid1.write(str(exodus_outfile), "exodus", "zarr")
-        tgrid1.write(str(ugrid_outfile), "ugrid", "zarr")
+        tgrid1.write(str(exodus_outfile), "exodus", "zarr",
+                     mode="w")  # write mode to overwrite any prior versions
+        tgrid1.write(str(ugrid_outfile), "ugrid", "zarr",
+                     mode="w")  # write mode to overwrite any prior versions
 
     def test_init_verts(self):
         """Create a uxarray grid from vertices and saves a ugrid file.

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -27,9 +27,9 @@ class TestGrid(TestCase):
         tgrid2 = ux.open_dataset(str(ug_filename2))
         tgrid3 = ux.open_dataset(str(ug_filename3))
 
-        tgrid1.write(str(ug_outfile1), "exodus")
-        tgrid2.write(str(ug_outfile2), "exodus")
-        tgrid3.write(str(ug_outfile3), "exodus")
+        tgrid1.write("exodus")
+        tgrid2.write("exodus")
+        tgrid3.write("exodus")
 
     def test_read_ugrid_write_scrip(self):
         """Reads in augrid file and writes to a scrip file."""
@@ -45,9 +45,9 @@ class TestGrid(TestCase):
         tgrid2 = ux.open_dataset(str(ug_filename2))
         tgrid3 = ux.open_dataset(str(ug_filename3))
 
-        tgrid1.write(str(ug_outfile1), "scrip")
-        tgrid2.write(str(ug_outfile2), "scrip")
-        tgrid3.write(str(ug_outfile3), "scrip")
+        tgrid1.write("scrip")
+        tgrid2.write("scrip")
+        tgrid3.write("scrip")
 
     def test_write_to_netcdf(self):
         """Tests that the writer functions create a correctly formatted file
@@ -62,10 +62,14 @@ class TestGrid(TestCase):
         ugrid_outfile = current_path / "meshfiles" / "test_ugrid_to_netcdf.nc"
 
         # User writer function with encoder argument
-        tgrid1.write(str(scrip_outfile), "scrip", 'netcdf',
-                     mode='w')  # test kwargs work
-        tgrid1.write(str(exodus_outfile), "exodus", "netcdf")
-        tgrid1.write(str(ugrid_outfile), "ugrid", "netcdf")
+        scrip = tgrid1.write("scrip")
+        scrip.to_netcdf(str(scrip_outfile))
+
+        exodus = tgrid1.write("exodus")
+        exodus.to_netcdf(str(exodus_outfile))
+
+        ugrid = tgrid1.write("ugrid")
+        ugrid.to_netcdf(str(ugrid_outfile))
 
     def test_write_to_zarr(self):
         """Tests that the writer functions create a correctly formatted file
@@ -80,12 +84,14 @@ class TestGrid(TestCase):
         ugrid_outfile = current_path / "meshfiles" / "test_ugrid_to_zarr.zarr"
 
         # User writer function with encoder argument
-        tgrid1.write(str(scrip_outfile), "scrip", "zarr",
-                     mode="w")  # test kwargs work
-        tgrid1.write(str(exodus_outfile), "exodus", "zarr",
-                     mode="w")  # write mode to overwrite any prior versions
-        tgrid1.write(str(ugrid_outfile), "ugrid", "zarr",
-                     mode="w")  # write mode to overwrite any prior versions
+        scrip = tgrid1.write("scrip")
+        scrip.to_zarr(str(scrip_outfile), mode='w')
+
+        exodus = tgrid1.write("exodus")
+        exodus.to_zarr(str(exodus_outfile), mode='w')
+
+        ugrid = tgrid1.write("ugrid")
+        ugrid.to_zarr(str(ugrid_outfile), mode='w')
 
     def test_init_verts(self):
         """Create a uxarray grid from vertices and saves a ugrid file.
@@ -100,7 +106,7 @@ class TestGrid(TestCase):
         assert (vgrid.source_datasets is None)
 
         face_filename = current_path / "meshfiles" / "1face.ug"
-        vgrid.write(face_filename, "ugrid")
+        vgrid.write("ugrid")
 
     def test_init_grid_var_attrs(self):
         """Tests to see if accessing variables through set attributes is equal

--- a/test/test_scrip.py
+++ b/test/test_scrip.py
@@ -1,4 +1,4 @@
-from uxarray._scrip import _read_scrip, _write_scrip
+from uxarray._scrip import _read_scrip, _encode_scrip
 import uxarray as ux
 import xarray as xr
 from unittest import TestCase
@@ -48,8 +48,8 @@ class TestScrip(TestCase):
 
         # Use uxarray open_dataset to then create SCRIP file from new UGRID file
         make_ux = ux.open_dataset(str(new_path))
-        to_scrip = _write_scrip(make_ux.Mesh2_face_nodes, make_ux.Mesh2_node_x,
-                                make_ux.Mesh2_node_y, make_ux.face_areas)
+        to_scrip = _encode_scrip(make_ux.Mesh2_face_nodes, make_ux.Mesh2_node_x,
+                                 make_ux.Mesh2_node_y, make_ux.face_areas)
 
         # Test newly created SCRIP is same as original SCRIP
         np.testing.assert_array_almost_equal(to_scrip['grid_corner_lat'],
@@ -80,8 +80,8 @@ class TestScrip(TestCase):
         """Tests that returned dataset from writer function has all required
         SCRIP variables."""
         ux_ne30 = ux.open_dataset(ne30)
-        scrip30 = _write_scrip(ux_ne30.Mesh2_face_nodes, ux_ne30.Mesh2_node_x,
-                               ux_ne30.Mesh2_node_y, ux_ne30.face_areas)
+        scrip30 = _encode_scrip(ux_ne30.Mesh2_face_nodes, ux_ne30.Mesh2_node_x,
+                                ux_ne30.Mesh2_node_y, ux_ne30.face_areas)
 
         # List of relevant variable names for a scrip file
         var_list = [

--- a/test/test_scrip.py
+++ b/test/test_scrip.py
@@ -48,8 +48,7 @@ class TestScrip(TestCase):
 
         # Use uxarray open_dataset to then create SCRIP file from new UGRID file
         make_ux = ux.open_dataset(str(new_path))
-        to_scrip = _write_scrip("test_scrip_outfile.nc",
-                                make_ux.Mesh2_face_nodes, make_ux.Mesh2_node_x,
+        to_scrip = _write_scrip(make_ux.Mesh2_face_nodes, make_ux.Mesh2_node_x,
                                 make_ux.Mesh2_node_y, make_ux.face_areas)
 
         # Test newly created SCRIP is same as original SCRIP
@@ -81,9 +80,8 @@ class TestScrip(TestCase):
         """Tests that returned dataset from writer function has all required
         SCRIP variables."""
         ux_ne30 = ux.open_dataset(ne30)
-        scrip30 = _write_scrip("write_to_scrip.nc", ux_ne30.Mesh2_face_nodes,
-                               ux_ne30.Mesh2_node_x, ux_ne30.Mesh2_node_y,
-                               ux_ne30.face_areas)
+        scrip30 = _write_scrip(ux_ne30.Mesh2_face_nodes, ux_ne30.Mesh2_node_x,
+                               ux_ne30.Mesh2_node_y, ux_ne30.face_areas)
 
         # List of relevant variable names for a scrip file
         var_list = [

--- a/test/test_ugrid.py
+++ b/test/test_ugrid.py
@@ -47,4 +47,4 @@ class TestUgrid(TestCase):
         exo2_filename = current_path / "meshfiles" / "outCSne8.g"
         ux_grid = ux.open_dataset(str(exo2_filename))
         outfile = current_path / "write_test_outCSne8.ug"
-        ux_grid.write(str(outfile), "ugrid")
+        ux_grid.write("ugrid").to_netcdf(str(outfile))

--- a/test/test_ugrid.py
+++ b/test/test_ugrid.py
@@ -41,10 +41,9 @@ class TestUgrid(TestCase):
         assert isinstance(getattr(ugrid, "Mesh2_node_y"), xr.DataArray)
         assert isinstance(getattr(ugrid, "Mesh2_face_nodes"), xr.DataArray)
 
-    def test_write_ugrid(self):
-        """Read an exodus file and writes a ugrid file."""
+    def test_encode_ugrid(self):
+        """Read an Exodus dataset and encode that as a UGRID format."""
 
         exo2_filename = current_path / "meshfiles" / "outCSne8.g"
         ux_grid = ux.open_dataset(str(exo2_filename))
-        outfile = current_path / "write_test_outCSne8.ug"
-        ux_grid.write("ugrid").to_netcdf(str(outfile))
+        ux_grid.encode_as("ugrid")

--- a/uxarray/_exodus.py
+++ b/uxarray/_exodus.py
@@ -148,13 +148,17 @@ def _encode_exodus(ds, outfile, ds_var_names):
     ----------
 
     ds : xarray.Dataset, required
-        Dataset to be written to exodus file.
+        Dataset to be encoded to exodus file.
 
     outfile : string, required
        Name of output file
+
+    Returns
+    -------
+    exo_ds : xarray.Dataset
+        Dataset encoded as exodus file.
     """
     # Note this is 1-based unlike native Mesh2 construct
-    # print("Writing exodus file: ", outfile)
 
     exo_ds = xr.Dataset()
 
@@ -318,10 +322,7 @@ def _encode_exodus(ds, outfile, ds_var_names):
         np.array(cnames, dtype='str')),
                                         dims=["num_dim"])
 
-    # done processing write the file to disk
-    # exo_ds.to_netcdf(outfile)
-    # print("Wrote: ", outfile)
-    return ds
+    return exo_ds
 
 
 def _get_element_type(num_nodes):

--- a/uxarray/_exodus.py
+++ b/uxarray/_exodus.py
@@ -149,11 +149,12 @@ def _write_exodus(ds, outfile, ds_var_names):
 
     ds : xarray.Dataset, required
         Dataset to be written to exodus file.
+
     outfile : string, required
        Name of output file
     """
     # Note this is 1-based unlike native Mesh2 construct
-    print("Writing exodus file: ", outfile)
+    # print("Writing exodus file: ", outfile)
 
     exo_ds = xr.Dataset()
 
@@ -318,8 +319,9 @@ def _write_exodus(ds, outfile, ds_var_names):
                                         dims=["num_dim"])
 
     # done processing write the file to disk
-    exo_ds.to_netcdf(outfile)
-    print("Wrote: ", outfile)
+    # exo_ds.to_netcdf(outfile)
+    # print("Wrote: ", outfile)
+    return ds
 
 
 def _get_element_type(num_nodes):

--- a/uxarray/_exodus.py
+++ b/uxarray/_exodus.py
@@ -151,7 +151,8 @@ def _encode_exodus(ds, ds_var_names, outfile=None):
         Dataset to be encoded to exodus file.
 
     outfile : string, required
-       Name of output file
+       Name of output file to be added as metadata into the output
+       dataset
 
     Returns
     -------

--- a/uxarray/_exodus.py
+++ b/uxarray/_exodus.py
@@ -142,7 +142,7 @@ def _read_exodus(ext_ds, ds_var_names):
 
 
 def _encode_exodus(ds, outfile, ds_var_names):
-    """Exodus file writer.
+    """Encodes an Exodus file.
 
     Parameters
     ----------

--- a/uxarray/_exodus.py
+++ b/uxarray/_exodus.py
@@ -141,7 +141,7 @@ def _read_exodus(ext_ds, ds_var_names):
     return ds
 
 
-def _encode_exodus(ds, outfile, ds_var_names):
+def _encode_exodus(ds, ds_var_names, outfile=None):
     """Encodes an Exodus file.
 
     Parameters
@@ -162,24 +162,32 @@ def _encode_exodus(ds, outfile, ds_var_names):
 
     exo_ds = xr.Dataset()
 
-    path = PurePath(outfile)
-    out_filename = path.name
-
     now = datetime.now()
     date = now.strftime("%Y:%m:%d")
     time = now.strftime("%H:%M:%S")
-
-    title = f"uxarray(" + str(out_filename) + ")" + date + ": " + time
     fp_word = np.int32(8)
     exo_version = np.float32(5.0)
     api_version = np.float32(5.0)
+
     exo_ds.attrs = {
         "api_version": api_version,
         "version": exo_version,
         "floating_point_word_size": fp_word,
-        "file_size": 0,
-        "title": title
+        "file_size": 0
     }
+
+    if outfile:
+        path = PurePath(outfile)
+        out_filename = path.name
+        title = f"uxarray(" + str(out_filename) + ")" + date + ": " + time
+
+        exo_ds.attrs = {
+            "api_version": api_version,
+            "version": exo_version,
+            "floating_point_word_size": fp_word,
+            "file_size": 0,
+            "title": title
+        }
 
     exo_ds["time_whole"] = xr.DataArray(data=[], dims=["time_step"])
 

--- a/uxarray/_exodus.py
+++ b/uxarray/_exodus.py
@@ -141,7 +141,7 @@ def _read_exodus(ext_ds, ds_var_names):
     return ds
 
 
-def _write_exodus(ds, outfile, ds_var_names):
+def _encode_exodus(ds, outfile, ds_var_names):
     """Exodus file writer.
 
     Parameters

--- a/uxarray/_scrip.py
+++ b/uxarray/_scrip.py
@@ -138,7 +138,7 @@ def _read_scrip(ext_ds):
     return ds
 
 
-def _write_scrip(mesh2_face_nodes, mesh2_node_x, mesh2_node_y, face_areas):
+def _encode_scrip(mesh2_face_nodes, mesh2_node_x, mesh2_node_y, face_areas):
     """Function to reassign UGRID formatted variables to SCRIP formatted
     variables and then writing them out to a netCDF file.
 

--- a/uxarray/_scrip.py
+++ b/uxarray/_scrip.py
@@ -138,8 +138,7 @@ def _read_scrip(ext_ds):
     return ds
 
 
-def _write_scrip(outfile, mesh2_face_nodes, mesh2_node_x, mesh2_node_y,
-                 face_areas):
+def _write_scrip(mesh2_face_nodes, mesh2_node_x, mesh2_node_y, face_areas):
     """Function to reassign UGRID formatted variables to SCRIP formatted
     variables and then writing them out to a netCDF file.
 

--- a/uxarray/_scrip.py
+++ b/uxarray/_scrip.py
@@ -222,7 +222,4 @@ def _write_scrip(outfile, mesh2_face_nodes, mesh2_node_x, mesh2_node_y,
 
     ds['grid_center_lat'] = xr.DataArray(data=center_lat, dims=["grid_size"])
 
-    # Create and save new scrip file
-    ds.to_netcdf(outfile)
-
     return ds

--- a/uxarray/_scrip.py
+++ b/uxarray/_scrip.py
@@ -140,7 +140,7 @@ def _read_scrip(ext_ds):
 
 def _encode_scrip(mesh2_face_nodes, mesh2_node_x, mesh2_node_y, face_areas):
     """Function to reassign UGRID formatted variables to SCRIP formatted
-    variables and then writing them out to a netCDF file.
+    variables.
 
     Currently, supports creating unstructured SCRIP grid files following traditional
     SCRIP naming practices (grid_corner_lat, grid_center_lat, etc).

--- a/uxarray/_scrip.py
+++ b/uxarray/_scrip.py
@@ -175,9 +175,8 @@ def _encode_scrip(mesh2_face_nodes, mesh2_node_x, mesh2_node_y, face_areas):
     Returns
     -------
     ds : xarray.Dataset
-        Dataset to be returned by ``_write_scrip``. The function returns both
-        the output dataset in SCRIP format for immediate and saves it as an
-        independent netCDF file.
+        Dataset to be returned by ``_encode_scrip``. The function returns
+        the output dataset in SCRIP format for immediate use.
     """
     # Create empty dataset to put new scrip format data into
     ds = xr.Dataset()

--- a/uxarray/_ugrid.py
+++ b/uxarray/_ugrid.py
@@ -66,5 +66,6 @@ def _write_ugrid(ds, outfile, ugrid_vars):
     Uses to_netcdf from xarray object.
     """
 
-    print("Writing ugrid file: ", outfile)
-    ds.to_netcdf(outfile)
+    # print("Writing ugrid file: ", outfile)
+    # ds.to_netcdf(outfile)
+    return ds

--- a/uxarray/_ugrid.py
+++ b/uxarray/_ugrid.py
@@ -54,7 +54,7 @@ def _read_ugrid(xr_ds, var_names_dict):
 
 
 # Write a uxgrid to a file with specified format.
-def _write_ugrid(ds, outfile, ugrid_vars):
+def _write_ugrid(ds, ugrid_vars):
     """UGRID file writer.
     Parameters
     ----------
@@ -65,7 +65,4 @@ def _write_ugrid(ds, outfile, ugrid_vars):
 
     Uses to_netcdf from xarray object.
     """
-
-    # print("Writing ugrid file: ", outfile)
-    # ds.to_netcdf(outfile)
     return ds

--- a/uxarray/_ugrid.py
+++ b/uxarray/_ugrid.py
@@ -59,7 +59,7 @@ def _encode_ugrid(ds):
     Parameters
     ----------
     ds : xarray.Dataset
-        Dataset to be written to file
+        Dataset to be encoded to file
 
     Uses to_netcdf from xarray object.
     """

--- a/uxarray/_ugrid.py
+++ b/uxarray/_ugrid.py
@@ -54,14 +54,12 @@ def _read_ugrid(xr_ds, var_names_dict):
 
 
 # Write a uxgrid to a file with specified format.
-def _write_ugrid(ds, ugrid_vars):
+def _encode_ugrid(ds):
     """UGRID file writer.
     Parameters
     ----------
     ds : xarray.Dataset
         Dataset to be written to file
-    outfile : string, required
-        Name of output file
 
     Uses to_netcdf from xarray object.
     """

--- a/uxarray/_ugrid.py
+++ b/uxarray/_ugrid.py
@@ -53,7 +53,6 @@ def _read_ugrid(xr_ds, var_names_dict):
     return xr_ds, var_names_dict
 
 
-# Write a uxgrid to a file with specified format.
 def _encode_ugrid(ds):
     """Encodes UGRID file.
     Parameters

--- a/uxarray/_ugrid.py
+++ b/uxarray/_ugrid.py
@@ -55,7 +55,7 @@ def _read_ugrid(xr_ds, var_names_dict):
 
 # Write a uxgrid to a file with specified format.
 def _encode_ugrid(ds):
-    """UGRID file writer.
+    """Encodes UGRID file.
     Parameters
     ----------
     ds : xarray.Dataset

--- a/uxarray/grid.py
+++ b/uxarray/grid.py
@@ -23,9 +23,9 @@ class Grid:
 
     >>> mesh = ux.Grid("filename.g")
 
-    Save as ugrid file
+    Encode as a `xarray.Dataset` in the UGRID format
 
-    >>> mesh.write("outfile.ug")
+    >>> mesh.encode_as("ugrid")
     """
 
     def __init__(self, dataset, **kwargs):
@@ -160,26 +160,25 @@ class Grid:
             raise RuntimeError("unknown file format: " + self.mesh_filetype)
         dataset.close()
 
-    def write(self, grid_type):
-        """Writes mesh file as per file type supplied in the `grid_type`
-        string.
+    def encode_as(self, grid_type):
+        """Encodes the grid as a new `xarray.Dataset` per grid format supplied
+        in the `grid_type` argument.
 
         Parameters
         ----------
         grid_type : str, required
-            Grid type of output file.
+            Grid type of output dataset.
             Currently supported options are "ugrid", "exodus", and "scrip"
 
         Returns
         -------
         out_ds : xarray.Dataset
-            xarray.Dataset that can then be turned into a zarr or netcdf file using Xarray
-            functionality `xarray.Dataset.to_zarr` and `xarray.Dataset.to_netcdf`
+            The output `xarray.Dataset` that is encoded from the this grid.
 
         Raises
         ------
         RuntimeError
-            If provided grid type or file type is unsupported, or provided outfile directory is not found
+            If provided grid type or file type is unsupported.
         """
 
         if grid_type == "ugrid":
@@ -192,7 +191,7 @@ class Grid:
             out_ds = _encode_scrip(self.Mesh2_face_nodes, self.Mesh2_node_x,
                                    self.Mesh2_node_y, self.face_areas)
         else:
-            raise RuntimeError("Format not supported for writing: ", grid_type)
+            raise RuntimeError("The grid type not supported: ", grid_type)
 
         return out_ds
 

--- a/uxarray/grid.py
+++ b/uxarray/grid.py
@@ -163,6 +163,12 @@ class Grid:
     def write(self, outfile, grid_type, save_as='netcdf', **kwargs):
         """Writes mesh file as per file type supplied in the `save_as` string.
 
+           Note:
+
+           `netcdf` option will return a new file in specified or working directory.
+
+           `zarr` option wil return a new directory in specified or working directory
+
         Parameters
         ----------
         outfile : str, required
@@ -176,9 +182,13 @@ class Grid:
             Grid type of output file.
             Currently supported options are "ugrid", "exodus", and "scrip"
 
-        save_as : str, default "netcdf"
+        save_as : str, optional default "netcdf"
             The specific file type to save newly created datasets to.
             Current options are "netcdf" and "zarr"
+
+        **kwargs : str, optional
+            Keyword arguments to be used in xarray.Dataset.to_netcdf and
+            xarray.Dataset.to_zarr as defined in the Xarray function documentation
 
         Raises
         ------

--- a/uxarray/grid.py
+++ b/uxarray/grid.py
@@ -160,37 +160,21 @@ class Grid:
             raise RuntimeError("unknown file format: " + self.mesh_filetype)
         dataset.close()
 
-    def write(self, outfile, grid_type, save_as='netcdf', **kwargs):
-        """Writes mesh file as per file type supplied in the `save_as` string.
-
-           Note:
-
-           `netcdf` option will return a new file in specified or working directory.
-
-           `zarr` option wil return a new directory in specified or working directory
+    def write(self, grid_type):
+        """Writes mesh file as per file type supplied in the `grid_type`
+        string.
 
         Parameters
         ----------
-        outfile : str, required
-            Name of, or path to, output file.
-
-            ex: "path/to/new/file/location/new_file.nc" or
-                "new_file.nc"
-
         grid_type : str, required
             Grid type of output file.
             Currently supported options are "ugrid", "exodus", and "scrip"
 
-        save_as : str, optional default "netcdf"
-            The specific file type to save newly created datasets to.
-            Current options are "netcdf" and "zarr". Both options will
-            automatically save to directory defined by `outfile`. There is
-            no need to use "path" kwarg with 'netcdf' or "store" kwarg
-            with 'zarr'.
-
-        **kwargs : str, optional
-            Keyword arguments to be used in xarray.Dataset.to_netcdf and
-            xarray.Dataset.to_zarr as defined in the Xarray function documentation
+        Returns
+        -------
+        out_ds : xarray.Dataset
+            xarray.Dataset that can then be turned into a zarr or netcdf file using Xarray
+            functionality `xarray.Dataset.to_zarr` and `xarray.Dataset.to_netcdf`
 
         Raises
         ------
@@ -202,7 +186,7 @@ class Grid:
             out_ds = _encode_ugrid(self.ds)
 
         elif grid_type == "exodus":
-            out_ds = _encode_exodus(self.ds, self.ds_var_names, outfile)
+            out_ds = _encode_exodus(self.ds, self.ds_var_names)
 
         elif grid_type == "scrip":
             out_ds = _encode_scrip(self.Mesh2_face_nodes, self.Mesh2_node_x,
@@ -210,15 +194,7 @@ class Grid:
         else:
             raise RuntimeError("Format not supported for writing: ", grid_type)
 
-        if save_as == 'netcdf':
-            out_ds.to_netcdf(outfile, **kwargs)
-
-        elif save_as == 'zarr':
-            out_ds.to_zarr(outfile, **kwargs)
-
-        else:
-            raise RuntimeError("File format not supported for writing: ",
-                               save_as)
+        return out_ds
 
     def calculate_total_face_area(self, quadrature_rule="triangular", order=4):
         """Function to calculate the total surface area of all the faces in a

--- a/uxarray/grid.py
+++ b/uxarray/grid.py
@@ -160,7 +160,7 @@ class Grid:
             raise RuntimeError("unknown file format: " + self.mesh_filetype)
         dataset.close()
 
-    def write(self, outfile, grid_type, save_as='netcdf'):
+    def write(self, outfile, grid_type, save_as='netcdf', **kwargs):
         """Writes mesh file as per file type supplied in the `save_as` string.
 
         Parameters
@@ -199,10 +199,10 @@ class Grid:
             raise RuntimeError("Format not supported for writing: ", grid_type)
 
         if save_as == 'netcdf':
-            out_ds.to_netcdf(outfile)
+            out_ds.to_netcdf(outfile, **kwargs)
 
         elif save_as == 'zarr':
-            out_ds.to_zarr(store=outfile, mode="w")
+            out_ds.to_zarr(**kwargs)
 
         else:
             raise RuntimeError("File format not supported for writing: ",

--- a/uxarray/grid.py
+++ b/uxarray/grid.py
@@ -160,16 +160,46 @@ class Grid:
             raise RuntimeError("unknown file format: " + self.mesh_filetype)
         dataset.close()
 
-    def write(self, outfile, grid_type):
+    def outfile_encoder(self, outfile, file_type):
+        """Writes xarray.Dataset to new file in current directory in specified
+        file type.
+
+        Parameters
+        ----------
+        outfile : str, required
+
+        file_type : str, required
+            New file type to be created from write function. Supported options are
+            "netcdf" and "zarr"
+        """
+        if file_type == "netcdf":
+            self.ds.to_netcdf(outfile)
+
+        elif file_type == "zarr":
+            self.ds.to_zarr()
+
+        else:
+            raise RuntimeError("Format not supported for writing: ", file_type)
+
+    def write(self, outfile, grid_type, save_as=None):
         """Writes mesh file as per extension supplied in the outfile string.
 
         Parameters
         ----------
         outfile : str, required
-            Path to output file
+            Name of or path to output file. If path is not given,
+            file is saved to current working directory
+
+            ex: "path/to/new/file/location/new_file.nc" or
+                "new_file.nc"
+
         grid_type : str, required
             Grid type of output file.
             Currently supported options are "ugrid", "exodus", and "scrip"
+
+        save_as : str, optional
+            The specific file type to save newly created datasets to.
+            Current options are "zarr" and "netcdf"
 
         Raises
         ------
@@ -179,13 +209,19 @@ class Grid:
 
         if grid_type == "ugrid":
             _write_ugrid(self.ds, outfile, self.ds_var_names)
+
         elif grid_type == "exodus":
             _write_exodus(self.ds, outfile, self.ds_var_names)
+
         elif grid_type == "scrip":
             _write_scrip(outfile, self.Mesh2_face_nodes, self.Mesh2_node_x,
                          self.Mesh2_node_y, self.face_areas)
+
         else:
             raise RuntimeError("Format not supported for writing: ", grid_type)
+
+        if save_as != None:
+            self.outfile_encoder(outfile, save_as)
 
     def calculate_total_face_area(self, quadrature_rule="triangular", order=4):
         """Function to calculate the total surface area of all the faces in a

--- a/uxarray/grid.py
+++ b/uxarray/grid.py
@@ -161,7 +161,7 @@ class Grid:
         dataset.close()
 
     def write(self, outfile, grid_type, save_as='netcdf'):
-        """Writes mesh file as per extension supplied in the outfile string.
+        """Writes mesh file as per extension supplied in the `save_as` string.
 
         Parameters
         ----------
@@ -183,7 +183,7 @@ class Grid:
         Raises
         ------
         RuntimeError
-            If unsupported provided grid type, file type, or outfile directory is not found
+            If provided grid type or file type is unsupported, or provided outfile directory is not found
         """
 
         if grid_type == "ugrid":
@@ -202,7 +202,7 @@ class Grid:
             out_ds.to_netcdf(outfile)
 
         elif save_as == 'zarr':
-            out_ds.to_zarr()
+            out_ds.to_zarr(store=outfile, mode="w")
 
         elif save_as == 'None':
             pass

--- a/uxarray/grid.py
+++ b/uxarray/grid.py
@@ -161,7 +161,7 @@ class Grid:
         dataset.close()
 
     def write(self, outfile, grid_type, save_as='netcdf'):
-        """Writes mesh file as per extension supplied in the `save_as` string.
+        """Writes mesh file as per file type supplied in the `save_as` string.
 
         Parameters
         ----------
@@ -178,7 +178,7 @@ class Grid:
 
         save_as : str, default "netcdf"
             The specific file type to save newly created datasets to.
-            Current options are "netcdf", "zarr", and "None" (no file saved)
+            Current options are "netcdf" and "zarr"
 
         Raises
         ------
@@ -190,7 +190,7 @@ class Grid:
             out_ds = _encode_ugrid(self.ds)
 
         elif grid_type == "exodus":
-            out_ds = _encode_exodus(self.ds, outfile, self.ds_var_names)
+            out_ds = _encode_exodus(self.ds, self.ds_var_names, outfile)
 
         elif grid_type == "scrip":
             out_ds = _encode_scrip(self.Mesh2_face_nodes, self.Mesh2_node_x,
@@ -203,9 +203,6 @@ class Grid:
 
         elif save_as == 'zarr':
             out_ds.to_zarr(store=outfile, mode="w")
-
-        elif save_as == 'None':
-            pass
 
         else:
             raise RuntimeError("File format not supported for writing: ",

--- a/uxarray/grid.py
+++ b/uxarray/grid.py
@@ -208,19 +208,19 @@ class Grid:
         """
 
         if grid_type == "ugrid":
-            _write_ugrid(self.ds, outfile, self.ds_var_names)
+            _write_ugrid(self.ds, self.ds_var_names)
 
         elif grid_type == "exodus":
             _write_exodus(self.ds, outfile, self.ds_var_names)
 
         elif grid_type == "scrip":
-            _write_scrip(outfile, self.Mesh2_face_nodes, self.Mesh2_node_x,
+            _write_scrip(self.Mesh2_face_nodes, self.Mesh2_node_x,
                          self.Mesh2_node_y, self.face_areas)
 
         else:
             raise RuntimeError("Format not supported for writing: ", grid_type)
 
-        if save_as != None:
+        if save_as:
             self.outfile_encoder(outfile, save_as)
 
     def calculate_total_face_area(self, quadrature_rule="triangular", order=4):

--- a/uxarray/grid.py
+++ b/uxarray/grid.py
@@ -172,8 +172,7 @@ class Grid:
         Parameters
         ----------
         outfile : str, required
-            Name of or path to output file. If path is not given,
-            file is saved to current working directory
+            Name of, or path to, output file.
 
             ex: "path/to/new/file/location/new_file.nc" or
                 "new_file.nc"
@@ -184,7 +183,10 @@ class Grid:
 
         save_as : str, optional default "netcdf"
             The specific file type to save newly created datasets to.
-            Current options are "netcdf" and "zarr"
+            Current options are "netcdf" and "zarr". Both options will
+            automatically save to directory defined by `outfile`. There is
+            no need to use "path" kwarg with 'netcdf' or "store" kwarg
+            with 'zarr'.
 
         **kwargs : str, optional
             Keyword arguments to be used in xarray.Dataset.to_netcdf and
@@ -212,7 +214,7 @@ class Grid:
             out_ds.to_netcdf(outfile, **kwargs)
 
         elif save_as == 'zarr':
-            out_ds.to_zarr(**kwargs)
+            out_ds.to_zarr(outfile, **kwargs)
 
         else:
             raise RuntimeError("File format not supported for writing: ",


### PR DESCRIPTION
@erogluorhan has taken this on as @michaelavs has left NCAR.

Add `encode_as` function and update relevant scrip, exodus, and ugrid encode functions as well the grid module, test scripts, and documentation files accordingly.

In light of the recent Grid class design changes we are planning, this PR changes the `write` function to an `encode_as` function in the UXarray PR and leaves the task of writing out to files (netcdf or zarr) to xarray. cc: @rajeeja @rljacob 

Changes:
-`encode_as` function in `grid.py` returns a `xarray.Dataset` in the given grid type and no longer writes that dataset to a new output file (Leaves this task tot the user's calls such as `uxarray.Grid.encode_as(...).to_netcdf()` or `...to_zarr()`)
- Update documentation including the draft UXarray API accordingly