### PR TITLE
Fix Failing CI 

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - numpy
   - pathlib
   - pre_commit
+  - pyarrow<13.0.0
   - pytest
   - pytest-cov
   - scipy

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - numpy
   - pathlib
   - pre_commit
-  - pyarrow<13.0.0
+  - pyarrow<13.0.0   # pin due to CI faliures on macOS & ubuntu
   - pytest
   - pytest-cov
   - scipy

--- a/ci/upstream-dev-environment.yml
+++ b/ci/upstream-dev-environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - numba
   - numpy
   - pathlib
+  - pyarrow<13.0.0   # pin due to CI faliures on macOS & ubuntu
   - pytest
   - pytest-cov
   - scipy


### PR DESCRIPTION
Closes #417 

CI & Upstream-dev CI began failing on macOS & ubuntu on 8/24 after a version bump to `pyarrow`. Pinning the version fixes it. 

[Successful CI Run](https://github.com/UXARRAY/uxarray/actions/runs/5995512115)

[Successful Upstream Run](https://github.com/UXARRAY/uxarray/actions/runs/5995694584)
