### PR TITLE
Support for Nearest Neighbor `edges` Remapping

### DIFF
--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -340,7 +340,7 @@ class UxDataset(xr.Dataset):
         destination_obj : Grid, UxDataArray, UxDataset
             Destination for remapping
         remap_to : str, default="nodes"
-            Location of where to map data, either "nodes" or "face centers"
+            Location of where to map data, either "nodes", "edges", or "face centers"
         coord_type : str, default="spherical"
             Indicates whether to remap using on spherical or cartesian coordinates
         """

--- a/uxarray/remap/nearest_neighbor.py
+++ b/uxarray/remap/nearest_neighbor.py
@@ -20,8 +20,8 @@ def _nearest_neighbor(
     coord_type: str = "spherical",
 ) -> np.ndarray:
     """Nearest Neighbor Remapping between two grids, mapping data that resides
-    on either the corner nodes or face centers on the source grid to the corner
-    nodes or face centers of the destination grid.
+    on the corner nodes, edge centers, or face centers on the source grid to
+    the corner nodes, edge centers, or face centers of the destination grid.
 
     Parameters
     ---------
@@ -32,7 +32,7 @@ def _nearest_neighbor(
     source_data : np.ndarray
         Data variable to remaps
     remap_to : str, default="nodes"
-        Location of where to map data, either "nodes" or "face centers"
+        Location of where to map data, either "nodes", "edges", or "face centers"
     coord_type: str, default="spherical"
         Coordinate type to use for nearest neighbor query, either "spherical" or "Cartesian"
 
@@ -50,12 +50,14 @@ def _nearest_neighbor(
     if n_elements == source_grid.n_node:
         source_data_mapping = "nodes"
     elif n_elements == source_grid.n_face:
+        source_data_mapping = "edges"
+    elif n_elements == source_grid.n_edge:
         source_data_mapping = "face centers"
     else:
         raise ValueError(
             f"Invalid source_data shape. The final dimension should be either match the number of corner "
-            f"nodes ({source_grid.n_node}) or face centers ({source_grid.n_face}) in the "
-            f"source grid, but received: {source_data.shape}"
+            f"nodes ({source_grid.n_node}), edges ({source_grid.n_edge}), or face centers ({source_grid.n_face}) in the"
+            f" source grid, but received: {source_data.shape}"
         )
 
     if coord_type == "spherical":
@@ -65,7 +67,11 @@ def _nearest_neighbor(
                 destination_grid.node_lon.values,
                 destination_grid.node_lat.values,
             )
-
+        elif remap_to == "edges":
+            lon, lat = (
+                destination_grid.edge_lon.values,
+                destination_grid.edge_lat.values,
+            )
         elif remap_to == "face centers":
             lon, lat = (
                 destination_grid.face_lon.values,
@@ -73,7 +79,7 @@ def _nearest_neighbor(
             )
         else:
             raise ValueError(
-                f"Invalid remap_to. Expected 'nodes' or 'face centers', "
+                f"Invalid remap_to. Expected 'nodes', 'edges', or 'face centers', "
                 f"but received: {remap_to}"
             )
 
@@ -93,7 +99,12 @@ def _nearest_neighbor(
                 destination_grid.node_y.values,
                 destination_grid.node_z.values,
             )
-
+        elif remap_to == "edges":
+            cart_x, cart_y, cart_z = (
+                destination_grid.edge_x.values,
+                destination_grid.edge_y.values,
+                destination_grid.edge_z.values,
+            )
         elif remap_to == "face centers":
             cart_x, cart_y, cart_z = (
                 destination_grid.face_x.values,
@@ -102,7 +113,7 @@ def _nearest_neighbor(
             )
         else:
             raise ValueError(
-                f"Invalid remap_to. Expected 'nodes' or 'face centers', "
+                f"Invalid remap_to. Expected 'nodes', 'edges', or 'face centers', "
                 f"but received: {remap_to}"
             )
 
@@ -148,7 +159,7 @@ def _nearest_neighbor_uxda(
     destination_obj : Grid, UxDataArray, UxDataset
         Destination for remapping
     remap_to : str, default="nodes"
-        Location of where to map data, either "nodes" or "face centers"
+        Location of where to map data, either "nodes", "edges", or "face centers"
     coord_type : str, default="spherical"
         Indicates whether to remap using on Spherical or Cartesian coordinates for nearest neighbor computations when
         remapping.
@@ -157,6 +168,8 @@ def _nearest_neighbor_uxda(
     # prepare dimensions
     if remap_to == "nodes":
         destination_dim = "n_node"
+    elif remap_to == "edges":
+        destination_dim = "n_edge"
     else:
         destination_dim = "n_face"
 
@@ -215,7 +228,7 @@ def _nearest_neighbor_uxds(
     destination_obj : Grid, UxDataArray, UxDataset
         Destination for remapping
     remap_to : str, default="nodes"
-        Location of where to map data, either "nodes" or "face centers"
+        Location of where to map data, either "nodes", "edges", or "face centers"
     coord_type : str, default="spherical"
         Indicates whether to remap using on Spherical or Cartesian coordinates
     """


### PR DESCRIPTION
<!--  The PR title should summarize the changes, for example "Add `Grid._build_face_dimension` function".
      Avoid non-descriptive titles such as "Addresses issue #229". -->

<!--  Replace XXX with the number of the issue that this PR will resolve. If this PR closed more than one,
      you may add a comma separated sequence-->
Closes #647

## Overview
<!--  Please provide a few bullet points summarizing the changes in this PR. This should include
      points on any bug fixes, new functions, or other changes that have been made. -->
Adds support to allow remapping from `edges` in our Nearest Neighbor Remapping implementation. Since Inverse Distance Weighted Remapping is still an open PR, I have already added the implementation directly there. 
## Expected Usage
<!--  If you are adding a feature into the Internal API, please produce a short example of it in action.
      You may ignore this step if it is not applicable (comment out this section). -->
```Python
import uxarray as ux

# File paths
mpasfile_QU = current_path / "meshfiles" / "mpas" / "QU" / "mesh.QU.1920km.151026.nc"
gridfile_geoflow = current_path / "meshfiles" / "ugrid" / "geoflow-small" / "grid.nc"
dsfile_v1_geoflow = current_path / "meshfiles" / "ugrid" / "geoflow-small" / "v1.nc"

# Open source and destination datasets to remap to
source_grid = ux.open_dataset(gridfile_geoflow, dsfile_v1_geoflow)
destination_grid = ux.open_dataset(mpasfile_QU, mpasfile_QU)

# Perform remapping to the edges of the dataset
remap_to_edges = source_grid['v1'].nearest_neighbor_remap(destination_obj=destination_grid,
                                                          remap_to="edges")

```

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->

**General**
- [x] An issue is linked created and linked
- [x] Add appropriate labels
- [x] Filled out Overview and Expected Usage (if applicable) sections

**Testing**
- [x] Adequate tests are created if there is new functionality
- [x] Tests cover all possible logical paths in your function
- [x] Tests are not too basic (such as simply calling a function and nothing else)

**Documentation**
- [x] Docstrings have been added to all new functions
- [x] Docstrings have updated with any function changes
- [x] Internal functions have a preceding underscore (`_`) and have been added to `docs/internal_api/index.rst`
- [x] User functions have been added to `docs/user_api/index.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

**PR Etiquette Reminders**
- This PR should be listed as a draft PR until you are ready to request reviewers

- After making changes in accordance with the reviews, re-request your reviewers

- Do *not* mark conversations as resolved if you didn't start them

- Do mark conversations as resolved *if you opened them* and are satisfied with the changes/discussion.
-->
