### PR TITLE
Allow more general inputs in `ux.open_grid` 

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - pyarrow<13.0.0   # pin due to CI faliures on macOS & ubuntu
   - pytest
   - pytest-cov
+  - requests
   - scikit-learn
   - scipy
   - shapely

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -66,3 +66,14 @@ class TestUxDataset(TestCase):
 
         for dim in ugrid_dims:
             assert dim in uxds_remap.dims
+
+    def test_read_from_https(self):
+        """Tests reading a dataset from a HTTPS link."""
+        import requests
+
+        small_file_480km = requests.get(
+            "https://web.lcrc.anl.gov/public/e3sm/inputdata/share/meshes/mpas/ocean/oQU480.230422.nc"
+        ).content
+
+        ds_small_480km = ux.open_dataset(small_file_480km, small_file_480km)
+        assert isinstance(ds_small_480km, ux.core.dataset.UxDataset)


### PR DESCRIPTION
Closes #480 

> **Describe the bug**
> After the `Grid` refactor, the `api.py/open_grid()` function seems to have broken. The issue is that it cannot open some of the files or object types anymore that are supported by `xarray.open_dataset()`. The problem seems to be coming from that after the refactor, we are strictly limiting the object types that can be opened in `open_grid` in an `if`-block to only {xr.Dataset, str, Path, PurePath, list, tuple, np.ndarray, xr.DataArray} and throwing an exception otherwise. Though, in the past, we used to open the rest of the file types with `xr.open_dataset()` and move on.
> 
> Below example only demonstrates the failure with opening a https file, but Zarr files, and maybe others should be similarly affected.
> 
> **To Reproduce**
> Try opening an https file (from summer internship notebook), which used to work before, as follows:
> 
> ```
> import requests
> 
> small_file_480km = requests.get("https://web.lcrc.anl.gov/public/e3sm/inputdata/share/meshes/mpas/ocean/oQU480.230422.nc").content
> 
> ds_small_480km = ux.open_dataset(small_file_480km, small_file_480km)
> ```
> 
> **Expected behavior**
> We have to be able to open whatever can be opened by `xr.open_dataset()`. Please revise the code to make that happen.
> 
> 
