### PR TITLE
Udate badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ UXarray](https://uxarray.readthedocs.io/en/latest/citation.html).
 
 
 
-[github-ci-badge]: https://img.shields.io/github/workflow/status/UXARRAY/uxarray/CI?label=CI&logo=github&style=for-the-badge
+[github-ci-badge]: https://img.shields.io/github/actions/workflow/status/UXARRAY/uxarray/ci.yml?branch=main&label=CI&logo=github&style=for-the-badge
 [github-ci-link]: https://github.com/UXARRAY/uxarray/actions?query=workflow%3ACI
 [codecov-badge]: https://img.shields.io/codecov/c/github/UXARRAY/uxarray.svg?logo=codecov&style=for-the-badge
 [codecov-link]: https://codecov.io/gh/UXARRAY/uxarray


### PR DESCRIPTION
Closes #197 

Summary of changes:
- updates CI badge link according to https://github.com/badges/shields/issues/8671

See changed README [here](https://github.com/UXARRAY/uxarray/tree/ci_badge_link#readme)

![image](https://user-images.githubusercontent.com/38434768/210431029-bb1befd9-94a9-49e9-8b2e-2cdec5921a58.png)
