### PR TITLE
Contributions to PR #406

### DIFF
--- a/docs/user_api/index.rst
+++ b/docs/user_api/index.rst
@@ -118,6 +118,7 @@ Methods
    Grid.calculate_total_face_area
    Grid.compute_face_areas
    Grid.encode_as
+   Grid.get_ball_tree
    Grid.integrate
    Grid.copy
 
@@ -151,7 +152,7 @@ Nearest Neighbors
 =================
 
 BallTree Data Structure
-------------------------
+-----------------------
 .. autosummary::
    :toctree: _autosummary
 

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -871,19 +871,18 @@ class TestBallTree(TestCase):
     corner_grid_files = [gridfile_CSne30, gridfile_mpas]
     center_grid_files = [gridfile_mpas]
 
-    def test_construction_from_corner_nodes(self):
-        """Tests the construction of the ball tree on corner nodes and performs
-        a sample query."""
+    def test_construction_from_nodes(self):
+        """Tests the construction of the ball tree on nodes and performs a
+        sample query."""
 
         for grid_file in self.corner_grid_files:
             uxgrid = ux.open_grid(grid_file)
 
             # performs a sample query
-            d, ind = uxgrid.ball_tree.query([3.0, 3.0],
-                                            k=3,
-                                            tree_type="corner nodes")
+            d, ind = uxgrid.get_ball_tree(tree_type="nodes").query([3.0, 3.0],
+                                                                   k=3)
 
-    def test_construction_from_center_nodes(self):
+    def test_construction_from_face_centers(self):
         """Tests the construction of the ball tree on center nodes and performs
         a sample query."""
 
@@ -891,11 +890,10 @@ class TestBallTree(TestCase):
             uxgrid = ux.open_grid(grid_file)
 
             # performs a sample query
-            d, ind = uxgrid.ball_tree.query([3.0, 3.0],
-                                            k=3,
-                                            tree_type="face centers")
+            d, ind = uxgrid.get_ball_tree(tree_type="face centers").query(
+                [3.0, 3.0], k=3)
 
-    def test_antimeridian_distance_corner_nodes(self):
+    def test_antimeridian_distance_nodes(self):
         """Verifies nearest neighbor search across Antimeridian."""
 
         # single triangle with point on antimeridian
@@ -904,9 +902,8 @@ class TestBallTree(TestCase):
         uxgrid = ux.open_grid(verts)
 
         # point on antimeridian, other side of grid
-        d, ind = uxgrid.ball_tree.query([180.0, 0.0],
-                                        k=1,
-                                        tree_type="corner nodes")
+        d, ind = uxgrid.get_ball_tree(tree_type="nodes").query([180.0, 0.0],
+                                                               k=1)
 
         # distance across antimeridian is approx zero
         assert np.isclose(d, 0.0)
@@ -915,14 +912,13 @@ class TestBallTree(TestCase):
         assert ind == 0
 
         # point on antimeridian, other side of grid, slightly larger than 90 due to floating point calcs
-        d, ind = uxgrid.ball_tree.query_radius([-180, 0.0],
-                                               r=90.01,
-                                               tree_type="corner nodes")
+        d, ind = uxgrid.get_ball_tree(tree_type="nodes").query_radius(
+            [-180, 0.0], r=90.01)
 
         expected_d = np.array([0.0, 90.0, 90.0])
 
         assert np.allclose(a=d, b=expected_d, atol=1e-03)
 
-    def test_antimeridian_distance_corner_nodes(self):
+    def test_antimeridian_distance_face_centers(self):
         """TODO: Write addition tests once construction and representation of face centers is implemented."""
         pass

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -893,6 +893,19 @@ class TestBallTree(TestCase):
             d, ind = uxgrid.get_ball_tree(tree_type="face centers").query(
                 [3.0, 3.0], k=3)
 
+    def test_construction_from_both_sequentially(self):
+        """Tests the construction of the ball tree on center nodes and performs
+        a sample query."""
+
+        for grid_file in self.center_grid_files:
+            uxgrid = ux.open_grid(grid_file)
+
+            # performs a sample query
+            d, ind = uxgrid.get_ball_tree(tree_type="nodes").query([3.0, 3.0],
+                                                                   k=3)
+            d_centers, ind_centers = uxgrid.get_ball_tree(
+                tree_type="face centers").query([3.0, 3.0], k=3)
+
     def test_antimeridian_distance_nodes(self):
         """Verifies nearest neighbor search across Antimeridian."""
 

--- a/uxarray/grid/grid.py
+++ b/uxarray/grid/grid.py
@@ -617,14 +617,19 @@ class Grid:
             self.compute_face_areas()
         return self._face_areas
 
-    @property
-    def ball_tree(self):
-        """BallTree data structure which allows for nearest neighbor queries (k
-        nearest or within some radius) on either the corner nodes
+    def get_ball_tree(self, tree_type: Optional[str] = "nodes"):
+        """Get the BallTree data structure of this Grid that allows for nearest
+        neighbor queries (k nearest or within some radius) on either the nodes
         (``Mesh2_node_x``, ``Mesh2_node_y``) or face centers (``Mesh2_face_x``,
         ``Mesh2_face_y``)."""
         if self._ball_tree is None:
-            self._ball_tree = BallTree(self, distance_metric='haversine')
+            self._ball_tree = BallTree(self,
+                                       tree_type=tree_type,
+                                       distance_metric='haversine')
+        else:
+            if tree_type != self._ball_tree.tree_type:
+                self._ball_tree.tree_type = tree_type
+
         return self._ball_tree
 
     def copy(self):

--- a/uxarray/grid/grid.py
+++ b/uxarray/grid/grid.py
@@ -627,7 +627,7 @@ class Grid:
                                        tree_type=tree_type,
                                        distance_metric='haversine')
         else:
-            if tree_type != self._ball_tree.tree_type:
+            if tree_type != self._ball_tree._tree_type:
                 self._ball_tree.tree_type = tree_type
 
         return self._ball_tree

--- a/uxarray/grid/neighbors.py
+++ b/uxarray/grid/neighbors.py
@@ -28,7 +28,7 @@ class BallTree:
         # maintain a reference to the source grid
         self._source_grid = grid
         self.distance_metric = distance_metric
-        self.tree_type = tree_type
+        self._tree_type = tree_type
 
         self._tree_from_nodes = None
         self._tree_from_face_centers = None
@@ -75,9 +75,9 @@ class BallTree:
 
         _tree = None
 
-        if self.tree_type == "nodes":
+        if self._tree_type == "nodes":
             _tree = self._tree_from_nodes
-        elif self.tree_type == "face centers":
+        elif self._tree_type == "face centers":
             _tree = self._tree_from_face_centers
         else:
             raise TypeError
@@ -209,6 +209,26 @@ class BallTree:
                 return d, ind
 
             return ind
+
+    @property
+    def tree_type(self):
+        return self._tree_type
+
+    @tree_type.setter
+    def tree_type(self, value):
+        self._tree_type = value
+
+        # set up appropriate reference to tree
+        if self._tree_type == "nodes":
+            if self._tree_from_nodes is None:
+                self._tree_from_nodes = self._build_from_nodes()
+            self._n_elements = self._source_grid.nMesh2_node
+        elif self._tree_type == "face centers":
+            if self._tree_from_face_centers is None:
+                self._tree_from_face_centers = self._build_from_face_centers()
+            self._n_elements = self._source_grid.nMesh2_face
+        else:
+            raise ValueError
 
 
 def _prepare_xy_for_query(xy, use_radians):

--- a/uxarray/grid/neighbors.py
+++ b/uxarray/grid/neighbors.py
@@ -20,57 +20,79 @@ class BallTree:
     for further information about the wrapped data structures.
     """
 
-    def __init__(self, grid, distance_metric='haversine'):
+    def __init__(self,
+                 grid,
+                 tree_type: Optional[str] = "nodes",
+                 distance_metric='haversine'):
 
         # maintain a reference to the source grid
         self._source_grid = grid
-
-        self._corner_node_ball_tree = None
-        self._face_center_ball_tree = None
-
-        self.n_node = grid.nMesh2_node
-        self.n_face = grid.nMesh2_face
-
         self.distance_metric = distance_metric
+        self.tree_type = tree_type
 
-    @property
-    def corner_node_ball_tree(self):
-        """Internal``sklearn.neighbors.BallTree`` constructed from corner
-        nodes."""
-        if self._corner_node_ball_tree is None:
-            latlon = np.vstack(
-                (deg2rad(self._source_grid.Mesh2_node_y.values),
-                 deg2rad(self._source_grid.Mesh2_node_x.values))).T
-            self._corner_node_ball_tree = SKBallTree(
-                latlon, metric=self.distance_metric)
-        return self._corner_node_ball_tree
+        self._tree_from_nodes = None
+        self._tree_from_face_centers = None
 
-    @property
-    def face_center_ball_tree(self):
+        # set up appropriate reference to tree
+        if tree_type == "nodes":
+            self._tree_from_nodes = self._build_from_nodes()
+            self._n_elements = self._source_grid.nMesh2_node
+        elif tree_type == "face centers":
+            self._tree_from_face_centers = self._build_from_face_centers()
+            self._n_elements = self._source_grid.nMesh2_face
+        else:
+            raise ValueError
+
+    def _build_from_face_centers(self):
         """Internal``sklearn.neighbors.BallTree`` constructed from face
         centers."""
-        if self._face_center_ball_tree is None:
+        if self._tree_from_face_centers is None:
             if self._source_grid.Mesh2_face_x is None:
                 raise ValueError
+
             latlon = np.vstack(
                 (deg2rad(self._source_grid.Mesh2_face_y.values),
                  deg2rad(self._source_grid.Mesh2_face_x.values))).T
 
-            self._face_center_ball_tree = SKBallTree(
+            self._tree_from_face_centers = SKBallTree(
                 latlon, metric=self.distance_metric)
-        return self._face_center_ball_tree
+
+        return self._tree_from_face_centers
+
+    def _build_from_nodes(self):
+        """Internal``sklearn.neighbors.BallTree`` constructed from corner
+        nodes."""
+        if self._tree_from_nodes is None:
+            latlon = np.vstack(
+                (deg2rad(self._source_grid.Mesh2_node_y.values),
+                 deg2rad(self._source_grid.Mesh2_node_x.values))).T
+            self._tree_from_nodes = SKBallTree(latlon,
+                                               metric=self.distance_metric)
+
+        return self._tree_from_nodes
+
+    def _current_tree(self):
+
+        _tree = None
+
+        if self.tree_type == "nodes":
+            _tree = self._tree_from_nodes
+        elif self.tree_type == "face centers":
+            _tree = self._tree_from_face_centers
+        else:
+            raise TypeError
+
+        return _tree
 
     def query(self,
               xy: Union[np.ndarray, list, tuple],
               k: Optional[int] = 1,
-              tree_type: Optional[str] = "corner nodes",
-              use_radians: Optional[bool] = False,
+              xy_in_radians: Optional[bool] = False,
               return_distance: Optional[bool] = True,
               dualtree: Optional[bool] = False,
               breadth_first: Optional[bool] = False,
               sort_results: Optional[bool] = True):
-        """Queries the tree defined by ``tree_type`` ("corner nodes" or "face
-        centers") for the ``k`` nearest neighbors.
+        """Queries the tree for the ``k`` nearest neighbors.
 
         Parameters
         ----------
@@ -78,9 +100,7 @@ class BallTree:
             coordinate pairs in degrees (lon, lat) to query
         k: int, default=1
             The number of nearest neighbors to return
-        tree_type: str, default="corner nodes"
-            Specifies which tree to use, "corner nodes" or "face centers"
-        use_radians : bool, optional
+        xy_in_radians : bool, optional
             if True, queries assuming xy are inputted in radians, not degrees
         return_distance : bool, optional
             Indicates whether distances should be returned
@@ -99,61 +119,42 @@ class BallTree:
             Index array that keeps the indices of the k-nearest neighbors to the entries from xy in each row
         """
 
-        # set up appropriate reference to tree
-        if tree_type == "corner nodes":
-            _tree = self.corner_node_ball_tree
-            _n_elements = self.n_node
-        elif tree_type == "face centers":
-            _tree = self.face_center_ball_tree
-            _n_elements = self.n_face
-        else:
-            raise ValueError
-
-        if k < 1 or k > _n_elements:
+        if k < 1 or k > self._n_elements:
             raise AssertionError(
                 f"The value of k must be greater than 1 and less than the number of elements used to construct "
-                f"the tree ({_n_elements}).")
+                f"the tree ({self._n_elements}).")
 
-        xy = _prepare_xy_for_query(xy, use_radians)
+        xy = _prepare_xy_for_query(xy, xy_in_radians)
+
+        d, ind = self._current_tree().query(xy, k, return_distance, dualtree,
+                                            breadth_first, sort_results)
+
+        ind = np.asarray(ind, dtype=INT_DTYPE)
+
+        if xy.shape[0] == 1:
+            ind = ind.squeeze()
 
         # perform query with distance
         if return_distance:
-            d, ind = _tree.query(xy, k, return_distance, dualtree,
-                                 breadth_first, sort_results)
-
-            ind = np.asarray(ind, dtype=INT_DTYPE)
-
             # only one pair was queried
             if xy.shape[0] == 1:
-                ind = ind.squeeze()
                 d = d.squeeze()
 
-            d = np.rad2deg(d)
+            if not xy_in_radians:
+                d = np.rad2deg(d)
 
             return d, ind
 
-        # perform query without distance
-        else:
-            ind = _tree.query(xy, k, return_distance, dualtree, breadth_first,
-                              sort_results)
-
-            ind = np.asarray(ind, dtype=INT_DTYPE)
-
-            if xy.shape[0] == 1:
-                ind = ind.squeeze()
-
-            return ind
+        return ind
 
     def query_radius(self,
                      xy: Union[np.ndarray, list, tuple],
                      r: Optional[int] = 1.0,
-                     tree_type: Optional[str] = "corner nodes",
-                     use_radians: Optional[bool] = False,
+                     xy_in_radians: Optional[bool] = False,
                      return_distance: Optional[bool] = True,
                      count_only: Optional[bool] = False,
                      sort_results: Optional[bool] = False):
-        """Queries the tree defined by ``tree_type`` ("corner nodes" or "face
-        centers") for all neighbors within a radius ``r``.
+        """Queries the tree for all neighbors within a radius ``r``.
 
         Parameters
         ----------
@@ -161,9 +162,7 @@ class BallTree:
            coordinate pairs in degrees (lon, lat) to query
         r: distance in degrees within which neighbors are returned
             r can be a single value , or an array of values of shape x.shape[:-1] if different radii are desired for each point.
-        tree_type: str, default="corner nodes"
-            Specifies which tree to use, "corner nodes" or "face centers"
-        use_radians : bool, default=True
+        xy_in_radians : bool, default=True
             if True, queries assuming xy are inputted in radians, not degrees
         return_distance : bool, default=False
             Indicates whether distances should be returned
@@ -180,50 +179,36 @@ class BallTree:
             Index array that keeps the indices of all neighbors within some radius to the entries from xy in each row
         """
 
-        # set up appropriate reference to tree
-        if tree_type == "corner nodes":
-            _tree = self._corner_node_ball_tree
-        elif tree_type == "face centers":
-            _n_elements = self.n_face
-        else:
-            raise ValueError
-
         if r < 0.0:
             raise AssertionError(
                 f"The value of r must be greater than or equal to zero.")
 
         r = np.deg2rad(r)
-        xy = _prepare_xy_for_query(xy, use_radians)
+        xy = _prepare_xy_for_query(xy, xy_in_radians)
 
         if count_only:
-            count = _tree.query_radius(xy, r, return_distance, count_only,
-                                       sort_results)
+            count = self._current_tree().query_radius(xy, r, return_distance,
+                                                      count_only, sort_results)
 
             return count
 
-        if not count_only and not return_distance:
-            ind = self.tree.query_radius(xy, r, return_distance, count_only,
-                                         sort_results)
-
-            ind = np.asarray(ind, dtype=INT_DTYPE)
-
-            if xy.shape[0] == 1:
-                ind = ind.squeeze()
-
-            return ind
-
         else:
-            ind, d = _tree.query_radius(xy, r, return_distance, count_only,
-                                        sort_results)
+
+            ind, d = self._current_tree().query_radius(xy, r, return_distance,
+                                                       count_only, sort_results)
 
             ind = np.asarray(ind[0], dtype=INT_DTYPE)
 
             if xy.shape[0] == 1:
                 ind = ind.squeeze()
 
-            d = np.rad2deg(d[0])
+            if return_distance:
+                if not xy_in_radians:
+                    d = np.rad2deg(d[0])
 
-            return d, ind
+                return d, ind
+
+            return ind
 
 
 def _prepare_xy_for_query(xy, use_radians):


### PR DESCRIPTION
Contributes to  PR #406 

## Overview

To address the thoughts [here](https://github.com/UXARRAY/uxarray/pull/406#pullrequestreview-1603614912):

1. Defines `Grid.get_ball_tree(tree_type:Optional)` instead of `ball_tree` that was decorated as a Grid property.
    - This allows to move `tree_type` determination from `query` methods to the first step: `BallTree` instantiation.
    - Relatedly, redesign the `BallTree.__init__()` to actually instantiate the `sklearn.BallTree` using the preferred tree type.
2. Introduces internal `BallTree._current_tree()` to always access or generate the tree type of interest using `BallTree.tree_type`.
3. Refactor the `query` methods' flows (it was cluttered and had some redundant code due to if-else branching for `return_distance` and `count_only` args)
4. Makes some simple refactors to consistently use the terms "face centers" and "nodes" everywhere relevant.

## Expected Usage

```Python
import uxarray as ux

grid_path = "/path/to/grid.nc"

uxgrid = ux.open_grid(grid_path)

# find the nearest corner node neighbor to (180.0, 0.0)
d, ind = uxgrid.get_ball_tree(tree_type="corner nodes").query([180.0, 0.0], k=1)

# find the nearest center node neighbor to (180.0, 0.0)
d, ind = uxgrid.get_ball_tree(tree_type="face centers").query([180.0, 0.0], k=1)

# find all corner nodes within a radius of 90.01 of (-180, 0.0)
d, ind = uxgrid.get_ball_tree(tree_type="corner nodes").query_radius([-180, 0.0], r=90.01)

# find all center nodes within a radius of 90.01 of (-180, 0.0)
d, ind = uxgrid.ball_tree(tree_type="face centers").query_radius([-180, 0.0], r=90.01)
```

## PR Checklist

**General**
- [x] Filled out Overview and Expected Usage (if applicable) sections

**Testing**
- [x] Adequate tests are created if there is new functionality
- [ ] Tests cover all possible logical paths in your function
- [ ] Tests are not too basic (such as simply calling a function and nothing else)

**Documentation**
- [x] Docstrings have been added to all new functions
- [x] Docstrings have updated with any function changes
- [x] Internal functions have a preceding underscore (`_`) and have been added to `docs/internal_api/index.rst`
- [x] User functions have been added to `docs/user_api/index.rst`

