### PR TITLE
Nodal Average

### DIFF
--- a/docs/user_api/index.rst
+++ b/docs/user_api/index.rst
@@ -113,6 +113,7 @@ Remapping
    :toctree: _autosummary
 
    UxDataArray.nearest_neighbor_remap
+   UxDataArray.nodal_average
 
 Plotting
 --------

--- a/test/test_dataarray.py
+++ b/test/test_dataarray.py
@@ -122,10 +122,10 @@ class TestGeometryConversions(TestCase):
         v1_nodal_average = uxds['v1'].nodal_average()
 
         # final dimension should match number of faces
-        assert v1_nodal_average.shape[-1] == uxds.uxgrid.n_face
+        self.assertEquals(v1_nodal_average.shape[-1], uxds.uxgrid.n_face)
 
         # all other dimensions should remain unchanged
-        assert uxds['v1'].shape[0:-1] == v1_nodal_average.shape[0:-1]
+        self.assertEquals(uxds['v1'].shape[0:-1], v1_nodal_average.shape[0:-1])
 
         # test on a sample mesh with 4 verts
         verts = [[[-170, 40], [180, 30], [165, 25], [-170, 20]]]
@@ -138,4 +138,4 @@ class TestGeometryConversions(TestCase):
         uxda_nodal_average = uxda.nodal_average()
 
         # resulting data should be the mean of the corner nodes of the single face
-        assert uxda_nodal_average.values == np.mean(data)
+        self.assertEquals(uxda_nodal_average, np.mean(data))

--- a/test/test_dataarray.py
+++ b/test/test_dataarray.py
@@ -3,6 +3,8 @@ import os
 from unittest import TestCase
 from pathlib import Path
 
+import numpy as np
+
 import uxarray as ux
 
 from uxarray.grid.geometry import _build_polygon_shells, _build_corrected_polygon_shells
@@ -111,3 +113,29 @@ class TestGeometryConversions(TestCase):
 
         # override will recompute the grid
         assert gdf_start is not gdf_end
+
+    def test_nodal_average(self):
+
+        # test on a node-centered dataset
+        uxds = ux.open_dataset(gridfile_geoflow, dsfile_v1_geoflow)
+
+        v1_nodal_average = uxds['v1'].nodal_average()
+
+        # final dimension should match number of faces
+        assert v1_nodal_average.shape[-1] == uxds.uxgrid.n_face
+
+        # all other dimensions should remain unchanged
+        assert uxds['v1'].shape[0:-1] == v1_nodal_average.shape[0:-1]
+
+        # test on a sample mesh with 4 verts
+        verts = [[[-170, 40], [180, 30], [165, 25], [-170, 20]]]
+        data = [1, 2, 3, 4]
+
+        uxgrid = ux.open_grid(verts, latlon=True)
+
+        uxda = ux.UxDataArray(uxgrid=uxgrid, data=data, dims=('n_node'))
+
+        uxda_nodal_average = uxda.nodal_average()
+
+        # resulting data should be the mean of the corner nodes of the single face
+        assert uxda_nodal_average.values == np.mean(data)

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -315,8 +315,11 @@ class UxDataArray(xr.DataArray):
         return uxda
 
     def nodal_average(self):
-        """Computes the Nodal Average of a Data Variable, which computes the
-        average of the nodes that surround each face."""
+        """Computes the Nodal Average of a Data Variable, which is the mean of
+        the nodes that surround each face.
+
+        Can be used for remapping node-centered data to each face.
+        """
 
         if not self._node_centered():
             # nodal average expects node-centered data

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -314,6 +314,35 @@ class UxDataArray(xr.DataArray):
 
         return uxda
 
+    def nodal_average(self):
+        """Computes the Nodal Average of a Data Variable, which computes the
+        average of the nodes that surround each face."""
+
+        if not self._node_centered():
+            # nodal average expects node-centered data
+            raise ValueError(
+                f"Data Variable must be mapped to the corner nodes of each face, with dimension "
+                f"{self.uxgrid.n_face}.")
+
+        data = self.values
+        face_nodes = self.uxgrid.face_node_connectivity.values
+        n_nodes_per_face = self.uxgrid.n_nodes_per_face.values
+
+        # compute the nodal average while preserving original dimensions
+        data_nodal_average = np.array([
+            np.mean(data[..., cur_face[0:n_max_nodes]], axis=-1)
+            for cur_face, n_max_nodes in zip(face_nodes, n_nodes_per_face)
+        ])
+
+        # set `n_nodes` as final dimension
+        data_nodal_average = np.moveaxis(data_nodal_average, 0, -1)
+
+        return UxDataArray(uxgrid=self.uxgrid,
+                           data=data_nodal_average,
+                           dims=self.dims,
+                           name=self.name + "_nodal_average" if self.name
+                           is not None else None).rename({"n_node": "n_face"})
+
     def _face_centered(self) -> bool:
         """Returns whether the data stored is Face Centered (i.e. dimensions
         match up with the number of faces)"""


### PR DESCRIPTION
<!--  The PR title should summarize the changes, for example "Add `Grid._build_face_dimension` function".
      Avoid non-descriptive titles such as "Addresses issue #229". -->

<!--  Replace XXX with the number of the issue that this PR will resolve. If this PR closed more than one,
      you may add a comma separated sequence-->
Closes #514 


## Overview
<!--  Please provide a few bullet points summarizing the changes in this PR. This should include
      points on any bug fixes, new functions, or other changes that have been made. -->
* Introduces `UxDataArray.nodal_average()`, which computes the nodal average (i.e. mean of all nodes that surround a given face, for each face) and returns a new `UxDataArray` 
* This is useful for visualization (mapping node centered data to face centers for shading polygons) and for quick remapping (from a node centered to face centered on the same grid without any expensive operations)

## Expected Usage
<!--  If you are adding a feature into the Internal API, please produce a short example of it in action.
      You may ignore this step if it is not applicable (comment out this section). -->
```Python
import uxarray as ux

grid_path = "/path/to/grid.nc"
data_path = "/path/to/data.nc"

uxds = ux.open_dataset(grid_path, data_path)

# compute the nodal average
uxda_nodal_average = uxds['v1'].nodal_average()


```

