### PR TITLE
Re-introduce Numba to face area computations 

### DIFF
--- a/uxarray/grid/area.py
+++ b/uxarray/grid/area.py
@@ -2,7 +2,13 @@ import numpy as np
 
 from uxarray.grid.coordinates import _lonlat_rad_to_xyz
 
+from numba import njit, config
+from uxarray.constants import ENABLE_JIT_CACHE, ENABLE_JIT
 
+config.DISABLE_JIT = not ENABLE_JIT
+
+
+@njit(cache=ENABLE_JIT_CACHE)
 def calculate_face_area(
     x, y, z, quadrature_rule="gaussian", order=4, coords_type="spherical"
 ):
@@ -92,6 +98,7 @@ def calculate_face_area(
     return area, jacobian
 
 
+@njit(cache=ENABLE_JIT_CACHE)
 def get_all_face_area_from_coords(
     x,
     y,
@@ -166,6 +173,7 @@ def get_all_face_area_from_coords(
     return area, jacobian
 
 
+@njit(cache=ENABLE_JIT_CACHE)
 def calculate_spherical_triangle_jacobian(node1, node2, node3, dA, dB):
     """Calculate Jacobian of a spherical triangle. This is a helper function
     for calculating face area.
@@ -255,6 +263,7 @@ def calculate_spherical_triangle_jacobian(node1, node2, node3, dA, dB):
     return dJacobian
 
 
+@njit(cache=ENABLE_JIT_CACHE)
 def calculate_spherical_triangle_jacobian_barycentric(node1, node2, node3, dA, dB):
     """Calculate Jacobian of a spherical triangle. This is a helper function
     for calculating face area.
@@ -333,6 +342,7 @@ def calculate_spherical_triangle_jacobian_barycentric(node1, node2, node3, dA, d
     return 0.5 * dJacobian
 
 
+@njit(cache=ENABLE_JIT_CACHE)
 def get_gauss_quadratureDG(nCount):
     """Gauss Quadrature Points for integration.
 
@@ -577,6 +587,7 @@ def get_gauss_quadratureDG(nCount):
     return dG, dW
 
 
+@njit(cache=ENABLE_JIT_CACHE)
 def get_tri_quadratureDG(nOrder):
     """Triangular Quadrature Points for integration.
 

--- a/uxarray/grid/coordinates.py
+++ b/uxarray/grid/coordinates.py
@@ -8,7 +8,10 @@ from uxarray.conventions import ugrid
 
 from typing import Union
 
+from numba import njit
 
+
+@njit
 def _lonlat_rad_to_xyz(
     lon: Union[np.ndarray, float],
     lat: Union[np.ndarray, float],

--- a/uxarray/grid/coordinates.py
+++ b/uxarray/grid/coordinates.py
@@ -11,7 +11,7 @@ from typing import Union
 from numba import njit
 
 
-@njit
+@njit(cache=True)
 def _lonlat_rad_to_xyz(
     lon: Union[np.ndarray, float],
     lat: Union[np.ndarray, float],


### PR DESCRIPTION
Closes #793 

The removal of Numba in #748 severely degraded the performance of the face area computations. The removal was initially due to the removal of Numba in favor of vectorization with the coordinate conversion functions (since _normalize_xyz can't use numba in it's current state).

[This performance can be observed in our ASV benchmark. ](https://uxarray.github.io/uxarray-asv/#mpas_ocean.Integrate.time_integrate)

However, `_lonlat_rad_to_xyz()`, which is used by the face area computations, can be optimized using Numba.  