### PR TITLE
Merge Duplicate Node Indices

### DIFF
--- a/test/test_duplicate_nodes.py
+++ b/test/test_duplicate_nodes.py
@@ -1,0 +1,26 @@
+import uxarray as ux
+
+import os
+from pathlib import Path
+
+current_path = Path(os.path.dirname(os.path.realpath(__file__)))
+
+import numpy.testing as nt
+
+gridfile_geos_cs = current_path / "meshfiles" / "geos-cs" / "c12" / "test-c12.native.nc4"
+
+
+
+def test_merge_nodes_geos():
+
+    uxgrid_with_duplicates = ux.open_grid(gridfile_geos_cs)
+
+    uxgrid_without_duplicates = ux.open_grid(gridfile_geos_cs)
+    uxgrid_without_duplicates.merge_duplicate_node_indices(inplace=True)
+
+    assert (uxgrid_with_duplicates.face_node_connectivity.values != uxgrid_without_duplicates.face_node_connectivity.values).any()
+
+    _uxgrid = ux.open_grid(gridfile_geos_cs)
+    uxgrid_without_duplicates_new_grid = _uxgrid.merge_duplicate_node_indices(inplace=False)
+
+    assert (uxgrid_with_duplicates.face_node_connectivity.values != uxgrid_without_duplicates_new_grid.face_node_connectivity.values).any()

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -31,6 +31,7 @@ gridfile_CSne30 = current_path / "meshfiles" / "ugrid" / "outCSne30" / "outCSne3
 gridfile_fesom = current_path / "meshfiles" / "ugrid" / "fesom" / "fesom.mesh.diag.nc"
 gridfile_geoflow = current_path / "meshfiles" / "ugrid" / "geoflow-small" / "grid.nc"
 gridfile_mpas = current_path / 'meshfiles' / "mpas" / "QU" / 'mesh.QU.1920km.151026.nc'
+gridfile_geos_cs = current_path / "meshfiles" / "geos-cs" / "c12" / "test-c12.native.nc4"
 
 dsfile_vortex_CSne30 = current_path / "meshfiles" / "ugrid" / "outCSne30" / "outCSne30_vortex.nc"
 dsfile_var2_CSne30 = current_path / "meshfiles" / "ugrid" / "outCSne30" / "outCSne30_var2.nc"
@@ -658,8 +659,8 @@ class TestConnectivity(TestCase):
 
         # construct edge nodes
         edge_nodes_output, _, _ = _build_edge_node_connectivity(mpas_grid_ux.face_node_connectivity.values,
-                                                          mpas_grid_ux.n_face,
-                                                          mpas_grid_ux.n_max_face_nodes)
+                                                                mpas_grid_ux.n_face,
+                                                                mpas_grid_ux.n_max_face_nodes)
 
         # _populate_face_edge_connectivity(mpas_grid_ux)
         # edge_nodes_output = mpas_grid_ux._ds['edge_node_connectivity'].values
@@ -932,6 +933,7 @@ class TestClassMethods(TestCase):
 
 class TestLatlonBounds(TestCase):
     gridfile_mpas = current_path / "meshfiles" / "mpas" / "QU" / "oQU480.231010.nc"
+
     def test_populate_bounds_GCA_mix(self):
         face_1 = [[10.0, 60.0], [10.0, 10.0], [50.0, 10.0], [50.0, 60.0]]
         face_2 = [[350, 60.0], [350, 10.0], [50.0, 10.0], [50.0, 60.0]]
@@ -941,11 +943,10 @@ class TestLatlonBounds(TestCase):
         faces = [face_1, face_2, face_3, face_4]
 
         # Hand calculated bounds for the above faces in radians
-        expected_bounds = [[[0.17453293, 1.07370494],[0.17453293, 0.87266463]],
-                           [[0.17453293, 1.10714872],[6.10865238, 0.87266463]],
-                           [[1.04719755, 1.57079633],[3.66519143, 0.52359878]],
-                           [[1.04719755,1.57079633],[0.,         6.28318531]]]
-
+        expected_bounds = [[[0.17453293, 1.07370494], [0.17453293, 0.87266463]],
+                           [[0.17453293, 1.10714872], [6.10865238, 0.87266463]],
+                           [[1.04719755, 1.57079633], [3.66519143, 0.52359878]],
+                           [[1.04719755, 1.57079633], [0., 6.28318531]]]
 
         grid = ux.Grid.from_face_vertices(faces, latlon=True)
         bounds_xarray = grid.bounds

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -983,3 +983,12 @@ class TestDualMesh(TestCase):
 
         # Assert the faces are the same
         nt.assert_equal(dual.face_node_connectivity.values,  mpas_dual.face_node_connectivity.values)
+
+
+    def test_duplicate(self):
+        uxgrid = ux.open_grid(gridfile_geos)
+        uxgrid.merge_duplicate_node_indices()
+
+        uxgrid.compute_dual()
+
+        pass

--- a/uxarray/grid/dual.py
+++ b/uxarray/grid/dual.py
@@ -34,7 +34,7 @@ def construct_dual(grid):
     )
 
 
-# @njit(cache=True)
+@njit(cache=True)
 def construct_faces(
     n_node,
     n_edges,
@@ -46,6 +46,7 @@ def construct_faces(
     node_y,
     node_z,
 ):
+    max_edges = len(node_face_connectivity[0])
     for i in range(n_node):
         # If we have less than 3 edges, we can't construct anything but a line
         if n_edges[i] < 3:
@@ -85,6 +86,7 @@ def construct_faces(
                 dual_node_x,
                 dual_node_y,
                 dual_node_z,
+                max_edges,
             )
             node_face_connectivity[i] = _face
     return node_face_connectivity
@@ -99,6 +101,7 @@ def _order_nodes(
     dual_node_x,
     dual_node_y,
     dual_node_z,
+    max_edges,
 ):
     node_zero = node_0 - node_central
 
@@ -107,7 +110,7 @@ def _order_nodes(
 
     d_angles = np.zeros(n_edges, dtype=np.float64)
     d_angles[0] = 0.0
-    final_face = np.array([INT_FILL_VALUE for _ in range(n_edges)], dtype=INT_DTYPE)
+    final_face = np.array([INT_FILL_VALUE for _ in range(max_edges)], dtype=INT_DTYPE)
     for j in range(1, n_edges):
         _cur_face_temp_idx = temp_face[j]
 

--- a/uxarray/grid/dual.py
+++ b/uxarray/grid/dual.py
@@ -34,7 +34,7 @@ def construct_dual(grid):
     )
 
 
-@njit(cache=True)
+# @njit(cache=True)
 def construct_faces(
     n_node,
     n_edges,

--- a/uxarray/grid/validation.py
+++ b/uxarray/grid/validation.py
@@ -68,6 +68,7 @@ def _check_area(grid):
 
 
 def _find_duplicate_nodes(grid):
+    """Creates a dictionary mapping which node indices reference duplicates."""
     # list of tuple indices
     lonlat_t = [
         (lon, lat) for lon, lat in zip(grid.node_lon.values, grid.node_lat.values)
@@ -95,6 +96,7 @@ def _find_duplicate_nodes(grid):
 
 
 def _merge_duplicate_node_indices_on_connectivity(conn, duplicate_dict):
+    """Replaces duplicate node indices that occur in a given connectivity."""
     new_conn = conn.copy().ravel()
 
     for idx, item in enumerate(new_conn):
@@ -103,5 +105,4 @@ def _merge_duplicate_node_indices_on_connectivity(conn, duplicate_dict):
 
     new_conn = new_conn.reshape(conn.shape)
 
-    # this might not be needed
     return new_conn

--- a/uxarray/grid/validation.py
+++ b/uxarray/grid/validation.py
@@ -63,6 +63,7 @@ def _check_duplicate_nodes_indices(grid):
 
     return False
 
+
 def _check_area(grid):
     """Check if each face area is greater than our constant ERROR_TOLERANCE."""
     areas = grid.face_areas
@@ -101,6 +102,7 @@ def _find_duplicate_nodes(grid):
             source_idx = indices[0]
             for duplicate_idx in indices[1:]:
                 duplicate_dict[duplicate_idx] = source_idx
+
 
 def _merge_duplicate_node_indices_on_connectivity(conn, duplicate_dict):
     """Replaces duplicate node indices that occur in a given connectivity."""

--- a/uxarray/grid/validation.py
+++ b/uxarray/grid/validation.py
@@ -80,6 +80,7 @@ def _check_area(grid):
 
 def _find_duplicate_nodes(grid):
     """Creates a dictionary mapping which node indices reference duplicates."""
+
     # list of tuple indices
     lonlat_t = [
         (lon, lat) for lon, lat in zip(grid.node_lon.values, grid.node_lat.values)
@@ -102,6 +103,8 @@ def _find_duplicate_nodes(grid):
             source_idx = indices[0]
             for duplicate_idx in indices[1:]:
                 duplicate_dict[duplicate_idx] = source_idx
+
+    return duplicate_dict
 
 
 def _merge_duplicate_node_indices_on_connectivity(conn, duplicate_dict):

--- a/uxarray/grid/validation.py
+++ b/uxarray/grid/validation.py
@@ -1,11 +1,11 @@
 import numpy as np
 from warnings import warn
 
-from uxarray.constants import ERROR_TOLERANCE
+from uxarray.constants import ERROR_TOLERANCE, INT_DTYPE
 
 
 # validation helper functions
-def _check_connectivity(self):
+def _check_connectivity(grid):
     """Check if all nodes are referenced by at least one element.
 
     If not, the mesh may have hanging nodes and may not a valid UGRID
@@ -14,28 +14,28 @@ def _check_connectivity(self):
 
     # Check if all nodes are referenced by at least one element
     # get unique nodes in connectivity
-    nodes_in_conn = np.unique(self.face_node_connectivity.values.flatten())
+    nodes_in_conn = np.unique(grid.face_node_connectivity.values.flatten())
     #  remove negative indices/fill values from the list
     nodes_in_conn = nodes_in_conn[nodes_in_conn >= 0]
 
     # check if the size of unique nodes in connectivity is equal to the number of nodes
-    if nodes_in_conn.size == self.n_node:
+    if nodes_in_conn.size == grid.n_node:
         print("-All nodes are referenced by at least one element.")
         return True
     else:
         warn(
             "Some nodes may not be referenced by any element. {0} and {1}".format(
-                nodes_in_conn.size, self.n_node
+                nodes_in_conn.size, grid.n_node
             ),
             RuntimeWarning,
         )
         return False
 
 
-def _check_duplicate_nodes(self):
+def _check_duplicate_nodes(grid):
     """Check if there are duplicate nodes in the mesh."""
 
-    coords1 = np.column_stack((np.vstack(self.node_lon), np.vstack(self.node_lat)))
+    coords1 = np.column_stack((np.vstack(grid.node_lon), np.vstack(grid.node_lat)))
     unique_nodes, indices = np.unique(coords1, axis=0, return_index=True)
     duplicate_indices = np.setdiff1d(np.arange(len(coords1)), indices)
 
@@ -52,9 +52,9 @@ def _check_duplicate_nodes(self):
         return True
 
 
-def _check_area(self):
+def _check_area(grid):
     """Check if each face area is greater than our constant ERROR_TOLERANCE."""
-    areas = self.face_areas
+    areas = grid.face_areas
     # Check if area of any face is close to zero
     if np.any(np.isclose(areas, 0, atol=ERROR_TOLERANCE)):
         warn(
@@ -65,3 +65,43 @@ def _check_area(self):
     else:
         print("-No face area is close to zero.")
         return True
+
+
+def _find_duplicate_nodes(grid):
+    # list of tuple indices
+    lonlat_t = [
+        (lon, lat) for lon, lat in zip(grid.node_lon.values, grid.node_lat.values)
+    ]
+
+    # dictionary to track first occurrence and later indices
+    occurrences = {}
+
+    # Iterate through the list and track occurrences
+    for index, tpl in enumerate(lonlat_t):
+        if tpl in occurrences:
+            occurrences[tpl].append((INT_DTYPE(index)))
+        else:
+            occurrences[tpl] = [INT_DTYPE(index)]
+
+    duplicate_dict = {}
+
+    for tpl, indices in occurrences.items():
+        if len(indices) > 1:
+            source_idx = indices[0]
+            for duplicate_idx in indices[1:]:
+                duplicate_dict[duplicate_idx] = source_idx
+
+    return duplicate_dict
+
+
+def _merge_duplicate_node_indices_on_connectivity(conn, duplicate_dict):
+    new_conn = conn.copy().ravel()
+
+    for idx, item in enumerate(new_conn):
+        if item in duplicate_dict:
+            new_conn[idx] = duplicate_dict[item]
+
+    new_conn = new_conn.reshape(conn.shape)
+
+    # this might not be needed
+    return new_conn


### PR DESCRIPTION
<!--  The PR title should summarize the changes, for example "Add `Grid._build_face_dimension` function".
      Avoid non-descriptive titles such as "Addresses issue #229". -->

<!--  Replace XXX with the number of the issue that this PR will resolve. If this PR closed more than one,
      you may add a comma separated sequence-->
Closes #865

## Overview
<!--  Please provide a few bullet points summarizing the changes in this PR. This should include
      points on any bug fixes, new functions, or other changes that have been made. -->
* Adds the `merge_duplicate_node_indices()` function that replaces the index of nodes that have the exact latitude and longitude to only reference one node.

## Expected Usage
<!--  If you are adding a feature into the Internal API, please produce a short example of it in action.
      You may ignore this step if it is not applicable (comment out this section). -->
```Python
import uxarray as ux

grid_path = "/path/to/grid.nc"

uxgrid = ux.open_grid(grid_path)

# inplace
uxgrid.merge_duplicate_node_indices()

# return a new grid
new_grid = uxgrid.merge_duplicate_node_indices(inplace=False)

```

