### PR TITLE
Add Missing Face Area Notebook to User Guide

### DIFF
--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -52,7 +52,7 @@ These user guides provide detailed explanations of the core functionality in UXa
 `Tree Structures <user-guide/tree_structures.ipynb>`_
  Data structures for nearest neighbor queries
 
-`Face Area Calculations <user-guide/tree_structures.ipynb>`_
+`Face Area Calculations <user-guide/area_calc.ipynb>`_
  Methods for computing the area of each face
 
 Supplementary Guides

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -52,6 +52,9 @@ These user guides provide detailed explanations of the core functionality in UXa
 `Tree Structures <user-guide/tree_structures.ipynb>`_
  Data structures for nearest neighbor queries
 
+`Face Area Calculations <user-guide/tree_structures.ipynb>`_
+ Methods for computing the area of each face
+
 Supplementary Guides
 --------------------
 


### PR DESCRIPTION
Adds the face area notebook to the user guide, which was missing before. 