### PR TITLE
Fix to `nan` Values Breaking UGRID Data Type and Fill Values

### DIFF
--- a/ci/docs.yml
+++ b/ci/docs.yml
@@ -18,7 +18,7 @@ dependencies:
     - ipython
     - jupyter_client
     - matplotlib-base
-    - sphinx-book-theme<=0.13.1
+    - sphinx-book-theme
     - myst-nb
     - sphinx-design
     - nbsphinx

--- a/ci/docs.yml
+++ b/ci/docs.yml
@@ -18,7 +18,7 @@ dependencies:
     - ipython
     - jupyter_client
     - matplotlib-base
-    - sphinx-book-theme
+    - sphinx-book-theme<=0.13.1
     - myst-nb
     - sphinx-design
     - nbsphinx

--- a/test/test_ugrid.py
+++ b/test/test_ugrid.py
@@ -82,8 +82,14 @@ class TestUgrid(TestCase):
         ux_grid3 = ux.Grid(xr_grid3)
 
         # check for correct dtype and fill value
-        grids = [ux_grid1, ux_grid2, ux_grid3]
-        for grid in grids:
+        grids_with_fill = [ux_grid2]
+        for grid in grids_with_fill:
+            assert grid.Mesh2_face_nodes.dtype == INT_DTYPE
+            assert grid.Mesh2_face_nodes._FillValue == INT_FILL_VALUE
+            assert INT_FILL_VALUE in grid.Mesh2_face_nodes.values
+
+        grids_without_fill = [ux_grid1, ux_grid2]
+        for grid in grids_without_fill:
             assert grid.Mesh2_face_nodes.dtype == INT_DTYPE
             assert grid.Mesh2_face_nodes._FillValue == INT_FILL_VALUE
 
@@ -93,9 +99,9 @@ class TestUgrid(TestCase):
 
         with dask chunking
         """
-        ug_filename = current_path / "meshfiles" / "ugrid" / "outCSne30" / "outCSne30.ug"
+        ug_filename = current_path / "meshfiles" / "ugrid" / "outRLL1deg" / "outRLL1deg.ug"
         xr_grid = xr.open_dataset(str(ug_filename), chunks={'nMesh2_node': 100})
         ux_grid = ux.Grid(xr_grid)
         assert ux_grid.Mesh2_face_nodes.dtype == INT_DTYPE
         assert ux_grid.Mesh2_face_nodes._FillValue == INT_FILL_VALUE
-        pass
+        assert INT_FILL_VALUE in ux_grid.Mesh2_face_nodes.values

--- a/test/test_ugrid.py
+++ b/test/test_ugrid.py
@@ -88,7 +88,7 @@ class TestUgrid(TestCase):
             assert grid.Mesh2_face_nodes._FillValue == INT_FILL_VALUE
             assert INT_FILL_VALUE in grid.Mesh2_face_nodes.values
 
-        grids_without_fill = [ux_grid1, ux_grid2]
+        grids_without_fill = [ux_grid1, ux_grid3]
         for grid in grids_without_fill:
             assert grid.Mesh2_face_nodes.dtype == INT_DTYPE
             assert grid.Mesh2_face_nodes._FillValue == INT_FILL_VALUE

--- a/uxarray/_ugrid.py
+++ b/uxarray/_ugrid.py
@@ -1,5 +1,5 @@
 import xarray as xr
-
+import numpy as np
 from uxarray.helpers import _replace_fill_values
 from uxarray.constants import INT_DTYPE, INT_FILL_VALUE
 
@@ -92,15 +92,17 @@ def _standardize_fill_values(ds, var_names_dict):
 
     # original fill value, if one exists
     if "_FillValue" in ds[var_names_dict['Mesh2_face_nodes']].attrs:
-        current_fv = ds[var_names_dict['Mesh2_face_nodes']]._FillValue
+        original_fv = ds[var_names_dict['Mesh2_face_nodes']]._FillValue
+    elif np.isnan(ds[var_names_dict['Mesh2_face_nodes']].values).any():
+        original_fv = np.nan
     else:
-        current_fv = None
+        original_fv = None
 
     # if current dtype and fill value are not standardized
-    if face_nodes.dtype != INT_DTYPE or current_fv != INT_FILL_VALUE:
+    if face_nodes.dtype != INT_DTYPE or original_fv != INT_FILL_VALUE:
         # replace fill values and set correct dtype
         new_face_nodes = _replace_fill_values(grid_var=face_nodes,
-                                              original_fill=current_fv,
+                                              original_fill=original_fv,
                                               new_fill=INT_FILL_VALUE,
                                               new_dtype=INT_DTYPE)
         # reassign data to use updated face nodes

--- a/uxarray/helpers.py
+++ b/uxarray/helpers.py
@@ -584,7 +584,10 @@ def _replace_fill_values(grid_var, original_fill, new_fill, new_dtype=None):
     """
 
     # locations of fill values
-    fill_val_idx = grid_var.ravel() == original_fill
+    if original_fill is not np.nan:
+        fill_val_idx = grid_var.ravel() == original_fill
+    else:
+        fill_val_idx = np.isnan(grid_var.ravel())
 
     # convert to new data type
     if new_dtype != grid_var.dtype and new_dtype is not None:

--- a/uxarray/helpers.py
+++ b/uxarray/helpers.py
@@ -584,23 +584,37 @@ def _replace_fill_values(grid_var, original_fill, new_fill, new_dtype=None):
     """
 
     # locations of fill values
-    if original_fill is not np.nan:
-        fill_val_idx = grid_var.ravel() == original_fill
+    if original_fill is not None and np.isnan(original_fill):
+        fill_val_idx = np.isnan(grid_var)
     else:
-        fill_val_idx = np.isnan(grid_var.ravel())
+        fill_val_idx = grid_var == original_fill
 
     # convert to new data type
     if new_dtype != grid_var.dtype and new_dtype is not None:
         grid_var = grid_var.astype(new_dtype)
 
-    # ensure select fill value can be represented with current dtype
-    dtype_min = np.iinfo(grid_var.dtype).min
-    dtype_max = np.iinfo(grid_var.dtype).max
-    if new_fill not in range(dtype_min, dtype_max + 1):
-        raise ValueError(f'New fill value: {new_fill} not representable by'
-                         f' dtype: {grid_var.dtype}')
+    # ensure fill value can be represented with current integer data type
+    if np.issubdtype(new_dtype, np.integer):
+        int_min = np.iinfo(grid_var.dtype).min
+        int_max = np.iinfo(grid_var.dtype).max
+        # ensure new_fill is in range [int_min, int_max]
+        if new_fill < int_min or new_fill > int_max:
+            raise ValueError(f'New fill value: {new_fill} not representable by'
+                             f' integer dtype: {grid_var.dtype}')
+
+    # ensure non-nan fill value can be represented with current float data type
+    elif np.issubdtype(new_dtype, np.floating) and not np.isnan(new_fill):
+        float_min = np.finfo(grid_var.dtype).min
+        float_max = np.finfo(grid_var.dtype).max
+        # ensure new_fill is in range [float_min, float_max]
+        if new_fill < float_min or new_fill > float_max:
+            raise ValueError(f'New fill value: {new_fill} not representable by'
+                             f' float dtype: {grid_var.dtype}')
+    else:
+        raise ValueError(f'Data type {grid_var.dtype} not supported'
+                         f'for grid variables')
 
     # replace all zeros with a fill value
-    grid_var.ravel()[fill_val_idx] = new_fill
+    grid_var[fill_val_idx] = new_fill
 
     return grid_var


### PR DESCRIPTION
# Overview
* Implementation from #241 broke when `nan` was used for `Mesh2_face_nodes`, since `np.isnan` needs to be used to locate any occurrences of `nan`
* This hotfix modifies `test_standardized_dtype_and_fill` to separate datasets that contain a fill value and those that don't
* Changes were made to `_read_ugrid` to correctly parse the original fill value 
* `_replace_fill_values` now uses `np.isnan` to find all occurrences of `nan`