### PR TITLE
[Multi_Precision_Calculation]Unique_coordinates_detection_through_input_vertices

### DIFF
--- a/ci/docs.yml
+++ b/ci/docs.yml
@@ -22,3 +22,5 @@ dependencies:
     - myst-nb
     - sphinx-design
     - nbsphinx
+    - gmpy2
+    - mpmath

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -12,3 +12,5 @@ dependencies:
   - pytest-cov
   - scipy
   - xarray
+  - gmpy2
+  - mpmath

--- a/ci/upstream-dev-environment.yml
+++ b/ci/upstream-dev-environment.yml
@@ -10,3 +10,5 @@ dependencies:
   - pytest
   - pytest-cov
   - scipy
+  - gmpy2
+  - mpmath

--- a/docs/user_api/index.rst
+++ b/docs/user_api/index.rst
@@ -43,3 +43,13 @@ Helper Functions
    helpers.node_lonlat_rad_to_xyz
    helpers.normalize_in_place
    helpers.close_face_nodes
+
+Multi-Precision Helper Functions
+-------------------------------
+.. autosummary::
+   :toctree: _autosummary
+
+   multi_precision_helpers.convert_to_multiprecision
+   multi_precision_helpers.unique_coordinates_multiprecision
+   multi_precision_helpers.decimal_digits_to_precision_bits
+   multi_precision_helpers.precision_bits_to_decimal_digits

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -152,10 +152,12 @@ class TestGrid(TestCase):
         # between any two nodes is less than 1e-17 (the precision of the nodes is 60 bits but we will use 65 bits for
         # testing)
         for i in range(4):
-            theta = gmpy2.div(i * 2 * gmpy2.const_pi(precision=65), 4)  # Angle in radians
+            theta = gmpy2.div(i * 2 * gmpy2.const_pi(precision=65),
+                              4)  # Angle in radians
             x = gmpy2.cos(theta)
             y = gmpy2.sin(theta)
-            z = mpfr(0)  # All nodes will have z-coordinate as 0 on the unit sphere
+            z = mpfr(
+                0)  # All nodes will have z-coordinate as 0 on the unit sphere
             nodes.append([x, y, z])
 
         # Generate the face nodes connectivity
@@ -167,7 +169,9 @@ class TestGrid(TestCase):
         ])
 
         # Create the grid
-        vgrid = ux.Grid(face_nodes_connectivity, multi_precision=True, precision= 65,
+        vgrid = ux.Grid(face_nodes_connectivity,
+                        multi_precision=True,
+                        precision=65,
                         vertices=True,
                         islatlon=False,
                         concave=False)
@@ -177,7 +181,6 @@ class TestGrid(TestCase):
 
     def test_init_verts_multi_precision_fill_values(self):
         # Set the desired precision
-        gmpy2.get_context().precision = 100
 
         # Generate the nodes on the unit sphere, and the nodes are extremely close to each other: the edge length
         # between any two nodes is less than 1e-17 (the precision of the nodes is 60 bits but we will use 65 bits for
@@ -185,22 +188,29 @@ class TestGrid(TestCase):
 
         nodes = []
         for i in range(4):
-            theta = gmpy2.div(i * 2 * gmpy2.const_pi(precision=65), 4)  # Angle in radians
+            theta = gmpy2.div(i * 2 * gmpy2.const_pi(precision=65),
+                              4)  # Angle in radians
             x = gmpy2.cos(theta)
             y = gmpy2.sin(theta)
-            z = mpfr('0')  # All nodes will have z-coordinate as 0 on the unit sphere
+            z = mpfr(
+                '0')  # All nodes will have z-coordinate as 0 on the unit sphere
             nodes.append([x, y, z])
 
         # Generate the face nodes connectivity
-        dumb_nodes = [ux.INT_FILL_VALUE_MPZ, ux.INT_FILL_VALUE_MPZ, ux.INT_FILL_VALUE_MPZ]
+        dumb_nodes = [
+            ux.INT_FILL_VALUE_MPZ, ux.INT_FILL_VALUE_MPZ, ux.INT_FILL_VALUE_MPZ
+        ]
         face_nodes_connectivity = np.array([
             np.array([nodes[0], nodes[1], nodes[2], dumb_nodes], dtype=object),
             np.array([nodes[0], nodes[2], nodes[3], dumb_nodes], dtype=object),
             np.array([nodes[0], nodes[3], nodes[1], dumb_nodes], dtype=object),
             np.array([nodes[1], nodes[2], nodes[3], nodes[0]], dtype=object)
-        ], dtype=object)
+        ],
+                                           dtype=object)
         # Create the grid
-        vgrid = ux.Grid(face_nodes_connectivity, multi_precision=True, precision= 65,
+        vgrid = ux.Grid(face_nodes_connectivity,
+                        multi_precision=True,
+                        precision=65,
                         vertices=True,
                         islatlon=False,
                         concave=False)

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -178,3 +178,32 @@ class TestConstants(TestCase):
                                                    original_fill=-1,
                                                    new_fill=INT_FILL_VALUE,
                                                    new_dtype=np.int16)
+
+class TestMultiPrecision(TestCase):
+    def test_convert_to_mpfr(self):
+        """Tests if the convert_to_mpfr() helper function converts a numpy
+        array to a numpy array of the correct dtype."""
+        # test different datatypes for face_nodes
+        f0_deg = np.array([np.array([120, -20]), np.array([130, -10]), np.array([120, 0]),
+                           np.array([105, 0]), np.array([95, -10]), np.array([105, -20])])
+        f1_deg = np.array([np.array([120, 0]), np.array([120, 10]), np.array([115, 0]),
+                           np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE]),
+                           np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE]),
+                           np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE])])
+        f2_deg = np.array([np.array([115, 0]), np.array([120, 10]), np.array([100, 10]),
+                           np.array([105, 0]), np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE]),
+                           np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE])])
+        f3_deg = np.array([np.array([95, -10]), np.array([105, 0]), np.array([95, 30]),
+                           np.array([80, 30]), np.array([70, 0]), np.array([75, -10])])
+        f4_deg = np.array([np.array([65, -20]), np.array([75, -10]), np.array([70, 0]),
+                           np.array([55, 0]), np.array([45, -10]), np.array([55, -20])])
+        f5_deg = np.array([np.array([70, 0]), np.array([80, 30]), np.array([70, 30]),
+                           np.array([60, 0]), np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE]),
+                           np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE])])
+        f6_deg = np.array([np.array([60, 0]), np.array([70, 30]), np.array([40, 30]),
+                           np.array([45, 0]), np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE]),
+                           np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE])])
+
+        verts = np.array([f0_deg, f1_deg, f2_deg, f3_deg, f4_deg, f5_deg, f6_deg])
+
+        verts_mpfr = ux.helpers.convert_to_mpfr(verts, str_mode=False,precision=64)

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -178,4 +178,3 @@ class TestConstants(TestCase):
                                                    original_fill=-1,
                                                    new_fill=INT_FILL_VALUE,
                                                    new_dtype=np.int16)
-

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -179,31 +179,3 @@ class TestConstants(TestCase):
                                                    new_fill=INT_FILL_VALUE,
                                                    new_dtype=np.int16)
 
-class TestMultiPrecision(TestCase):
-    def test_convert_to_mpfr(self):
-        """Tests if the convert_to_mpfr() helper function converts a numpy
-        array to a numpy array of the correct dtype."""
-        # test different datatypes for face_nodes
-        f0_deg = np.array([np.array([120, -20]), np.array([130, -10]), np.array([120, 0]),
-                           np.array([105, 0]), np.array([95, -10]), np.array([105, -20])])
-        f1_deg = np.array([np.array([120, 0]), np.array([120, 10]), np.array([115, 0]),
-                           np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE]),
-                           np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE]),
-                           np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE])])
-        f2_deg = np.array([np.array([115, 0]), np.array([120, 10]), np.array([100, 10]),
-                           np.array([105, 0]), np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE]),
-                           np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE])])
-        f3_deg = np.array([np.array([95, -10]), np.array([105, 0]), np.array([95, 30]),
-                           np.array([80, 30]), np.array([70, 0]), np.array([75, -10])])
-        f4_deg = np.array([np.array([65, -20]), np.array([75, -10]), np.array([70, 0]),
-                           np.array([55, 0]), np.array([45, -10]), np.array([55, -20])])
-        f5_deg = np.array([np.array([70, 0]), np.array([80, 30]), np.array([70, 30]),
-                           np.array([60, 0]), np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE]),
-                           np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE])])
-        f6_deg = np.array([np.array([60, 0]), np.array([70, 30]), np.array([40, 30]),
-                           np.array([45, 0]), np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE]),
-                           np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE])])
-
-        verts = np.array([f0_deg, f1_deg, f2_deg, f3_deg, f4_deg, f5_deg, f6_deg])
-
-        verts_mpfr = ux.helpers.convert_to_mpfr(verts, str_mode=False,precision=64)

--- a/test/test_multi_precision_helpers.py
+++ b/test/test_multi_precision_helpers.py
@@ -1,0 +1,157 @@
+
+
+import os
+import numpy as np
+import numpy.testing as nt
+import random
+import xarray as xr
+import gmpy2
+from gmpy2 import mpfr
+
+from unittest import TestCase
+from pathlib import Path
+
+import uxarray as ux
+
+from uxarray.helpers import _replace_fill_values
+from uxarray.constants import INT_DTYPE, INT_FILL_VALUE, FLOAT_PRECISION_BITS
+from  uxarray.multi_precision_helpers import convert_to_mpfr, unique_coordinates_mpfr
+
+try:
+    import constants
+except ImportError:
+    from . import constants
+
+# Data files
+current_path = Path(os.path.dirname(os.path.realpath(__file__)))
+
+exodus = current_path / "meshfiles" / "exodus" / "outCSne8" / "outCSne8.g"
+ne8 = current_path / 'meshfiles' / "scrip" / "outCSne8" / 'outCSne8.nc'
+err_tolerance = 1.0e-12
+
+
+class TestMultiPrecision(TestCase):
+    def test_convert_to_mpfr(self):
+        """Tests if the convert_to_mpfr() helper function converts a numpy
+        array to a numpy array of the correct dtype."""
+        # test different datatypes for face_nodes
+        test_precision = 64
+        f0_deg = np.array([np.array([120, -20]), np.array([130, -10]), np.array([120, 0]),
+                           np.array([105, 0]), np.array([95, -10]), np.array([105, -20])])
+        f1_deg = np.array([np.array([120, 0]), np.array([120, 10]), np.array([115, 0]),
+                           np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE]),
+                           np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE]),
+                           np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE])])
+        f2_deg = np.array([np.array([115, 0]), np.array([120, 10]), np.array([100, 10]),
+                           np.array([105, 0]), np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE]),
+                           np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE])])
+        f3_deg = np.array([np.array([95, -10]), np.array([105, 0]), np.array([95, 30]),
+                           np.array([80, 30]), np.array([70, 0]), np.array([75, -10])])
+        f4_deg = np.array([np.array([65, -20]), np.array([75, -10]), np.array([70, 0]),
+                           np.array([55, 0]), np.array([45, -10]), np.array([55, -20])])
+        f5_deg = np.array([np.array([70, 0]), np.array([80, 30]), np.array([70, 30]),
+                           np.array([60, 0]), np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE]),
+                           np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE])])
+        f6_deg = np.array([np.array([60, 0]), np.array([70, 30]), np.array([40, 30]),
+                           np.array([45, 0]), np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE]),
+                           np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE])])
+
+        verts = np.array([f0_deg, f1_deg, f2_deg, f3_deg, f4_deg, f5_deg, f6_deg])
+
+        verts_mpfr = convert_to_mpfr(verts, str_mode=False,precision=test_precision)
+
+        # Test if every object in the verts_mpfr array is of type mpfr
+        for i in range(verts_mpfr.shape[0]):
+            for j in range(verts_mpfr.shape[1]):
+                self.assertEqual(verts_mpfr[i, j][0].precision, test_precision)
+                self.assertEqual(verts_mpfr[i, j][1].precision, test_precision)
+
+                # Then compare the values between verts and verts_mpfr up to the 53 bits of precision
+                self.assertAlmostEqual(verts[i, j][0], verts_mpfr[i, j][0], places=FLOAT_PRECISION_BITS)
+                self.assertAlmostEqual(verts[i, j][1], verts_mpfr[i, j][1], places=FLOAT_PRECISION_BITS)
+
+    def test_mpfr_unique_normal_case(self):
+        """
+        The input cartesian coordinates represents 8 vertices on a cube
+             7---------6
+            /|        /|
+           / |       / |
+          3---------2  |
+          |  |      |  |
+          |  4------|--5
+          | /       | /
+          |/        |/
+          0---------1
+        """
+
+        test_precision = 64
+        cart_x = [
+            0.577340924821405, 0.577340924821405, 0.577340924821405,
+            0.577340924821405, -0.577345166204668, -0.577345166204668,
+            -0.577345166204668, -0.577345166204668
+        ]
+        cart_y = [
+            0.577343045516932, 0.577343045516932, -0.577343045516932,
+            -0.577343045516932, 0.577338804118089, 0.577338804118089,
+            -0.577338804118089, -0.577338804118089
+        ]
+        cart_z = [
+            0.577366836872017, -0.577366836872017, 0.577366836872017,
+            -0.577366836872017, 0.577366836872017, -0.577366836872017,
+            0.577366836872017, -0.577366836872017
+        ]
+
+        # The order of the vertexes is irrelevant, the following indexing is just for forming a face matrix
+        face_vertices = [
+            [0, 1, 2, 3],  # front face
+            [1, 5, 6, 2],  # right face
+            [5, 4, 7, 6],  # back face
+            [4, 0, 3, 7],  # left face
+            [3, 2, 6, 7],  # top face
+            [4, 5, 1, 0]  # bottom face
+        ]
+
+        # Pack the cart_x/y/z into the face matrix using the index from face_vertices
+        faces_coords = []
+        for face in face_vertices:
+            face_coords = []
+            for vertex_index in face:
+                x, y, z = cart_x[vertex_index], cart_y[vertex_index], cart_z[
+                    vertex_index]
+                face_coords.append([x, y, z])
+            faces_coords.append(face_coords)
+
+        # Now consturct the grid using the faces_coords
+        verts_cart = np.array(faces_coords)
+        verts_cart_mpfr = convert_to_mpfr(verts_cart, str_mode=False, precision=test_precision)
+        verts_cart_mpfr_unique, unique_inverse = unique_coordinates_mpfr(verts_cart_mpfr.reshape(
+            -1, verts_cart_mpfr.shape[-1]), precision=test_precision)
+        recovered_verts_cart_mpfr = verts_cart_mpfr_unique[unique_inverse]
+
+        # Compare the recovered verts_cart_mpfr with the original verts_cart_mpfr.reshape(-1, verts_cart_mpfr.shape[-1])
+        expected = verts_cart_mpfr.reshape(-1, verts_cart_mpfr.shape[-1])
+        for i in range(recovered_verts_cart_mpfr.shape[0]):
+            for j in range(recovered_verts_cart_mpfr.shape[1]):
+                self.assertEqual(recovered_verts_cart_mpfr[i, j].precision, test_precision)
+                # Then compare the values between verts and verts_mpfr up to the 53 bits of precision
+                self.assertAlmostEqual(expected[i, j], recovered_verts_cart_mpfr[i, j], places=FLOAT_PRECISION_BITS)
+
+    def test_mpfr_unique_extreme_case(self):
+        coord1 = [gmpy2.mpfr('1.23456789'), gmpy2.mpfr('2.34567890'), gmpy2.mpfr('3.45678901')]
+        coord2 = [gmpy2.mpfr('1.23456789'), gmpy2.mpfr('2.34567890'), gmpy2.mpfr('3.45678901')]
+        # Convert the coordinates to string format
+        coord1_str = ["{0:.17f}".format(coord) for coord in coord1]
+        coord2_str = ["{0:.17f}".format(coord) for coord in coord2]
+
+        # Create the final coordinates with the differing 64th bit
+        coord1_final = [coord + '0' for coord in coord1_str]
+        coord2_final = [coord + '1' for coord in coord2_str]
+        verts = np.array([coord1_final, coord2_final])
+        verts_60 = convert_to_mpfr(verts, str_mode=True, precision=60)
+        verts_57 = convert_to_mpfr(verts, str_mode=True, precision=57)
+
+        verts_cart_mpfr_unique_64, unique_inverse_64 = unique_coordinates_mpfr(verts_60, precision=60)
+        verts_cart_mpfr_unique_57, unique_inverse_57 = unique_coordinates_mpfr(verts_57, precision=57)
+        self.assertTrue(len(verts_cart_mpfr_unique_64) == 2)
+        self.assertTrue(len(verts_cart_mpfr_unique_57) == 1)
+

--- a/test/test_multi_precision_helpers.py
+++ b/test/test_multi_precision_helpers.py
@@ -1,5 +1,3 @@
-
-
 import os
 import numpy as np
 import gmpy2
@@ -11,7 +9,7 @@ from pathlib import Path
 import uxarray as ux
 
 from uxarray.constants import INT_DTYPE, INT_FILL_VALUE, FLOAT_PRECISION_BITS, INT_FILL_VALUE_MPZ
-from  uxarray.multi_precision_helpers import convert_to_mpfr, unique_coordinates_mpfr, precision_bits_to_decimal_digits, decimal_digits_to_precision_bits
+from uxarray.multi_precision_helpers import convert_to_multiprecision, unique_coordinates_multiprecision, precision_bits_to_decimal_digits, decimal_digits_to_precision_bits
 import math
 
 try:
@@ -28,34 +26,75 @@ err_tolerance = 1.0e-12
 
 
 class TestMultiPrecision(TestCase):
-    def test_convert_to_mpfr(self):
+
+    def test_convert_to_multiprecision(self):
         """Tests if the convert_to_mpfr() helper function converts a numpy
         array to a numpy array of the correct dtype."""
         # test different datatypes for face_nodes
         test_precision = 64
-        f0_deg = np.array([np.array([120, -20]), np.array([130, -10]), np.array([120, 0]),
-                           np.array([105, 0]), np.array([95, -10]), np.array([105, -20])])
-        f1_deg = np.array([np.array([120, 0]), np.array([120, 10]), np.array([115, 0]),
-                           np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE]),
-                           np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE]),
-                           np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE])])
-        f2_deg = np.array([np.array([115, 0]), np.array([120, 10]), np.array([100, 10]),
-                           np.array([105, 0]), np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE]),
-                           np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE])])
-        f3_deg = np.array([np.array([95, -10]), np.array([105, 0]), np.array([95, 30]),
-                           np.array([80, 30]), np.array([70, 0]), np.array([75, -10])])
-        f4_deg = np.array([np.array([65, -20]), np.array([75, -10]), np.array([70, 0]),
-                           np.array([55, 0]), np.array([45, -10]), np.array([55, -20])])
-        f5_deg = np.array([np.array([70, 0]), np.array([80, 30]), np.array([70, 30]),
-                           np.array([60, 0]), np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE]),
-                           np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE])])
-        f6_deg = np.array([np.array([60, 0]), np.array([70, 30]), np.array([40, 30]),
-                           np.array([45, 0]), np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE]),
-                           np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE])])
+        f0_deg = np.array([
+            np.array([120, -20]),
+            np.array([130, -10]),
+            np.array([120, 0]),
+            np.array([105, 0]),
+            np.array([95, -10]),
+            np.array([105, -20])
+        ])
+        f1_deg = np.array([
+            np.array([120, 0]),
+            np.array([120, 10]),
+            np.array([115, 0]),
+            np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE]),
+            np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE]),
+            np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE])
+        ])
+        f2_deg = np.array([
+            np.array([115, 0]),
+            np.array([120, 10]),
+            np.array([100, 10]),
+            np.array([105, 0]),
+            np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE]),
+            np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE])
+        ])
+        f3_deg = np.array([
+            np.array([95, -10]),
+            np.array([105, 0]),
+            np.array([95, 30]),
+            np.array([80, 30]),
+            np.array([70, 0]),
+            np.array([75, -10])
+        ])
+        f4_deg = np.array([
+            np.array([65, -20]),
+            np.array([75, -10]),
+            np.array([70, 0]),
+            np.array([55, 0]),
+            np.array([45, -10]),
+            np.array([55, -20])
+        ])
+        f5_deg = np.array([
+            np.array([70, 0]),
+            np.array([80, 30]),
+            np.array([70, 30]),
+            np.array([60, 0]),
+            np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE]),
+            np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE])
+        ])
+        f6_deg = np.array([
+            np.array([60, 0]),
+            np.array([70, 30]),
+            np.array([40, 30]),
+            np.array([45, 0]),
+            np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE]),
+            np.array([ux.INT_FILL_VALUE, ux.INT_FILL_VALUE])
+        ])
 
-        verts = np.array([f0_deg, f1_deg, f2_deg, f3_deg, f4_deg, f5_deg, f6_deg])
+        verts = np.array(
+            [f0_deg, f1_deg, f2_deg, f3_deg, f4_deg, f5_deg, f6_deg])
 
-        verts_mpfr = convert_to_mpfr(verts, str_mode=False,precision=test_precision)
+        verts_mpfr = convert_to_multiprecision(verts,
+                                               str_mode=False,
+                                               precision=test_precision)
 
         # Test if every object in the verts_mpfr array is of type mpfr
         for i in range(verts_mpfr.shape[0]):
@@ -64,23 +103,26 @@ class TestMultiPrecision(TestCase):
                     if type(val) != mpz:
                         self.assertEqual(val.precision, test_precision)
                         # Then compare the values between verts and verts_mpfr up to the 53 bits of precision
-                        self.assertAlmostEqual(verts[i, j][idx], val, places=FLOAT_PRECISION_BITS)
+                        self.assertAlmostEqual(verts[i, j][idx],
+                                               val,
+                                               places=FLOAT_PRECISION_BITS)
 
                     else:
                         self.assertTrue(gmpy2.cmp(val, INT_FILL_VALUE_MPZ) == 0)
 
-    def test_mpfr_unique_normal_case(self):
-        """
-        The input cartesian coordinates represents 8 vertices on a cube
-             7---------6
-            /|        /|
-           / |       / |
-          3---------2  |
-          |  |      |  |
-          |  4------|--5
-          | /       | /
-          |/        |/
-          0---------1
+    def test_unique_coordinates_multiprecision_normal_case(self):
+        """The input cartesian coordinates represents 8 vertices on a cube 7.
+
+        ---------6.
+
+          /|        /|
+         / |       / |
+        3---------2  |
+        |  |      |  |
+        |  4------|--5
+        | /       | /
+        |/        |/
+        0---------1
         """
 
         test_precision = 64
@@ -122,22 +164,37 @@ class TestMultiPrecision(TestCase):
 
         # Now consturct the grid using the faces_coords
         verts_cart = np.array(faces_coords)
-        verts_cart_mpfr = convert_to_mpfr(verts_cart, str_mode=False, precision=test_precision)
-        verts_cart_mpfr_unique, unique_inverse = unique_coordinates_mpfr(verts_cart_mpfr.reshape(
-            -1, verts_cart_mpfr.shape[-1]), precision=test_precision)
+        verts_cart_mpfr = convert_to_multiprecision(verts_cart,
+                                                    str_mode=False,
+                                                    precision=test_precision)
+        verts_cart_mpfr_unique, unique_inverse = unique_coordinates_multiprecision(
+            verts_cart_mpfr.reshape(-1, verts_cart_mpfr.shape[-1]),
+            precision=test_precision)
         recovered_verts_cart_mpfr = verts_cart_mpfr_unique[unique_inverse]
 
         # Compare the recovered verts_cart_mpfr with the original verts_cart_mpfr.reshape(-1, verts_cart_mpfr.shape[-1])
         expected = verts_cart_mpfr.reshape(-1, verts_cart_mpfr.shape[-1])
         for i in range(recovered_verts_cart_mpfr.shape[0]):
             for j in range(recovered_verts_cart_mpfr.shape[1]):
-                self.assertEqual(recovered_verts_cart_mpfr[i, j].precision, test_precision)
+                self.assertEqual(recovered_verts_cart_mpfr[i, j].precision,
+                                 test_precision)
                 # Then compare the values between verts and verts_mpfr up to the 53 bits of precision
-                self.assertAlmostEqual(expected[i, j], recovered_verts_cart_mpfr[i, j], places=FLOAT_PRECISION_BITS)
+                self.assertAlmostEqual(expected[i, j],
+                                       recovered_verts_cart_mpfr[i, j],
+                                       places=FLOAT_PRECISION_BITS)
 
-    def test_mpfr_unique_extreme_case(self):
-        coord1 = [gmpy2.mpfr('1.23456789'), gmpy2.mpfr('2.34567890'), gmpy2.mpfr('3.45678901')]
-        coord2 = [gmpy2.mpfr('1.23456789'), gmpy2.mpfr('2.34567890'), gmpy2.mpfr('3.45678901')]
+    def test_unique_coordinates_multiprecision_extreme_case(self):
+        # Construct coordinates that are extremely closed to each other
+        coord1 = [
+            gmpy2.mpfr('1.23456789'),
+            gmpy2.mpfr('2.34567890'),
+            gmpy2.mpfr('3.45678901')
+        ]
+        coord2 = [
+            gmpy2.mpfr('1.23456789'),
+            gmpy2.mpfr('2.34567890'),
+            gmpy2.mpfr('3.45678901')
+        ]
         # Convert the coordinates to string format
         coord1_str = ["{0:.17f}".format(coord) for coord in coord1]
         coord2_str = ["{0:.17f}".format(coord) for coord in coord2]
@@ -147,16 +204,30 @@ class TestMultiPrecision(TestCase):
         coord2_final = [coord + '1' for coord in coord2_str]
         verts = np.array([coord1_final, coord2_final])
         bit_precision = decimal_digits_to_precision_bits(18)
-        verts_60 = convert_to_mpfr(verts, str_mode=True, precision=bit_precision)
-        verts_57 = convert_to_mpfr(verts, str_mode=True, precision=bit_precision - 1)
+        verts_60 = convert_to_multiprecision(verts,
+                                             str_mode=True,
+                                             precision=bit_precision)
+        verts_57 = convert_to_multiprecision(verts,
+                                             str_mode=True,
+                                             precision=bit_precision - 1)
 
-        verts_cart_mpfr_unique_64, unique_inverse_64 = unique_coordinates_mpfr(verts_60, precision=bit_precision)
-        verts_cart_mpfr_unique_57, unique_inverse_57 = unique_coordinates_mpfr(verts_57, precision=bit_precision - 1)
+        verts_cart_mpfr_unique_64, unique_inverse_64 = unique_coordinates_multiprecision(
+            verts_60, precision=bit_precision)
+        verts_cart_mpfr_unique_57, unique_inverse_57 = unique_coordinates_multiprecision(
+            verts_57, precision=bit_precision - 1)
         self.assertTrue(len(verts_cart_mpfr_unique_64) == 2)
         self.assertTrue(len(verts_cart_mpfr_unique_57) == 1)
 
-        coord1 = [gmpy2.mpfr('1.23456789'), gmpy2.mpfr('2.34567890'), gmpy2.mpfr('3.45678901')]
-        coord2 = [gmpy2.mpfr('1.23456789'), gmpy2.mpfr('2.34567890'), gmpy2.mpfr('3.45678901')]
+        coord1 = [
+            gmpy2.mpfr('1.23456789'),
+            gmpy2.mpfr('2.34567890'),
+            gmpy2.mpfr('3.45678901')
+        ]
+        coord2 = [
+            gmpy2.mpfr('1.23456789'),
+            gmpy2.mpfr('2.34567890'),
+            gmpy2.mpfr('3.45678901')
+        ]
         # Convert the coordinates to string format
         precision_bits = 200
         decimal_digits = precision_bits_to_decimal_digits(precision_bits - 1)
@@ -171,14 +242,50 @@ class TestMultiPrecision(TestCase):
         coord2_final = [coord + '1' for coord in coord2_str]
         verts = np.array([coord1_final, coord2_final])
 
-        verts_200 = convert_to_mpfr(verts, str_mode=True, precision=precision_bits)
-        verts_199 = convert_to_mpfr(verts, str_mode=True, precision=check - 1)
+        verts_200 = convert_to_multiprecision(verts,
+                                              str_mode=True,
+                                              precision=precision_bits)
+        verts_199 = convert_to_multiprecision(verts,
+                                              str_mode=True,
+                                              precision=check - 1)
 
-        verts_cart_mpfr_unique_200, unique_inverse_200 = unique_coordinates_mpfr(verts_200, precision=precision_bits)
-        verts_cart_mpfr_unique_199, unique_inverse_199 = unique_coordinates_mpfr(verts_199, precision=check - 1)
+        verts_cart_mpfr_unique_200, unique_inverse_200 = unique_coordinates_multiprecision(
+            verts_200, precision=precision_bits)
+        verts_cart_mpfr_unique_199, unique_inverse_199 = unique_coordinates_multiprecision(
+            verts_199, precision=check - 1)
         self.assertTrue(len(verts_cart_mpfr_unique_200) == 2)
         self.assertTrue(len(verts_cart_mpfr_unique_199) == 1)
 
+    def test_unique_coordinates_multiprecision_filled_values(self):
+        # The mpft_unique function should be able to handle filled values
+        coord1 = [
+            gmpy2.mpfr('1.23456789'),
+            gmpy2.mpfr('2.34567890'),
+            gmpy2.mpfr('3.45678901')
+        ]
+        coord2 = [
+            gmpy2.mpfr('1.23456789'),
+            gmpy2.mpfr('2.34567890'),
+            gmpy2.mpfr('3.45678901')
+        ]
+        # Convert the coordinates to string format
+        precision_bits = 200
+        decimal_digits = precision_bits_to_decimal_digits(precision_bits - 1)
 
+        format_str = "{0:." + str(decimal_digits) + "f}"
+        coord1_str = [format_str.format(coord) for coord in coord1]
+        coord2_str = [format_str.format(coord) for coord in coord2]
 
-
+        # Create the final coordinates with the differing 64th bit
+        coord1_final = [coord + '0' for coord in coord1_str]
+        coord2_final = [coord + '1' for coord in coord2_str]
+        verts = np.array([
+            coord1_final, coord2_final,
+            ['INT_FILL_VALUE', 'INT_FILL_VALUE', 'INT_FILL_VALUE']
+        ])
+        verts_200 = convert_to_multiprecision(verts,
+                                              str_mode=True,
+                                              precision=precision_bits)
+        unique_coords, unique_inverse = unique_coordinates_multiprecision(
+            verts_200, precision=precision_bits)
+        self.assertTrue(len(unique_coords) == 3)

--- a/uxarray/constants.py
+++ b/uxarray/constants.py
@@ -1,6 +1,8 @@
 import numpy as np
+from gmpy2 import mpz
 
 # numpy indexing code is written for np.intp
 INT_DTYPE = np.intp
 INT_FILL_VALUE = np.iinfo(INT_DTYPE).min
+INT_FILL_VALUE_MPZ = mpz(str(INT_FILL_VALUE))
 FLOAT_PRECISION_BITS = 53

--- a/uxarray/constants.py
+++ b/uxarray/constants.py
@@ -3,3 +3,4 @@ import numpy as np
 # numpy indexing code is written for np.intp
 INT_DTYPE = np.intp
 INT_FILL_VALUE = np.iinfo(INT_DTYPE).min
+FLOAT_PRECISION_BITS = 53

--- a/uxarray/grid.py
+++ b/uxarray/grid.py
@@ -13,7 +13,7 @@ from ._scrip import _read_scrip, _encode_scrip
 from ._mpas import _read_mpas
 from .helpers import get_all_face_area_from_coords, parse_grid_type, node_xyz_to_lonlat_rad, node_lonlat_rad_to_xyz, close_face_nodes
 from .constants import INT_DTYPE, INT_FILL_VALUE, FLOAT_PRECISION_BITS, INT_FILL_VALUE_MPZ
-from .multi_precision_helpers import convert_to_mpfr, unique_coordinates_mpfr, precision_bits_to_decimal_digits, decimal_digits_to_precision_bits
+from .multi_precision_helpers import convert_to_multiprecision, unique_coordinates_multiprecision, precision_bits_to_decimal_digits, decimal_digits_to_precision_bits
 
 
 class Grid:
@@ -31,7 +31,11 @@ class Grid:
     >>> mesh.encode_as("ugrid")
     """
 
-    def __init__(self, dataset, multi_precision=False, precision = FLOAT_PRECISION_BITS, **kwargs):
+    def __init__(self,
+                 dataset,
+                 multi_precision=False,
+                 precision=FLOAT_PRECISION_BITS,
+                 **kwargs):
         """Initialize grid variables, decide if loading happens via file, verts
         or gridspec.
 
@@ -88,12 +92,16 @@ class Grid:
             dataset = np.asarray(dataset)
             # grid with multiple faces
             if dataset.ndim == 3:
-                self.__from_vert__(dataset, multi_precision=multi_precision, precision=precision)
+                self.__from_vert__(dataset,
+                                   multi_precision=multi_precision,
+                                   precision=precision)
                 self.source_grid = "From vertices"
             # grid with a single face
             elif dataset.ndim == 2:
                 dataset = np.array([dataset])
-                self.__from_vert__(dataset, multi_precision=multi_precision, precision=precision)
+                self.__from_vert__(dataset,
+                                   multi_precision=multi_precision,
+                                   precision=precision)
                 self.source_grid = "From vertices"
             else:
                 raise RuntimeError(
@@ -172,7 +180,10 @@ class Grid:
                 if value in self.ds.dims:
                     setattr(self, key, len(self.ds[value]))
 
-    def __from_vert__(self, dataset, multi_precision=False, precision= FLOAT_PRECISION_BITS):
+    def __from_vert__(self,
+                      dataset,
+                      multi_precision=False,
+                      precision=FLOAT_PRECISION_BITS):
         """Create a grid with faces constructed from vertices specified by the
         given argument.
 
@@ -218,13 +229,15 @@ class Grid:
                 # Flatten the input_array_mpfr to a 1D array so that we can check the type of each element
                 input_array_mpfr_copy = np.ravel(dataset)
                 for i in range(len(input_array_mpfr_copy)):
-                    if type(input_array_mpfr_copy[i]) != gmpy2.mpfr and type(input_array_mpfr_copy[i]) != gmpy2.mpz:
-                        dataset= convert_to_mpfr(dataset, precision=precision)
+                    if type(input_array_mpfr_copy[i]) != gmpy2.mpfr and type(
+                            input_array_mpfr_copy[i]) != gmpy2.mpz:
+                        dataset = convert_to_multiprecision(dataset,
+                                                            precision=precision)
             except Exception as e:
                 raise e
 
-            unique_verts, indices = unique_coordinates_mpfr(dataset.reshape(
-                -1, dataset.shape[-1]), precision=precision)
+            unique_verts, indices = unique_coordinates_multiprecision(
+                dataset.reshape(-1, dataset.shape[-1]), precision=precision)
 
         else:
             unique_verts, indices = np.unique(dataset.reshape(
@@ -236,22 +249,39 @@ class Grid:
         if multi_precision:
             # Perform element-wise comparison using gmpy.cmp()
             fill_value_mask = np.logical_or(
-                np.array([gmpy2.cmp(x, INT_FILL_VALUE_MPZ) == 0 for x in unique_verts[:, 0]], dtype=bool),
-                np.array([gmpy2.cmp(x, INT_FILL_VALUE_MPZ) == 0 for x in unique_verts[:, 1]], dtype=bool)
-            )
+                np.array([
+                    gmpy2.cmp(x, INT_FILL_VALUE_MPZ) == 0
+                    for x in unique_verts[:, 0]
+                ],
+                         dtype=bool),
+                np.array([
+                    gmpy2.cmp(x, INT_FILL_VALUE_MPZ) == 0
+                    for x in unique_verts[:, 1]
+                ],
+                         dtype=bool))
 
             if dataset[0][0].size > 2:
                 fill_value_mask = np.logical_or(
-                    np.array([gmpy2.cmp(x, INT_FILL_VALUE_MPZ) == 0 for x in
-                              unique_verts[:, 0]], dtype=bool),
-                    np.array([gmpy2.cmp(x, INT_FILL_VALUE_MPZ) == 0 for x in
-                              unique_verts[:, 1]], dtype=bool),
-                    np.array([gmpy2.cmp(x, INT_FILL_VALUE_MPZ) == 0 for x in
-                              unique_verts[:, 2]], dtype=bool))
+                    np.array([
+                        gmpy2.cmp(x, INT_FILL_VALUE_MPZ) == 0
+                        for x in unique_verts[:, 0]
+                    ],
+                             dtype=bool),
+                    np.array([
+                        gmpy2.cmp(x, INT_FILL_VALUE_MPZ) == 0
+                        for x in unique_verts[:, 1]
+                    ],
+                             dtype=bool),
+                    np.array([
+                        gmpy2.cmp(x, INT_FILL_VALUE_MPZ) == 0
+                        for x in unique_verts[:, 2]
+                    ],
+                             dtype=bool))
 
         else:
-            fill_value_mask = np.logical_or(unique_verts[:, 0] == INT_FILL_VALUE,
-                                            unique_verts[:, 1] == INT_FILL_VALUE)
+            fill_value_mask = np.logical_or(
+                unique_verts[:, 0] == INT_FILL_VALUE,
+                unique_verts[:, 1] == INT_FILL_VALUE)
             if dataset[0][0].size > 2:
                 fill_value_mask = np.logical_or(
                     unique_verts[:, 0] == INT_FILL_VALUE,
@@ -273,7 +303,9 @@ class Grid:
                 for i, idx in enumerate(false_indices):
                     indices[indices == idx] = INT_FILL_VALUE_MPZ
                     for j in range(indices.size):
-                        if gmpy2.cmp(mpz(indices[j]), mpz(idx)) > 0 and gmpy2.cmp(mpz(indices[j]), INT_FILL_VALUE_MPZ) != 0:
+                        if gmpy2.cmp(mpz(
+                                indices[j]), mpz(idx)) > 0 and gmpy2.cmp(
+                                    mpz(indices[j]), INT_FILL_VALUE_MPZ) != 0:
                             indices[j] -= 1
 
             else:

--- a/uxarray/grid.py
+++ b/uxarray/grid.py
@@ -2,6 +2,7 @@
 import os
 import xarray as xr
 import numpy as np
+from gmpy2 import mpfr
 
 # reader and writer imports
 from ._exodus import _read_exodus, _encode_exodus
@@ -199,6 +200,7 @@ class Grid:
             z_coord = x_coord * 0.0
 
         # Identify unique vertices and their indices
+        # TODO: Utilize GMPY2 for precise unique vertex identification
         unique_verts, indices = np.unique(dataset.reshape(
             -1, dataset.shape[-1]),
                                           axis=0,

--- a/uxarray/grid.py
+++ b/uxarray/grid.py
@@ -39,7 +39,16 @@ class Grid:
         ----------
         dataset : xarray.Dataset, ndarray, list, tuple, required
             Input xarray.Dataset or vertex coordinates that form one face.
-
+        multi_precision : bool, optional
+            Specify if want to use multi-precision (mpfr) for all grid operations (default: False).
+            Each node coordinates will be stored as the gmpy2.mpfr/mpz(filled value) type
+            instead of the python ``float``/``int`` type.
+            Note: when using multi-precision, all grid operations are done in multi-precision using the GMPY2 library. And
+            the run time will significantly increase. To gain the full benefit of multi-precision, it is recommended to input
+            the grid coordinates in string format (eg. '0.1', '0.2', etc) and use string 'INT_FILL_VALUE'
+            to specify the fill value.
+        precision : int, optional
+            Specify the precision of the grid coordinates (default: FLOAT_PRECISION_BITS (python `float` bit precision)).
         Other Parameters
         ----------------
         islatlon : bool, optional
@@ -95,6 +104,7 @@ class Grid:
         # TODO: re-add gridspec initialization when implemented
         elif isinstance(dataset, xr.Dataset):
             self.mesh_type = parse_grid_type(dataset)
+            #TODO: Support multiprecision for __from_ds__
             self.__from_ds__(dataset=dataset)
         else:
             raise RuntimeError("Dataset is not a valid input type.")

--- a/uxarray/helpers.py
+++ b/uxarray/helpers.py
@@ -1,10 +1,9 @@
 import numpy as np
 import xarray as xr
-import gmpy2
+
 from pathlib import PurePath
 from .get_quadratureDG import get_gauss_quadratureDG, get_tri_quadratureDG
 from numba import njit, config
-from gmpy2 import mpfr
 import math
 
 from uxarray.constants import INT_DTYPE, INT_FILL_VALUE
@@ -676,43 +675,8 @@ def close_face_nodes(Mesh2_face_nodes, nMesh2_face, nMaxMesh2_face_nodes):
 
     return closed
 
-def convert_to_mpfr(input_array, str_mode = True, precision = 53):
-    """
-    Convert a numpy array to a list of mpfr numbers.
-    The default precision of an mpfr is 53 bits - the same precision as Python’s `float` type.
-    https://gmpy2.readthedocs.io/en/latest/mpfr.html
 
-    Parameters
-    ----------
-    input_array : numpy array, float/string
-        The input array to be converted to mpfr
-    str_mode : bool, optional
-        If True, the input array should be string when passing into the function.
-        If False, the input array should be float when passing into the function.
-        str_mode is True by default and is recommended. Because to take advantage of the higher precision provided by
-        the mpfr type, always pass constants as strings.
-    precision : int, optional
-        The precision of the mpfr numbers. The default precision of an mpfr is 53 bits - the same precision as Python’s `float` type.
 
-    Returns
-    ----------
-    mpfr_array : numpy array, mpfr type
-        The output array with mpfr type, which supports correct
-        rounding, selectable rounding modes, and many trigonometric, exponential, and special functions. A context
-        manager is used to control precision, rounding modes, and the behavior of exceptions.
-    """
-    gmpy2.set_context(gmpy2.context())
-    gmpy2.get_context().precision = precision
 
-    # To take advantage of the higher precision provided by the mpfr type, always pass constants as strings.
-    # https://gmpy2.readthedocs.io/en/latest/mpfr.html
-    if not str_mode:
-        # Cast the input 2D array to string array
-        input_array = input_array.astype(str)
-    else:
-        if input_array.dtype != 'str':
-            raise ValueError('The input array should be string when str_mode is True.')
 
-    # Then convert the input array to mpfr array
-    mpfr_array = np.array([gmpy2.mpfr(x) for x in input_array.ravel()]).reshape(input_array.shape)
-    return mpfr_array
+

--- a/uxarray/helpers.py
+++ b/uxarray/helpers.py
@@ -1,7 +1,5 @@
 import numpy as np
 import xarray as xr
-
-from pathlib import PurePath
 from .get_quadratureDG import get_gauss_quadratureDG, get_tri_quadratureDG
 from numba import njit, config
 import math
@@ -674,9 +672,3 @@ def close_face_nodes(Mesh2_face_nodes, nMesh2_face, nMaxMesh2_face_nodes):
     np.put(closed.ravel(), first_fv_idx_1d, first_node_value)
 
     return closed
-
-
-
-
-
-

--- a/uxarray/helpers.py
+++ b/uxarray/helpers.py
@@ -1,8 +1,10 @@
 import numpy as np
 import xarray as xr
+import gmpy2
 from pathlib import PurePath
 from .get_quadratureDG import get_gauss_quadratureDG, get_tri_quadratureDG
 from numba import njit, config
+from gmpy2 import mpfr
 import math
 
 from uxarray.constants import INT_DTYPE, INT_FILL_VALUE
@@ -673,3 +675,44 @@ def close_face_nodes(Mesh2_face_nodes, nMesh2_face, nMaxMesh2_face_nodes):
     np.put(closed.ravel(), first_fv_idx_1d, first_node_value)
 
     return closed
+
+def convert_to_mpfr(input_array, str_mode = True, precision = 53):
+    """
+    Convert a numpy array to a list of mpfr numbers.
+    The default precision of an mpfr is 53 bits - the same precision as Python’s `float` type.
+    https://gmpy2.readthedocs.io/en/latest/mpfr.html
+
+    Parameters
+    ----------
+    input_array : numpy array, float/string
+        The input array to be converted to mpfr
+    str_mode : bool, optional
+        If True, the input array should be string when passing into the function.
+        If False, the input array should be float when passing into the function.
+        str_mode is True by default and is recommended. Because to take advantage of the higher precision provided by
+        the mpfr type, always pass constants as strings.
+    precision : int, optional
+        The precision of the mpfr numbers. The default precision of an mpfr is 53 bits - the same precision as Python’s `float` type.
+
+    Returns
+    ----------
+    mpfr_array : numpy array, mpfr type
+        The output array with mpfr type, which supports correct
+        rounding, selectable rounding modes, and many trigonometric, exponential, and special functions. A context
+        manager is used to control precision, rounding modes, and the behavior of exceptions.
+    """
+    gmpy2.set_context(gmpy2.context())
+    gmpy2.get_context().precision = precision
+
+    # To take advantage of the higher precision provided by the mpfr type, always pass constants as strings.
+    # https://gmpy2.readthedocs.io/en/latest/mpfr.html
+    if not str_mode:
+        # Cast the input 2D array to string array
+        input_array = input_array.astype(str)
+    else:
+        if input_array.dtype != 'str':
+            raise ValueError('The input array should be string when str_mode is True.')
+
+    # Then convert the input array to mpfr array
+    mpfr_array = np.array([gmpy2.mpfr(x) for x in input_array.ravel()]).reshape(input_array.shape)
+    return mpfr_array

--- a/uxarray/multi_precision_helpers.py
+++ b/uxarray/multi_precision_helpers.py
@@ -1,0 +1,99 @@
+import gmpy2
+from gmpy2 import mpfr
+import numpy as np
+from .constants import INT_DTYPE, INT_FILL_VALUE, FLOAT_PRECISION_BITS
+
+
+def convert_to_mpfr(input_array, str_mode=True, precision=FLOAT_PRECISION_BITS):
+    """
+    Convert a numpy array to a list of mpfr numbers.
+    The default precision of an mpfr is 53 bits - the same precision as Python’s `float` type.
+    https://gmpy2.readthedocs.io/en/latest/mpfr.html
+
+    Parameters
+    ----------
+    input_array : numpy array, float/string, shape is arbitrary
+        The input array to be converted to mpfr. The input array should be float or string. If the input array is float,
+        str_mode should be False. If the input array is string, str_mode should be True.
+
+    str_mode : bool, optional
+        If True, the input array should be string when passing into the function.
+        If False, the input array should be float when passing into the function.
+        str_mode is True by default and is recommended. Because to take advantage of the higher precision provided by
+        the mpfr type, always pass constants as strings.
+    precision : int, optional
+        The precision of the mpfr numbers. The default precision of an mpfr is 53 bits - the same precision as Python’s `float` type.
+
+    Returns
+    ----------
+    mpfr_array : numpy array, mpfr type, shape will be same as the input_array
+        The output array with mpfr type, which supports correct
+        rounding, selectable rounding modes, and many trigonometric, exponential, and special functions. A context
+        manager is used to control precision, rounding modes, and the behavior of exceptions.
+    """
+    gmpy2.set_context(gmpy2.context())
+    gmpy2.get_context().precision = precision
+
+    # To take advantage of the higher precision provided by the mpfr type, always pass constants as strings.
+    # https://gmpy2.readthedocs.io/en/latest/mpfr.html
+    if not str_mode:
+        # Cast the input 2D array to string array
+        input_array = input_array.astype(str)
+    else:
+        flattened_array = np.ravel(input_array)
+        if ~np.all([np.issubdtype(type(element), np.str_) for element in flattened_array]):
+            raise ValueError('The input array should be string when str_mode is True.')
+
+    # Then convert the input array to mpfr array
+    mpfr_array = np.array([gmpy2.mpfr(x,precision) for x in input_array.ravel()]).reshape(input_array.shape)
+    return mpfr_array
+
+
+def unique_coordinates_mpfr(input_array_mpfr, precision=FLOAT_PRECISION_BITS):
+    """
+    Find the unique coordinates in the input array with mpfr numbers.
+    The default precision of an mpfr is 53 bits - the same precision as Python’s `float` type.
+
+    Parameters:
+    ----------
+
+
+    """
+
+    # Reset the mpfr precision
+    gmpy2.get_context().precision = precision
+
+    # Check if the input_array is in th mpfr type
+    try:
+        # Flatten the input_array_mpfr to a 1D array so that we can check the type of each element
+        input_array_mpfr_copy = np.ravel(input_array_mpfr)
+        for i in range(len(input_array_mpfr_copy)):
+            if type(input_array_mpfr_copy[i]) != gmpy2.mpfr:
+                raise ValueError('The input array should be in the mpfr type. You can use convert_to_mpfr() to '
+                                 'convert the input array to mpfr.')
+    except Exception as e:
+        raise e
+
+    unique_arr = []
+    inverse_indices = []
+    m, n = input_array_mpfr.shape
+
+    unique_dict = {}
+    current_index = 0
+
+    for i in range(m):
+        format_string = "{0:+."+str(precision+1)+"Uf}"
+        hashable_row = tuple(format_string.format(gmpy2.mpfr(x, precision)) for x in input_array_mpfr[i])
+
+        if hashable_row not in unique_dict:
+            unique_dict[hashable_row] = current_index
+            unique_arr.append(input_array_mpfr[i])
+            inverse_indices.append(current_index)
+            current_index += 1
+        else:
+            inverse_indices.append(unique_dict[hashable_row])
+
+    unique_arr = np.array(unique_arr)
+    inverse_indices = np.array(inverse_indices)
+
+    return unique_arr, inverse_indices

--- a/uxarray/multi_precision_helpers.py
+++ b/uxarray/multi_precision_helpers.py
@@ -69,7 +69,7 @@ def unique_coordinates_mpfr(input_array_mpfr, precision=FLOAT_PRECISION_BITS):
         # Flatten the input_array_mpfr to a 1D array so that we can check the type of each element
         input_array_mpfr_copy = np.ravel(input_array_mpfr)
         for i in range(len(input_array_mpfr_copy)):
-            if type(input_array_mpfr_copy[i]) != gmpy2.mpfr:
+            if type(input_array_mpfr_copy[i]) != gmpy2.mpfr and type(input_array_mpfr_copy[i]) != gmpy2.mpz:
                 raise ValueError('The input array should be in the mpfr type. You can use convert_to_mpfr() to '
                                  'convert the input array to mpfr.')
     except Exception as e:

--- a/uxarray/multi_precision_helpers.py
+++ b/uxarray/multi_precision_helpers.py
@@ -1,6 +1,7 @@
 import gmpy2
-from gmpy2 import mpfr
+from gmpy2 import mpfr, mpz
 import numpy as np
+import math
 from .constants import INT_DTYPE, INT_FILL_VALUE, FLOAT_PRECISION_BITS
 
 
@@ -45,7 +46,7 @@ def convert_to_mpfr(input_array, str_mode=True, precision=FLOAT_PRECISION_BITS):
             raise ValueError('The input array should be string when str_mode is True.')
 
     # Then convert the input array to mpfr array
-    mpfr_array = np.array([gmpy2.mpfr(x,precision) for x in input_array.ravel()]).reshape(input_array.shape)
+    mpfr_array = np.array([gmpy2.mpfr(x, precision) for x in input_array.ravel()]).reshape(input_array.shape)
     return mpfr_array
 
 
@@ -82,7 +83,7 @@ def unique_coordinates_mpfr(input_array_mpfr, precision=FLOAT_PRECISION_BITS):
     current_index = 0
 
     for i in range(m):
-        format_string = "{0:+."+str(precision+1)+"Uf}"
+        format_string = "{0:+." + str(precision + 1) + "Uf}"
         hashable_row = tuple(format_string.format(gmpy2.mpfr(x, precision)) for x in input_array_mpfr[i])
 
         if hashable_row not in unique_dict:
@@ -97,3 +98,46 @@ def unique_coordinates_mpfr(input_array_mpfr, precision=FLOAT_PRECISION_BITS):
     inverse_indices = np.array(inverse_indices)
 
     return unique_arr, inverse_indices
+
+
+def decimal_digits_to_precision_bits(decimal_digits):
+    """
+    Convert the number of decimal digits to the number of bits of precision
+
+    Parameters
+    ----------
+    decimal_digits : int
+        The number of decimal digits of precision
+
+    Returns
+    -------
+    bits : int
+        The number of bits of precision
+    """
+    bits = math.ceil(decimal_digits * math.log2(10))
+    return bits
+
+
+def precision_bits_to_decimal_digits(precision):
+    """
+    Convert the number of bits of precision to the number of decimal digits
+
+    Parameters
+    ----------
+    precision : int
+        The number of bits of precision
+
+    Returns
+    -------
+    decimal_digits : int
+        The number of decimal digits of precision
+    """
+    # Compute the decimal digit count using gmpy2.log10()
+    log10_2 = gmpy2.log10(gmpy2.mpfr(2))  # Logarithm base 10 of 2
+    log10_precision = gmpy2.div(1, log10_2)  # Logarithm base 10 of the precision
+    decimal_digits = gmpy2.div(precision, log10_precision)
+
+    # Convert the result to an integer
+    decimal_digits = int(math.floor(decimal_digits))
+
+    return decimal_digits

--- a/uxarray/multi_precision_helpers.py
+++ b/uxarray/multi_precision_helpers.py
@@ -32,8 +32,6 @@ def convert_to_mpfr(input_array, str_mode=True, precision=FLOAT_PRECISION_BITS):
         rounding, selectable rounding modes, and many trigonometric, exponential, and special functions. A context
         manager is used to control precision, rounding modes, and the behavior of exceptions.
     """
-    gmpy2.set_context(gmpy2.context())
-    gmpy2.get_context().precision = precision
 
     # To take advantage of the higher precision provided by the mpfr type, always pass constants as strings.
     # https://gmpy2.readthedocs.io/en/latest/mpfr.html
@@ -76,9 +74,6 @@ def unique_coordinates_mpfr(input_array_mpfr, precision=FLOAT_PRECISION_BITS):
 
 
     """
-
-    # Reset the mpfr precision
-    gmpy2.get_context().precision = precision
 
     # Check if the input_array is in th mpfr type
     try:


### PR DESCRIPTION
<!--  The PR title should summarize the changes, for example "Add `Grid._build_face_dimension` function".
      Avoid non-descriptive titles such as "Addresses issue #229". -->

<!--  Replace XXX with the number of the issue that this PR will resolve. If this PR closed more than one,
      you may add a comma-separated sequence-->
Finish the 1st step of #318 

## Overview
<!--  Please provide a few bullet points summarizing the changes in this PR. This should include
      points on any bug fixes, new functions, or other changes that have been made. -->
This will convert every user input coordinates to the user-specified precision `gmpy2.mpfr` types. It can recognize two coordinates even though they're extremely closed up to any `gmpy2` supported precision. To achieve the precision higher than python`float` (53 bits), it's highly recommended that users use the string as input. This PR also introduce new constant for multi-precision usage:
1. `INT_FILL_VALUE_MPZ`: The filled value that represented by the `gmpy2.mpz` type, the value will be the same as `INT_FILL_VALUE`
2. `FLOAT_PRECISION_BITS`: 53, the python`float` precision bits




For more information about the multi-precision and exact computation paradigm, please refers to the following materials
[GMPY2](https://gmpy2.readthedocs.io/en/latest/index.html)
[The Exact Computation Paradigm](https://www.cgal.org/exact.html)

## Expected Usage
<!--  If you are adding a feature into the Internal API, please produce a short example of it in action.
      You may ignore this step if it is not applicable (comment out this section). -->
```Python
import uxarray as ux

# Provide nodes that are extremely closed to each other
face_nodes_connectivity = [['1.000000000000000000', '1.000000000000000000001', '1.0000000000000000000012'],
 ['1.000000000000000001', '1.000000000000000000002', '1.0000000000000000000013']]

uxgrid =   ux.Grid(face_nodes_connectivity, multi_precision=True, precision= 65,
                        vertices=True,
                        islatlon=False,
                        concave=False)
print(uxgrid.nMesh2_face )# It will still detect two faces without degenration
>>> 2

# Perform any provided grid manipulation and then the results is precise up the the 65 bits
```
## Proposed Progress

**Data Read in**
- [x] Support multi-precision when initializing through `Grid.__from_vert__()`
- [ ] Support multi-precision when initializing through `Grid.__from_ds__()`

**Grid Pre-processing**
- [ ] Precise spherical and cartesian coordinates conversion
- [ ] Build exact Latitude Longitude bound

**Grid Operation**
- [ ] Exact intersection between two great circle arcs (GCR)
- [ ] Exact intersection between a GCR and a constant latitude
- [ ] Exact Non-conservative Zonal Average

**Grid Construction**
- [ ] Exact conservative zonal regrinding.

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->

**General**
- [x] An issue is linked created and linked
- [x] Add appropriate labels
- [x] Filled out Overview and Expected Usage (if applicable) sections

**Testing**
- [ ] Adequate tests are created if there is new functionality
- [ ] Tests cover all possible logical paths in your function
- [ ] Tests are not too basic (such as simply calling a function and nothing else)

**Documentation**
- [ ] Docstrings have been added to all new functions
- [ ] Docstrings have updated with any function changes
- [ ] Internal functions have a preceding underscore (`_`) and have been added to `docs/internal_api/index.rst`
- [ ] User functions have been added to `docs/user_api/index.rst`

**Examples**
- [ ] Any new notebook examples added to `docs/examples/` folder
- [ ] Clear the output of all cells before committing
- [ ] New notebook files added to `docs/examples.rst` toctree
- [ ] New notebook files added to new entry in `docs/gallery.yml` with appropriate thumbnail photo in `docs/_static/thumbnails/`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

**PR Etiquette Reminders**
- This PR should be listed as a draft PR until you are ready to request reviewers

- After making changes in accordance with the reviews, re-request your reviewers

- Do *not* mark conversations as resolved if you didn't start them

- Do mark conversations as resolved *if you opened them* and are satisfied with the changes/discussion.
-->
