### PR TITLE
Version 2022.11.0 to get bug fixes released before tutorial

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2022.10.0" %}
+{% set version = "2022.11.0" %}
 
 package:
   name: 'uxarray'


### PR DESCRIPTION
To release PR #168 and #160 that fix an important bug before the NCAR ESDS tutorial.