### PR TITLE
Implement `UxDataArray.integrate()` and begin to deprecate current `UxDataset.integrate()` 

### DIFF
--- a/docs/user_api/index.rst
+++ b/docs/user_api/index.rst
@@ -81,6 +81,13 @@ Attributes
    :toctree: _autosummary
    UxDataArray.uxgrid
 
+Methods
+-------
+.. autosummary::
+   :toctree: _autosummary
+
+   UxDataArray.integrate
+
 
 
 Grid

--- a/test/test_integrate.py
+++ b/test/test_integrate.py
@@ -14,7 +14,6 @@ class TestIntegrate(TestCase):
     gridfile_ne30 = current_path / "meshfiles" / "ugrid" / "outCSne30" / "outCSne30.ug"
     dsfile_var2_ne30 = current_path / "meshfiles" / "ugrid" / "outCSne30" / "outCSne30_var2.nc"
 
-
     def test_single_dim(self):
         uxgrid = ux.open_grid(self.gridfile_ne30)
 
@@ -22,12 +21,14 @@ class TestIntegrate(TestCase):
 
         dims = {"nMesh2_face": uxgrid.nMesh2_face}
 
-        uxda = ux.UxDataArray(data=test_data, dims=dims, uxgrid=uxgrid, name='var2')
+        uxda = ux.UxDataArray(data=test_data,
+                              dims=dims,
+                              uxgrid=uxgrid,
+                              name='var2')
 
         integral = uxda.integrate()
 
         pass
-
 
     def test_multi_dim(self):
         uxgrid = ux.open_grid(self.gridfile_ne30)
@@ -36,7 +37,10 @@ class TestIntegrate(TestCase):
 
         dims = {"a": 5, "b": 5, "nMesh2_face": uxgrid.nMesh2_face}
 
-        uxda = ux.UxDataArray(data=test_data, dims=dims, uxgrid=uxgrid, name='var2')
+        uxda = ux.UxDataArray(data=test_data,
+                              dims=dims,
+                              uxgrid=uxgrid,
+                              name='var2')
 
         integral = uxda.integrate()
         pass

--- a/test/test_integrate.py
+++ b/test/test_integrate.py
@@ -1,0 +1,42 @@
+import uxarray as ux
+import os
+from unittest import TestCase
+from pathlib import Path
+import xarray as xr
+import numpy as np
+
+import uxarray as ux
+
+current_path = Path(os.path.dirname(os.path.realpath(__file__)))
+
+
+class TestIntegrate(TestCase):
+    gridfile_ne30 = current_path / "meshfiles" / "ugrid" / "outCSne30" / "outCSne30.ug"
+    dsfile_var2_ne30 = current_path / "meshfiles" / "ugrid" / "outCSne30" / "outCSne30_var2.nc"
+
+
+    def test_single_dim(self):
+        uxgrid = ux.open_grid(self.gridfile_ne30)
+
+        test_data = np.ones(uxgrid.nMesh2_face)
+
+        dims = {"nMesh2_face": uxgrid.nMesh2_face}
+
+        uxda = ux.UxDataArray(data=test_data, dims=dims, uxgrid=uxgrid, name='var2')
+
+        integral = uxda.integrate()
+
+        pass
+
+
+    def test_multi_dim(self):
+        uxgrid = ux.open_grid(self.gridfile_ne30)
+
+        test_data = np.ones((5, 5, uxgrid.nMesh2_face))
+
+        dims = {"a": 5, "b": 5, "nMesh2_face": uxgrid.nMesh2_face}
+
+        uxda = ux.UxDataArray(data=test_data, dims=dims, uxgrid=uxgrid, name='var2')
+
+        integral = uxda.integrate()
+        pass

--- a/test/test_integrate.py
+++ b/test/test_integrate.py
@@ -15,6 +15,7 @@ class TestIntegrate(TestCase):
     dsfile_var2_ne30 = current_path / "meshfiles" / "ugrid" / "outCSne30" / "outCSne30_var2.nc"
 
     def test_single_dim(self):
+        """Integral with 1D data mapped to each face."""
         uxgrid = ux.open_grid(self.gridfile_ne30)
 
         test_data = np.ones(uxgrid.nMesh2_face)
@@ -28,9 +29,13 @@ class TestIntegrate(TestCase):
 
         integral = uxda.integrate()
 
+        # integration reduces the dimension by 1
+        assert integral.ndim == len(dims) - 1
+
         pass
 
     def test_multi_dim(self):
+        """Integral with 3D data mapped to each face."""
         uxgrid = ux.open_grid(self.gridfile_ne30)
 
         test_data = np.ones((5, 5, uxgrid.nMesh2_face))
@@ -43,4 +48,8 @@ class TestIntegrate(TestCase):
                               name='var2')
 
         integral = uxda.integrate()
+
+        # integration reduces the dimension by 1
+        assert integral.ndim == len(dims) - 1
+
         pass

--- a/test/test_integrate.py
+++ b/test/test_integrate.py
@@ -2,8 +2,9 @@ import uxarray as ux
 import os
 from unittest import TestCase
 from pathlib import Path
-import xarray as xr
 import numpy as np
+
+import numpy.testing as nt
 
 import uxarray as ux
 
@@ -32,7 +33,7 @@ class TestIntegrate(TestCase):
         # integration reduces the dimension by 1
         assert integral.ndim == len(dims) - 1
 
-        pass
+        nt.assert_almost_equal(integral, 4 * np.pi)
 
     def test_multi_dim(self):
         """Integral with 3D data mapped to each face."""
@@ -52,4 +53,4 @@ class TestIntegrate(TestCase):
         # integration reduces the dimension by 1
         assert integral.ndim == len(dims) - 1
 
-        pass
+        nt.assert_almost_equal(integral, np.ones((5, 5)) * 4 * np.pi)

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import xarray as xr
 import numpy as np
 
@@ -207,8 +209,11 @@ class UxDataArray(xr.DataArray):
                 f"Data Variable with size {self.data.size} does not match the number of faces "
                 f"({self.uxgrid.nMesh2_face}.")
 
-    def integrate(self, quadrature_rule="triangular", order=4):
-        """TODO: Docstring
+    def integrate(self,
+                  quadrature_rule: Optional[str] = "triangular",
+                  order: Optional[int] = 4) -> UxDataArray:
+        """Computes the integral of a data variable residing on an unstructured
+        grid.
 
         Parameters
         ----------
@@ -219,17 +224,16 @@ class UxDataArray(xr.DataArray):
 
         Returns
         -------
-        Calculated integral : float
+        uxda : UxDataArray
+            UxDataArray containing the integrated data variable
 
         Examples
         --------
-        Open a Uxarray dataset
-
         >>> import uxarray as ux
         >>> uxds = ux.open_dataset("grid.ug", "centroid_pressure_data_ug")
 
         # Compute the integral
-        >>> integral = uxds.integrate()
+        >>> integral = uxds['psi'].integrate()
         """
         if self.data.shape[-1] == self.uxgrid.nMesh2_face:
             face_areas = self.uxgrid.compute_face_areas(quadrature_rule, order)

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -231,11 +231,7 @@ class UxDataArray(xr.DataArray):
         # Compute the integral
         >>> integral = uxds.integrate()
         """
-        # call function to get area of all the faces as a np array
-        face_areas = self.uxgrid.compute_face_areas(quadrature_rule, order)
-
         if self.data.shape[-1] == self.uxgrid.nMesh2_face:
-
             face_areas = self.uxgrid.compute_face_areas(quadrature_rule, order)
 
             # perform dot product between face areas and last dimension of data
@@ -256,6 +252,7 @@ class UxDataArray(xr.DataArray):
                 f"{self.uxgrid.nMesh2_face}, {self.uxgrid.nMesh2_edge}, or {self.uxgrid.nMesh2_face}, "
                 f"but received {self.data.shape[-1]}")
 
+        # construct a uxda with integrated quantity
         uxda = UxDataArray(integral,
                            uxgrid=self.uxgrid,
                            dims=self.dims[:-1],

--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -282,8 +282,9 @@ class UxDataset(xr.Dataset):
 
         # TODO: Deprecation Warning
         warn(
-            "Integration of a single data variable will be deprecated in a future release. For integrating"
-            "a single variable, use the UxDataArray.integrate() method.",
+            "This method currently only works when there is a single DataArray in this Dataset. For integration of a "
+            "single data variable, use the UxDataArray.integrate() method instead. This function will be deprecated and "
+            "replaced with one that can perform a Dataset-wide integration in a future release.",
             DeprecationWarning)
 
         integral = 0.0

--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -277,6 +277,8 @@ class UxDataset(xr.Dataset):
         # Compute the integral
         >>> integral = uxds.integrate()
         """
+
+        # TODO: Deprecation Warning
         integral = 0.0
 
         # call function to get area of all the faces as a np array

--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -8,6 +8,8 @@ from typing import Optional, IO
 from uxarray.core.dataarray import UxDataArray
 from uxarray.grid import Grid
 
+from warnings import warn
+
 
 class UxDataset(xr.Dataset):
     """A ``xarray.Dataset``-like, multi-dimensional, in memory, array database.
@@ -279,6 +281,11 @@ class UxDataset(xr.Dataset):
         """
 
         # TODO: Deprecation Warning
+        warn(
+            "Integration of a single data variable will be deprecated in a future release. For integrating"
+            "a single variable, use the UxDataArray.integrate() method.",
+            DeprecationWarning)
+
         integral = 0.0
 
         # call function to get area of all the faces as a np array

--- a/uxarray/grid/grid.py
+++ b/uxarray/grid/grid.py
@@ -651,52 +651,6 @@ class Grid:
 
         return self._face_areas
 
-    # TODO: Make a decision on whether to provide Dataset- or DataArray-specific
-    # functions from within Grid
-    # def integrate(self, var_ds, quadrature_rule="triangular", order=4):
-    #     """Integrates a xarray.Dataset over all the faces of the given mesh.
-    #
-    #     Parameters
-    #     ----------
-    #     var_ds : Xarray dataset, required
-    #         Xarray dataset containing values to integrate on this grid
-    #     quadrature_rule : str, optional
-    #         Quadrature rule to use. Defaults to "triangular".
-    #     order : int, optional
-    #         Order of quadrature rule. Defaults to 4.
-    #
-    #     Returns
-    #     -------
-    #     Calculated integral : float
-    #
-    #     Examples
-    #     --------
-    #     Open grid file only
-    #
-    #     >>> xr_grid = xr.open_dataset("grid.ug")
-    #     >>> grid = ux.Grid.(xr_grid)
-    #     >>> var_ds = xr.open_dataset("centroid_pressure_data_ug")
-    #
-    #     # Compute the integral
-    #     >>> integral_psi = grid.integrate(var_ds)
-    #     """
-    #     integral = 0.0
-    #
-    #     # call function to get area of all the faces as a np array
-    #     face_areas = self.compute_face_areas(quadrature_rule, order)
-    #
-    #     var_key = list(var_ds.keys())
-    #     if len(var_key) > 1:
-    #         # warning: print message
-    #         print(
-    #             "WARNING: The xarray dataset file has more than one variable, using the first variable for integration"
-    #         )
-    #     var_key = var_key[0]
-    #     face_vals = var_ds[var_key].to_numpy()
-    #     integral = np.dot(face_areas, face_vals)
-    #
-    #     return integral
-
     def to_geodataframe(self,
                         override: Optional[bool] = False,
                         cache: Optional[bool] = True,


### PR DESCRIPTION
<!--  The PR title should summarize the changes, for example "Add `Grid._build_face_dimension` function".
      Avoid non-descriptive titles such as "Addresses issue #229". -->

<!--  Replace XXX with the number of the issue that this PR will resolve. If this PR closed more than one,
      you may add a comma separated sequence-->
Closes #460

## Overview
<!--  Please provide a few bullet points summarizing the changes in this PR. This should include
      points on any bug fixes, new functions, or other changes that have been made. -->
* Introduces `UxDataArray.integrate()` method and begins to deprecate the existing `UxDataset.integrate()` method
* Adds checks for data mapped to geometries other than faces
* Allows for integrals with multiple non-grid dimensions to be computed (i.e. time, layers, etc)

## Expected Usage
<!--  If you are adding a feature into the Internal API, please produce a short example of it in action.
      You may ignore this step if it is not applicable (comment out this section). -->
```Python
import uxarray as ux

grid_path = "/path/to/grid.nc"
data_path = "/path/to/data.nc"

uxds = ux.open_dataset(grid_path, data_path)

# integrate a data variable
integral = uxds['v1'].integrate()

```

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->

**General**
- [x] An issue is linked created and linked
- [x] Add appropriate labels
- [x] Filled out Overview and Expected Usage (if applicable) sections

**Testing**
- [x] Adequate tests are created if there is new functionality
- [x] Tests cover all possible logical paths in your function
- [x] Tests are not too basic (such as simply calling a function and nothing else)

**Documentation**
- [x] Docstrings have been added to all new functions
- [x] Docstrings have updated with any function changes
- [x] Internal functions have a preceding underscore (`_`) and have been added to `docs/internal_api/index.rst`
- [x] User functions have been added to `docs/user_api/index.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

**PR Etiquette Reminders**
- This PR should be listed as a draft PR until you are ready to request reviewers

- After making changes in accordance with the reviews, re-request your reviewers

- Do *not* mark conversations as resolved if you didn't start them

- Do mark conversations as resolved *if you opened them* and are satisfied with the changes/discussion.
-->
