### PR TITLE
Pass coords to new UxDataArray in remap methods

### DIFF
--- a/uxarray/remap/inverse_distance_weighted.py
+++ b/uxarray/remap/inverse_distance_weighted.py
@@ -230,6 +230,7 @@ def _inverse_distance_weighted_remap_uxda(
     uxda_remap = uxarray.core.dataarray.UxDataArray(
         data=destination_data,
         name=source_uxda.name,
+        coords=source_uxda.coords,
         dims=destination_dims,
         uxgrid=destination_grid,
     )

--- a/uxarray/remap/nearest_neighbor.py
+++ b/uxarray/remap/nearest_neighbor.py
@@ -198,6 +198,7 @@ def _nearest_neighbor_uxda(
     uxda_remap = uxarray.core.dataarray.UxDataArray(
         data=destination_data,
         name=source_uxda.name,
+        coords=source_uxda.coords,
         dims=destination_dims,
         uxgrid=destination_grid,
     )


### PR DESCRIPTION
Just like #818 did for subset methods.

I think this is analogous to pull request #818. 

I noted my Coordinates and Indexes were disappearing after remapping. This preserved them. 
The Coordinates and Indexes were for time and ensemble member (i.e. nothing to do with space).