### PR TITLE
Fix conflict between user-defined `clabel` and `kwargs`

### DIFF
--- a/test/test_plot.py
+++ b/test/test_plot.py
@@ -81,3 +81,13 @@ class TestPlot(TestCase):
             uxds['v1'][0][0].plot.points(backend=backend)
 
             uxds['v1'][0][0].nodal_average().plot.polygons(backend=backend)
+
+
+    def test_clabel(self):
+        """Tests the execution of passing in a custom clabel."""
+
+        uxds = ux.open_dataset(gridfile_geoflow, datafile_geoflow)
+
+        raster_no_clabel = uxds['v1'][0][0].plot.rasterize(method='point')
+
+        raster_no_clabel = uxds['v1'][0][0].plot.rasterize(method='point', clabel="Foo")

--- a/uxarray/plot/dataarray_plot.py
+++ b/uxarray/plot/dataarray_plot.py
@@ -210,9 +210,7 @@ def _point_raster(
 
     if "clabel" not in kwargs:
         # set default label for color bar
-        clabel = uxda.name
-    else:
-        clabel = kwargs.get("clabel")
+        kwargs["clabel"] = uxda.name
 
     if uxda._face_centered():
         # data mapped to face centroid coordinates
@@ -291,7 +289,6 @@ def _point_raster(
             cmap=cmap,
             xlabel=xlabel,
             ylabel=ylabel,
-            clabel=clabel,
             **kwargs,
         )
     elif backend == "bokeh":
@@ -311,7 +308,6 @@ def _point_raster(
             cmap=cmap,
             xlabel=xlabel,
             ylabel=ylabel,
-            clabel=clabel,
             **kwargs,
         )
 
@@ -346,9 +342,7 @@ def _polygon_raster(
 
     if "clabel" not in kwargs:
         # set default label for color bar
-        clabel = uxda.name
-    else:
-        clabel = kwargs.get("clabel")
+        kwargs["clabel"] = uxda.name
 
     gdf = uxda.to_geodataframe(
         exclude_antimeridian=exclude_antimeridian, cache=cache, override=override
@@ -371,7 +365,6 @@ def _polygon_raster(
             cmap=cmap,
             xlabel=xlabel,
             ylabel=ylabel,
-            clabel=clabel,
             **kwargs,
         )
     elif backend == "bokeh":
@@ -391,7 +384,6 @@ def _polygon_raster(
             cmap=cmap,
             xlabel=xlabel,
             ylabel=ylabel,
-            clabel=clabel,
             **kwargs,
         )
 
@@ -439,9 +431,7 @@ def polygons(
 
     if "clabel" not in kwargs:
         # set default label for color bar
-        clabel = uxda.name
-    else:
-        clabel = kwargs.get("clabel")
+        kwargs["clabel"] = uxda.name
 
     gdf = uxda.to_geodataframe(
         exclude_antimeridian=exclude_antimeridian, cache=cache, override=override
@@ -465,7 +455,6 @@ def polygons(
             cmap=cmap,
             xlabel=xlabel,
             ylabel=ylabel,
-            clabel=clabel,
             **kwargs,
         )
 
@@ -549,9 +538,7 @@ def _plot_data_as_points(
 
     if "clabel" not in kwargs:
         # set default label for color bar
-        clabel = uxda.name
-    else:
-        clabel = kwargs.get("clabel")
+        kwargs["clabel"] = uxda.name
 
     uxgrid = uxda.uxgrid
     if element == "node":
@@ -578,7 +565,6 @@ def _plot_data_as_points(
             cmap=cmap,
             xlabel=xlabel,
             ylabel=ylabel,
-            clabel=clabel,
             **kwargs,
         )
 
@@ -593,6 +579,5 @@ def _plot_data_as_points(
             cmap=cmap,
             xlabel=xlabel,
             ylabel=ylabel,
-            clabel=clabel,
             **kwargs,
         )


### PR DESCRIPTION
<!--  The PR title should summarize the changes, for example "Add `Grid._build_face_dimension` function".
      Avoid non-descriptive titles such as "Addresses issue #229". -->

<!--  Replace XXX with the number of the issue that this PR will resolve. If this PR closed more than one,
      you may add a comma separated sequence-->
Closes #671 

## Overview
<!--  Please provide a few bullet points summarizing the changes in this PR. This should include
      points on any bug fixes, new functions, or other changes that have been made. -->
* Fixes a bug where passing in a `clabel` argument would lead to two `clabels` being passed into the plotting routines, leading to an error.