### PR TITLE
Fix UXARRAY/uxarray#846

### DIFF
--- a/uxarray/io/_ugrid.py
+++ b/uxarray/io/_ugrid.py
@@ -24,15 +24,15 @@ def _read_ugrid(ds):
         node_lat_name: ugrid.NODE_COORDINATES[1],
     }
 
-    if "edge_coordinates" in ds["grid_topology"]:
+    if "edge_coordinates" in ds["grid_topology"].attrs:
         # get the names of edge_lon and edge_lat, if they exist
         edge_lon_name, edge_lat_name = ds["grid_topology"].edge_coordinates.split()
         coord_dict[edge_lon_name] = ugrid.EDGE_COORDINATES[0]
         coord_dict[edge_lat_name] = ugrid.EDGE_COORDINATES[1]
 
-    if "face_coordinates" in ds["grid_topology"]:
+    if "face_coordinates" in ds["grid_topology"].attrs:
         # get the names of face_lon and face_lat, if they exist
-        face_lon_name, face_lat_name = ds["grid_topology"].edge_coordinates.split()
+        face_lon_name, face_lat_name = ds["grid_topology"].face_coordinates.split()
         coord_dict[face_lon_name] = ugrid.FACE_COORDINATES[0]
         coord_dict[face_lat_name] = ugrid.FACE_COORDINATES[1]
 


### PR DESCRIPTION
Addresses UXARRAY/uxarray#846

## Overview
The code to rename UGRID topology names does not use attributes to check names. This bug ignores edge and face coordinates names to rename.
Also, there is a typo in the face coordinates renaming, which will replace names with the wrong variables.

## PR Checklist

**General**
- [x] An issue is linked created and linked
- [x] Add appropriate labels
- [x] Filled out Overview and Expected Usage (if applicable) sections

**Testing**
- [ ] Adequate tests are created if there is new functionality
- [ ] Tests cover all possible logical paths in your function
- [ ] Tests are not too basic (such as simply calling a function and nothing else)

**Documentation**
- [ ] Docstrings have been added to all new functions
- [ ] Docstrings have updated with any function changes
- [ ] Internal functions have a preceding underscore (`_`) and have been added to `docs/internal_api/index.rst`
- [ ] User functions have been added to `docs/user_api/index.rst`

**Examples**
- [ ] Any new notebook examples added to `docs/examples/` folder
- [ ] Clear the output of all cells before committing
- [ ] New notebook files added to `docs/examples.rst` toctree
- [ ] New notebook files added to new entry in `docs/gallery.yml` with appropriate thumbnail photo in `docs/_static/thumbnails/`