### PR TITLE
Fix FutureWarnings in the code and tests 

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - pandas<2.1.0
   - pathlib
   - pre_commit
-  - pyarrow<13.0.0   # pin due to CI faliures on macOS & ubuntu
+  - pyarrow
   - pytest
   - pytest-cov
   - requests

--- a/test/test_computing.py
+++ b/test/test_computing.py
@@ -41,7 +41,7 @@ class TestFMAOperations(TestCase):
         a = 1.0
         b = 2.0
         s, e = ac_utils._two_sum(a, b)
-        self.assertAlmostEquals(a + b, s + e, places=15)
+        self.assertAlmostEqual(a + b, s + e, places=15)
 
     def test_fast_two_sum(self):
         """Test the fase_two_sum function."""
@@ -49,8 +49,8 @@ class TestFMAOperations(TestCase):
         b = 1.0
         s, e = ac_utils._two_sum(a, b)
         sf, ef = ac_utils._fast_two_sum(a, b)
-        self.assertEquals(s, sf)
-        self.assertEquals(e, ef)
+        self.assertEqual(s, sf)
+        self.assertEqual(e, ef)
 
     def test_two_prod_fma(self):
         """Test the two_prod_fma function."""
@@ -58,9 +58,9 @@ class TestFMAOperations(TestCase):
         a = 1.0
         b = 2.0
         x, y = ac_utils._two_prod_fma(a, b)
-        self.assertEquals(x, a * b)
-        self.assertEquals(y, pyfma.fma(a, b, -x))
-        self.assertAlmostEquals(a * b, x + y, places=15)
+        self.assertEqual(x, a * b)
+        self.assertEqual(y, pyfma.fma(a, b, -x))
+        self.assertAlmostEqual(a * b, x + y, places=15)
 
     def test_fast_two_mult(self):
         """Test the two_prod_fma function."""
@@ -68,8 +68,8 @@ class TestFMAOperations(TestCase):
         b = 2.0
         x, y = ac_utils._two_prod_fma(a, b)
         xf, yf = ac_utils._fast_two_mult(a, b)
-        self.assertEquals(x, xf)
-        self.assertEquals(y, yf)
+        self.assertEqual(x, xf)
+        self.assertEqual(y, yf)
 
     def test_err_fmac(self):
         """Test the _err_fmac function."""
@@ -78,8 +78,8 @@ class TestFMAOperations(TestCase):
         b = 2.0
         c = 3.0
         x, y, z = ac_utils._err_fmac(a, b, c)
-        self.assertEquals(x, pyfma.fma(a, b, c))
-        self.assertAlmostEquals(a * b + c, x + y + z, places=15)
+        self.assertEqual(x, pyfma.fma(a, b, c))
+        self.assertAlmostEqual(a * b + c, x + y + z, places=15)
 
 
 class TestAccurateSum(TestCase):
@@ -88,7 +88,7 @@ class TestAccurateSum(TestCase):
         """Test the _vec_sum function."""
         a = np.array([1.0, 2.0, 3.0])
         res = ac_utils._vec_sum(a)
-        self.assertAlmostEquals(6.0, res, places=15)
+        self.assertAlmostEqual(6.0, res, places=15)
         import gmpy2
         a = gmpy2.mpfr('2.28888888888')
         b = gmpy2.mpfr('-2.2888889999')
@@ -114,16 +114,16 @@ class TestNorm(TestCase):
         """Test the norm_faithful function."""
         a = np.array([1.0, 2.0, 3.0])
         res = ac_utils._norm_faithful(a)
-        self.assertAlmostEquals(np.linalg.norm(a), res, places=15)
+        self.assertAlmostEqual(np.linalg.norm(a), res, places=15)
 
     def test_sqrt_faithful(self):
         """Test the sqrt_faithful function."""
         a = 10.0
         res = ac_utils._acc_sqrt(a, 0.0)
-        self.assertAlmostEquals(np.sqrt(a), res, places=15)
+        self.assertAlmostEqual(np.sqrt(a), res, places=15)
 
     def test_two_square(self):
         """Test the _two_square function."""
         a = 10.0
         res = ac_utils._two_square(a)
-        self.assertAlmostEquals(a * a, res[0], places=15)
+        self.assertAlmostEqual(a * a, res[0], places=15)

--- a/test/test_dataarray.py
+++ b/test/test_dataarray.py
@@ -122,10 +122,10 @@ class TestGeometryConversions(TestCase):
         v1_nodal_average = uxds['v1'].nodal_average()
 
         # final dimension should match number of faces
-        self.assertEquals(v1_nodal_average.shape[-1], uxds.uxgrid.n_face)
+        self.assertEqual(v1_nodal_average.shape[-1], uxds.uxgrid.n_face)
 
         # all other dimensions should remain unchanged
-        self.assertEquals(uxds['v1'].shape[0:-1], v1_nodal_average.shape[0:-1])
+        self.assertEqual(uxds['v1'].shape[0:-1], v1_nodal_average.shape[0:-1])
 
         # test on a sample mesh with 4 verts
         verts = [[[-170, 40], [180, 30], [165, 25], [-170, 20]]]
@@ -138,4 +138,4 @@ class TestGeometryConversions(TestCase):
         uxda_nodal_average = uxda.nodal_average()
 
         # resulting data should be the mean of the corner nodes of the single face
-        self.assertEquals(uxda_nodal_average, np.mean(data))
+        self.assertEqual(uxda_nodal_average, np.mean(data))

--- a/test/test_geometry.py
+++ b/test/test_geometry.py
@@ -390,12 +390,12 @@ class TestLatlonBound(TestCase):
 
         # Calculate the width of the latlonbox
         width = ux.grid.geometry._get_latlonbox_width(gca_latlon)
-        self.assertEquals(width, 3.0)
+        self.assertEqual(width, 3.0)
 
         # Define a great circle arc that is not wrapping around the meridian
         gca_latlon = np.array([[0.0, 0.0], [2 * np.pi - 1.0, 1.0]])
         width = ux.grid.geometry._get_latlonbox_width(gca_latlon)
-        self.assertEquals(width, 2.0)
+        self.assertEqual(width, 2.0)
 
     def test_insert_pt_in_latlonbox_non_periodic(self):
         old_box = np.array([[0.1, 0.2], [0.3, 0.4]])  # Radians

--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -234,7 +234,7 @@ class UxDataset(xr.Dataset):
         lines.append("uxarray.Dataset {")
 
         lines.append("grid topology dimensions:")
-        for name, size in self.uxgrid._ds.dims.items():
+        for name, size in self.uxgrid._ds.sizes.items():
             lines.append(f"\t{name} = {size}")
 
         lines.append("\ngrid topology variables:")
@@ -246,7 +246,7 @@ class UxDataset(xr.Dataset):
                     lines.append(f"\t\t{name}:{k} = {v}")
 
         lines.append("\ndata dimensions:")
-        for name, size in self.dims.items():
+        for name, size in self.sizes.items():
             lines.append(f"\t{name} = {size}")
 
         lines.append("\ndata variables:")

--- a/uxarray/core/utils.py
+++ b/uxarray/core/utils.py
@@ -19,11 +19,11 @@ def _map_dims_to_ugrid(
 
     for dim in set(ds.dims) ^ _source_dims_dict.keys():
         # obtain dimensions that were not parsed source_dims_dict and attempt to match to a grid element
-        if ds.dims[dim] == grid.n_face:
+        if ds.sizes[dim] == grid.n_face:
             _source_dims_dict[dim] = "n_face"
-        elif ds.dims[dim] == grid.n_node:
+        elif ds.sizes[dim] == grid.n_node:
             _source_dims_dict[dim] = "n_node"
-        elif ds.dims[dim] == grid.n_edge:
+        elif ds.sizes[dim] == grid.n_edge:
             _source_dims_dict[dim] = "n_edge"
 
     # Possible Issue: https://github.com/UXARRAY/uxarray/issues/610

--- a/uxarray/grid/grid.py
+++ b/uxarray/grid/grid.py
@@ -426,13 +426,13 @@ class Grid:
     def n_node(self) -> int:
         """Dimension ``n_node``, which represents the total number of unique
         corner nodes."""
-        return self._ds.dims["n_node"]
+        return self._ds.sizes["n_node"]
 
     @property
     def n_face(self) -> int:
         """Dimension ``n_face``, which represents the total number of unique
         faces."""
-        return self._ds.dims["n_face"]
+        return self._ds.sizes["n_face"]
 
     @property
     def n_edge(self) -> int:
@@ -441,7 +441,7 @@ class Grid:
         if "edge_node_connectivity" not in self._ds:
             _populate_edge_node_connectivity(self)
 
-        return self._ds.dims["n_edge"]
+        return self._ds.sizes["n_edge"]
 
     # ==================================================================================================================
     @property

--- a/uxarray/grid/grid.py
+++ b/uxarray/grid/grid.py
@@ -272,7 +272,7 @@ class Grid:
         dims_heading = "Grid Dimensions:\n"
         dims_str = ""
 
-        for key, value in zip(self._ds.dims.keys(), self._ds.dims.values()):
+        for key, value in zip(self._ds.sizes.keys(), self._ds.sizes.values()):
             dims_str += f"  * {key}: {value}\n"
 
         dims_str += f"  * n_nodes_per_face: {self.n_nodes_per_face.shape}\n"

--- a/uxarray/io/_exodus.py
+++ b/uxarray/io/_exodus.py
@@ -28,8 +28,8 @@ def _read_exodus(ext_ds):
     max_face_nodes = 0
     for dim in ext_ds.dims:
         if "num_nod_per_el" in dim:
-            if ext_ds.dims[dim] > max_face_nodes:
-                max_face_nodes = ext_ds.dims[dim]
+            if ext_ds.sizes[dim] > max_face_nodes:
+                max_face_nodes = ext_ds.sizes[dim]
 
     # create an empty conn array for storing all blk face_nodes_data
     conn = np.empty((0, max_face_nodes))
@@ -57,7 +57,7 @@ def _read_exodus(ext_ds):
                     "units": "m",
                 },
             )
-            if ext_ds.dims["num_dim"] > 2:
+            if ext_ds.sizes["num_dim"] > 2:
                 ds["node_z"] = xr.DataArray(
                     data=ext_ds.coord[2],
                     dims=["n_node"],
@@ -88,7 +88,7 @@ def _read_exodus(ext_ds):
                 },
             )
         elif key == "coordz":
-            if ext_ds.dims["num_dim"] > 2:
+            if ext_ds.sizes["num_dim"] > 2:
                 ds["node_z"] = xr.DataArray(
                     data=ext_ds.coordx,
                     dims=["n_node"],


### PR DESCRIPTION
Closes #710 

## Overview
Addresses:

- "FutureWarning: The return type of `Dataset.dims` will be changed to return a set of dimension names in future, in order to be more consistent with `DataArray.dims`. To access a mapping from dimension names to lengths, please use `Dataset.sizes`"
- Unpinning of `pyarrow` to fix "FutureWarning: Minimal version of pyarrow will soon be increased to 14.0.1. You are using 12.0.1. Please consider upgrading."
- DeprecationWarnings about `assertEquals()` calls in the test files by converting them to `assertEqual()`
- DeprecationWarnings about `assertAlmostEquals()` calls in the test files by converting them to `assertAlmostEqual()`

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->

**General**
- [x] An issue is linked created and linked
- [x] Add appropriate labels
- [x] Filled out Overview and Expected Usage (if applicable) sections