### PR TITLE
Change pip uninstall command a bit in install-upstream.sh as discussed

### DIFF
--- a/ci/install-upstream.sh
+++ b/ci/install-upstream.sh
@@ -16,7 +16,7 @@ conda remove -y --force \
     shapely \
     xarray
 
-python -m pip uninstall \
+pip uninstall -y \
     antimeridian \
     spatialpandas
 


### PR DESCRIPTION
## Overview
Uninstallation of the packages antimeridian and spatialpandas are throwing [exception](https://github.com/UXARRAY/uxarray/actions/runs/7509141139/job/20445821282) in the current upstream CI that doesn’t lead the whole CI to fail though. This PR changes a single pip uninstall command in the shell script and [fixes](https://github.com/UXARRAY/uxarray/actions/runs/7508805275/job/20444918891) that issue. 