### PR TITLE
Use face, not node, in _build_from_face_centers

### DIFF
--- a/uxarray/grid/neighbors.py
+++ b/uxarray/grid/neighbors.py
@@ -283,8 +283,8 @@ class BallTree:
             if self._source_grid.node_lon is None:
                 raise ValueError
 
-            latlon = np.vstack((deg2rad(self._source_grid.node_lat.values),
-                                deg2rad(self._source_grid.node_lon.values))).T
+            latlon = np.vstack((deg2rad(self._source_grid.face_lat.values),
+                                deg2rad(self._source_grid.face_lon.values))).T
 
             self._tree_from_face_centers = SKBallTree(
                 latlon, metric=self.distance_metric)


### PR DESCRIPTION
Closes #617

## Overview
BallTree built from "nodes" instead of "face centers" Changed node_lat to face_lat and node_lon to face_lon

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->

**General**
- [ ] An issue is linked created and linked
- [ ] Add appropriate labels
- [ ] Filled out Overview and Expected Usage (if applicable) sections

**Testing**
- [ ] Adequate tests are created if there is new functionality
- [ ] Tests cover all possible logical paths in your function
- [ ] Tests are not too basic (such as simply calling a function and nothing else)

**Documentation**
- [ ] Docstrings have been added to all new functions
- [ ] Docstrings have updated with any function changes
- [ ] Internal functions have a preceding underscore (`_`) and have been added to `docs/internal_api/index.rst`
- [ ] User functions have been added to `docs/user_api/index.rst`

**Examples**
- [ ] Any new notebook examples added to `docs/examples/` folder
- [ ] Clear the output of all cells before committing
- [ ] New notebook files added to `docs/examples.rst` toctree
- [ ] New notebook files added to new entry in `docs/gallery.yml` with appropriate thumbnail photo in `docs/_static/thumbnails/`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

**PR Etiquette Reminders**
- This PR should be listed as a draft PR until you are ready to request reviewers

- After making changes in accordance with the reviews, re-request your reviewers

- Do *not* mark conversations as resolved if you didn't start them

- Do mark conversations as resolved *if you opened them* and are satisfied with the changes/discussion.
-->
