### PR TITLE
Pin numpy in requirements.txt for documentation generation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 xarray
-numpy
+numpy<1.24


### PR DESCRIPTION
Closes #199 

Summary of changes:
- pins numpy<1.24 in `requirements.txt`

See passing RTD build for this branch [here](https://readthedocs.org/projects/uxarray/builds/19068929/)

@hongyuchen1030 This should fix the issues you're experiencing in #188 