### PR TITLE
Bug fixed for `Grid.__from_vert__()`

### DIFF
--- a/uxarray/grid.py
+++ b/uxarray/grid.py
@@ -214,7 +214,7 @@ class Grid:
             # Update indices accordingly
             for i, idx in enumerate(false_indices):
                 indices[indices == idx] = INT_FILL_VALUE
-                indices[indices > idx] -= 1
+                indices[(indices > idx) & (indices != INT_FILL_VALUE)] -= 1
 
         # Create coordinate DataArrays
         self.ds["Mesh2_node_x"] = xr.DataArray(data=unique_verts[:, 0],


### PR DESCRIPTION
A small but important bug fix for `Grid.__from_vert__()`
 The previous version doesn't have `& (indices != INT_FILL_VALUE)` which will decrease the `INT_FILL_VALUE` by 1, deprecating all following `INT_FILL_VALUE` detection
``` python
            # Update indices accordingly
            for i, idx in enumerate(false_indices):
                indices[indices == idx] = INT_FILL_VALUE
                indices[(indices > idx) ] -= 1
```