### PR TITLE
slots warning fix

### DIFF
--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -7,6 +7,7 @@ from uxarray.core.grid import Grid
 
 
 class UxDataArray(xr.DataArray):
+    # expected instance attributes, required for subclassing with xarray (as of v0.13.0)
     __slots__ = ("_uxgrid",)
 
     def __init__(self, *args, uxgrid: Grid = None, **kwargs):

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -7,7 +7,7 @@ from uxarray.core.grid import Grid
 
 
 class UxDataArray(xr.DataArray):
-
+    __slots__ = ("source_datasets")
     _uxgrid = None
 
     def __init__(self, *args, uxgrid: Grid = None, **kwargs):
@@ -20,6 +20,8 @@ class UxDataArray(xr.DataArray):
         else:
             self.uxgrid = uxgrid
 
+    # def __slots__ = ()
+    #     # print("slots")
     @property
     def uxgrid(self):
         return self._uxgrid

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -14,8 +14,12 @@ class UxDataArray(xr.DataArray):
 
         self._uxgrid = uxgrid
 
-        if uxgrid is None:
-            raise RuntimeError("uxgrid cannot be None")
+        if uxgrid is None or not isinstance(uxgrid, Grid):
+            raise RuntimeError(
+                "UxDataArray__init__: uxgrid cannot be None. It needs to "
+                "be of an instance of the uxarray.core.Grid class")
+        else:
+            self.uxgrid = uxgrid
 
     @property
     def uxgrid(self):
@@ -23,9 +27,9 @@ class UxDataArray(xr.DataArray):
 
     # a setter function
     @uxgrid.setter
-    def uxgrid(self, ugrid):
-        self._uxgrid = ugrid
+    def uxgrid(self, grid_obj):
+        self._uxgrid = grid_obj
 
-    # You can add custom methods to the class here
+    # You can add custom methods to the class here.
     def custom_method(self):
         print("Custom method for the class")

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -7,21 +7,16 @@ from uxarray.core.grid import Grid
 
 
 class UxDataArray(xr.DataArray):
-    __slots__ = ("source_datasets")
-    _uxgrid = None
+    __slots__ = ("_uxgrid",)
 
     def __init__(self, *args, uxgrid: Grid = None, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.uxgrid = uxgrid
+        self._uxgrid = uxgrid
 
         if uxgrid is None:
             raise RuntimeError("uxgrid cannot be None")
-        else:
-            self.uxgrid = uxgrid
 
-    # def __slots__ = ()
-    #     # print("slots")
     @property
     def uxgrid(self):
         return self._uxgrid
@@ -29,7 +24,6 @@ class UxDataArray(xr.DataArray):
     # a setter function
     @uxgrid.setter
     def uxgrid(self, ugrid):
-
         self._uxgrid = ugrid
 
     # You can add custom methods to the class here

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -28,8 +28,8 @@ class UxDataArray(xr.DataArray):
 
     # a setter function
     @uxgrid.setter
-    def uxgrid(self, grid_obj):
-        self._uxgrid = grid_obj
+    def uxgrid(self, ugrid_obj):
+        self._uxgrid = ugrid_obj
 
     # You can add custom methods to the class here.
     def custom_method(self):

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -17,8 +17,8 @@ class UxDataArray(xr.DataArray):
 
         if uxgrid is None or not isinstance(uxgrid, Grid):
             raise RuntimeError(
-                "UxDataArray__init__: uxgrid cannot be None. It needs to "
-                "be of an instance of the uxarray.core.Grid class")
+                "uxarray.core.UxDataArray.__init__: uxgrid cannot be None. It needs to "
+                "be an instance of the uxarray.core.Grid class")
         else:
             self.uxgrid = uxgrid
 

--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -10,7 +10,7 @@ from uxarray.core.grid import Grid
 
 
 class UxDataset(xr.Dataset):
-
+    __slots__ = ("source_datasets",)
     _uxgrid = None
 
     def __init__(self,

--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -43,8 +43,8 @@ class UxDataset(xr.Dataset):
 
     # a setter function
     @uxgrid.setter
-    def uxgrid(self, ugrid):
-        self._uxgrid = ugrid
+    def uxgrid(self, ugrid_obj):
+        self._uxgrid = ugrid_obj
 
     def _construct_dataarray(self, name) -> UxDataArray:
         """Override to check if the result is an instance of xarray.DataArray.

--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -13,6 +13,7 @@ from uxarray.core.grid import Grid
 
 class UxDataset(xr.Dataset):
 
+    # expected instance attributes, required for subclassing with xarray (as of v0.13.0)
     __slots__ = (
         '_uxgrid',
         'source_datasets',

--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -32,7 +32,6 @@ class UxDataset(xr.Dataset):
         if uxgrid is None or not isinstance(uxgrid, Grid):
             raise RuntimeError(
                 "uxarray.core.UxDataset.__init__: uxgrid cannot be None. It needs to "
-                "be an instance of the uxarray.core.Grid class")
                 "be of an instance of the uxarray.core.Grid class")
         else:
             self.uxgrid = uxgrid

--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -31,7 +31,8 @@ class UxDataset(xr.Dataset):
 
         if uxgrid is None or not isinstance(uxgrid, Grid):
             raise RuntimeError(
-                "uxgrid cannot be None or it needs to "
+                "uxarray.core.UxDataset.__init__: uxgrid cannot be None. It needs to "
+                "be an instance of the uxarray.core.Grid class")
                 "be of an instance of the uxarray.core.Grid class")
         else:
             self.uxgrid = uxgrid

--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -10,8 +10,11 @@ from uxarray.core.grid import Grid
 
 
 class UxDataset(xr.Dataset):
-    __slots__ = ("source_datasets",)
-    _uxgrid = None
+
+    __slots__ = (
+        '_uxgrid',
+        'source_datasets',
+    )
 
     def __init__(self,
                  *args,
@@ -20,9 +23,8 @@ class UxDataset(xr.Dataset):
                  **kwargs):
         super().__init__(*args, **kwargs)
 
+        self._uxgrid = uxgrid
         setattr(self, 'source_datasets', source_datasets)
-
-        self.uxgrid = uxgrid
 
         if uxgrid is None or not isinstance(uxgrid, Grid):
             raise RuntimeError(
@@ -38,7 +40,6 @@ class UxDataset(xr.Dataset):
     # a setter function
     @uxgrid.setter
     def uxgrid(self, ugrid):
-
         self._uxgrid = ugrid
 
     def _construct_dataarray(self, name) -> UxDataArray:
@@ -47,7 +48,6 @@ class UxDataset(xr.Dataset):
         If so, convert to UxDataArray.
         """
         xarr = super()._construct_dataarray(name)
-
         return UxDataArray(xarr, uxgrid=self.uxgrid)
 
     def __getitem__(self, key):
@@ -60,7 +60,8 @@ class UxDataset(xr.Dataset):
         if isinstance(xarr, xr.DataArray):
             return UxDataArray(xarr, uxgrid=self.uxgrid)
         else:
-            return xarr
+            assert isinstance(xarr, xr.Dataset)
+            return UxDataset(xarr, uxgrid=self.uxgrid)
 
     def __setitem__(self, key, value):
         """Override to check if the value being set is an instance of


### PR DESCRIPTION
 https://docs.xarray.dev/en/stable/whats-new.html\?highlight\=slots\#v0-13-0-17-sep-2019

    object.__setattr__(self, name, value)
../uxarray/core/dataset.py:42: in uxgrid
    self._uxgrid = ugrid
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <[AttributeError("'UxDataArray' object attribute '_uxgrid' is read-only") raised in repr()] UxDataset object at 0x15ff32640>
name = '_uxgrid', value = <uxarray.core.grid.Grid object at 0x16c7103d0>

    def __setattr__(self, name: str, value: Any) -> None:
        """Objects with ``__slots__`` raise AttributeError if you try setting an
        undeclared attribute. This is desirable, but the error message could use some
        improvement.
        """
        try:
>           object.__setattr__(self, name, value)
E           AttributeError: 'UxDataset' object attribute '_uxgrid' is read-only