### PR TITLE
CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,10 @@ jobs:
         run: |
           python -m pip install . --no-deps
 
+      - name: conda list
+        run: |
+          conda list
+
       - name: Run Namespace Tests
         run: |
           python -m pytest test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: [ "3.7", "3.8", "3.9"]
+        python-version: [ "3.7", "3.8", "3.9", "3.10"]
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.11.0

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           activate-environment: uxarray_upstream_build
           channel-priority: strict
-          mamba-version: "*"
+          miniconda-version: "latest"
           python-version: "3.10"
           channels: conda-forge
 
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install conda dependencies
         run: |
-          mamba env update --file ci/upstream-dev-environment.yml
+          conda env update --file ci/upstream-dev-environment.yml
 
       - name: Install uxarray
         run: |

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -38,7 +38,6 @@ jobs:
         run: |
           pip install https://github.com/pydata/xarray/archive/main.zip
           pip install https://github.com/dask/dask/archive/main.zip
-          conda list
 
       - name: Install conda dependencies
         run: |

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -29,7 +29,7 @@ jobs:
           activate-environment: uxarray_build
           channel-priority: strict
           mamba-version: '*'
-          python-version: 3.8
+          python-version: 3.10
           channels: conda-forge
           environment-file: ci/upstream-dev-environment.yml
 

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           pip install https://github.com/pydata/xarray/archive/main.zip
           pip install https://github.com/dask/dask/archive/main.zip
+          conda list
 
       - name: Install conda dependencies
         run: |

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install conda dependencies
         run: |
-          conda install -c conda-forge -f ci/upstream-dev-environment.yml
+          conda install -c conda-forge --file ci/upstream-dev-environment.yml
 
       - name: Install uxarray
         run: |

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -31,7 +31,7 @@ jobs:
           activate-environment: uxarray_upstream_build
           channel-priority: strict
           miniconda-version: "latest"
-          python-version: 3.10
+          python-version: "3.10"
           channels: conda-forge
 
       - name: Install select upstream dependencies

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -19,10 +19,17 @@ jobs:
         uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
+
       - name: checkout
         uses: actions/checkout@v3
         with:
           token: ${{ github.token }}
+
+      - name: Install select upstream dependencies
+        run: |
+          pip install https://github.com/pydata/xarray/archive/main.zip
+          pip install https://github.com/dask/dask/archive/main.zip
+
       - name: conda_setup
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install conda dependencies
         run: |
-          conda install -c conda-forge --file ci/upstream-dev-environment.yml
+          conda env update --file ci/upstream-dev-environment.yml
 
       - name: Install uxarray
         run: |

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           activate-environment: uxarray_upstream_build
           channel-priority: strict
-          miniconda-version: "latest"
+          mamba-version: "*"
           python-version: "3.10"
           channels: conda-forge
 
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install conda dependencies
         run: |
-          conda env update --file ci/upstream-dev-environment.yml
+          mamba env update --file ci/upstream-dev-environment.yml
 
       - name: Install uxarray
         run: |

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -8,7 +8,7 @@ jobs:
   upstream-dev:
     if: |
       github.repository == 'UXARRAY/uxarray'
-    name:  upstream-dev-py38
+    name:  upstream-dev-py310
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -25,20 +25,23 @@ jobs:
         with:
           token: ${{ github.token }}
 
+      - name: conda_setup
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: uxarray_upstream_build
+          channel-priority: strict
+          miniconda-version: "latest"
+          python-version: 3.10
+          channels: conda-forge
+
       - name: Install select upstream dependencies
         run: |
           pip install https://github.com/pydata/xarray/archive/main.zip
           pip install https://github.com/dask/dask/archive/main.zip
 
-      - name: conda_setup
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          activate-environment: uxarray_build
-          channel-priority: strict
-          mamba-version: '*'
-          python-version: 3.10
-          channels: conda-forge
-          environment-file: ci/upstream-dev-environment.yml
+      - name: Install conda dependencies
+        run: |
+          conda install -c conda-forge -f ci/upstream-dev-environment.yml
 
       - name: Install uxarray
         run: |

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -37,6 +37,10 @@ jobs:
         run: |
           python -m pip install . --no-deps
 
+      - name: conda list
+        run: |
+          conda list
+
       - name: Running Tests
         run: |
           python -m pytest test -v --cov=./uxarray --cov-report=xml

--- a/ci/upstream-dev-environment.yml
+++ b/ci/upstream-dev-environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - netcdf4
   - numba
-  - numpy
+  - numpy>=1.2, <1.25
   - pathlib
   - python
   - pytest

--- a/ci/upstream-dev-environment.yml
+++ b/ci/upstream-dev-environment.yml
@@ -1,17 +1,12 @@
-name: uxarray_build
+name: uxarray_upstream_build
 channels:
   - conda-forge
 dependencies:
   - netcdf4
   - numba
-  # pinning the numpy version for numba compatibility
   - numpy
   - pathlib
   - python
   - pytest
   - pytest-cov
-  - pip
   - scipy
-  - pip:
-    - git+https://github.com/pydata/xarray.git
-    - git+https://github.com/dask/dask.git

--- a/ci/upstream-dev-environment.yml
+++ b/ci/upstream-dev-environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - netcdf4
   - numba
-  - numpy>=1.2, <1.25
+  - numpy
   - pathlib
   - python
   - pytest

--- a/test/test_ugrid.py
+++ b/test/test_ugrid.py
@@ -3,6 +3,7 @@ import xarray as xr
 
 from unittest import TestCase
 from pathlib import Path
+import warnings
 
 import uxarray as ux
 
@@ -39,12 +40,21 @@ class TestUgrid(TestCase):
     def test_read_ugrid_opendap(self):
         """Read an ugrid model from an OPeNDAP URL."""
 
-        url = "http://www.smast.umassd.edu:8080/thredds/dodsC/FVCOM/NECOFS/Forecasts/NECOFS_GOM3_FORECAST.nc"
-        xr_grid = xr.open_dataset(url, drop_variables="siglay")
-        ugrid = ux.Grid(xr_grid)
-        assert isinstance(getattr(ugrid, "Mesh2_node_x"), xr.DataArray)
-        assert isinstance(getattr(ugrid, "Mesh2_node_y"), xr.DataArray)
-        assert isinstance(getattr(ugrid, "Mesh2_face_nodes"), xr.DataArray)
+        try:
+            # make sure we can read the ugrid file from the OPeNDAP URL
+            url = "http://www.smast.umassd.edu:8080/thredds/dodsC/FVCOM/NECOFS/Forecasts/NECOFS_GOM3_FORECAST.nc"
+            xr_grid = xr.open_dataset(url, drop_variables="siglay")
+
+        except OSError:
+            # print warning and pass if we can't connect to the OPeNDAP server
+            warnings.warn(f'Could not connect to OPeNDAP server: {url}')
+            pass
+
+        else:
+            ugrid = ux.Grid(xr_grid)
+            assert isinstance(getattr(ugrid, "Mesh2_node_x"), xr.DataArray)
+            assert isinstance(getattr(ugrid, "Mesh2_node_y"), xr.DataArray)
+            assert isinstance(getattr(ugrid, "Mesh2_face_nodes"), xr.DataArray)
 
     def test_encode_ugrid(self):
         """Read an Exodus dataset and encode that as a UGRID format."""


### PR DESCRIPTION
Addresses #207 

### Summary of changes directly addressing #207:
- To address the broken OPeNDAP url: adds a try/catch before attempting remainder of test (in addition to @ocefpaf's contribution in https://github.com/UXARRAY/uxarray/pull/209)
- Does not touch reflected list deprecation in numba, that will be a separate PR since it's not currently causing tests to fail
- To address failing upstream ci caused by pip installs overriding conda pins:
    - removes upstream pip installs from `upstream-dev-environment.yml`
    - take dependency install out of `conda_setup` step
    - add `Install select upstream dependencies` step
    - re-add conda dependencies install _after_ pip dependencies

### Bonus changes:
- adds a `conda list` step to `upstream-dev-ci.yml` and `ci.yml`
- updated upstream CI to run on python 3.10
- added python 3.10 to version matrix for regular CI, too
- renames environment in `upstream-dev-ci.yml` to be `uxarray_upstream_build` instead of `uxarray_build` to be distinct from the environment name in `environment.yml` and `ci.yml`
- changes pip install from git to zip for speed
- uses conda instead of mamba for more consistent environment solving only for upstream ci (errors persist if mamba is used)

See passing upstream ci for this branch here: https://github.com/UXARRAY/uxarray/actions/runs/4021274777/jobs/6910001710