### PR TITLE
Fix UXARRAY/uxarray#862

### DIFF
--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -1073,11 +1073,9 @@ class UxDataArray(xr.DataArray):
             ).values
 
         elif self._node_centered():
-            d_var = (
-                self.isel(
-                    n_node=sliced_grid._ds["subgrid_node_indices"], ignore_grid=True
-                ).values,
-            )
+            d_var = self.isel(
+                n_node=sliced_grid._ds["subgrid_node_indices"], ignore_grid=True
+            ).values
 
         else:
             raise ValueError(


### PR DESCRIPTION
This commit removes an unnecessary set of parentheses around isel, which creates a tuple, causing an error later in the UxDataArray construction.

## Overview
## Expected Usage
No change in usage.

## PR Checklist

**General**
- [x] An issue is linked created and linked
- [x] Add appropriate labels
- [x] Filled out Overview and Expected Usage (if applicable) sections

**Testing**
- [ ] Adequate tests are created if there is new functionality
- [ ] Tests cover all possible logical paths in your function
- [ ] Tests are not too basic (such as simply calling a function and nothing else)

**Documentation**
- [ ] Docstrings have been added to all new functions
- [ ] Docstrings have updated with any function changes
- [ ] Internal functions have a preceding underscore (`_`) and have been added to `docs/internal_api/index.rst`
- [ ] User functions have been added to `docs/user_api/index.rst`

**Examples**
- [ ] Any new notebook examples added to `docs/examples/` folder
- [ ] Clear the output of all cells before committing
- [ ] New notebook files added to `docs/examples.rst` toctree
- [ ] New notebook files added to new entry in `docs/gallery.yml` with appropriate thumbnail photo in `docs/_static/thumbnails/`