### PR TITLE
Fix optional args for `dataarray_plot.datashade` call in the accessor

### DIFF
--- a/uxarray/plot/accessor.py
+++ b/uxarray/plot/accessor.py
@@ -302,13 +302,13 @@ class UxDataArrayPlotAccessor:
         return dataarray_plot.datashade(
             self._uxda,
             *args,
-            method,
-            plot_height,
-            plot_width,
-            x_range,
-            y_range,
-            cmap,
-            agg,
+            method=method,
+            plot_height=plot_height,
+            plot_width=plot_width,
+            x_range=x_range,
+            y_range=y_range,
+            cmap=cmap,
+            agg=agg,
             **kwargs,
         )
 


### PR DESCRIPTION
<!--  The PR title should summarize the changes, for example "Add `Grid._build_face_dimension` function".
      Avoid non-descriptive titles such as "Addresses issue #229". -->

<!--  Replace XXX with the number of the issue that this PR will resolve. If this PR closed more than one,
      you may add a comma separated sequence-->
Closes #673 

## Overview
<!--  Please provide a few bullet points summarizing the changes in this PR. This should include
      points on any bug fixes, new functions, or other changes that have been made. -->

The optional arguments in the function call signature were given incorrectly, which we noticed through `cmap` input not working as expected.

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->

**General**
- [x] An issue is linked created and linked
- [x] Add appropriate labels
- [x] Filled out Overview and Expected Usage (if applicable) sections

