### PR TITLE
Fix #889: Remove .values in _slice_from_grid

### DIFF
--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -1077,17 +1077,17 @@ class UxDataArray(xr.DataArray):
         if self._face_centered():
             d_var = self.isel(
                 n_face=sliced_grid._ds["subgrid_face_indices"], ignore_grid=True
-            ).values
+            )
 
         elif self._edge_centered():
             d_var = self.isel(
                 n_edge=sliced_grid._ds["subgrid_edge_indices"], ignore_grid=True
-            ).values
+            )
 
         elif self._node_centered():
             d_var = self.isel(
                 n_node=sliced_grid._ds["subgrid_node_indices"], ignore_grid=True
-            ).values
+            )
 
         else:
             raise ValueError(


### PR DESCRIPTION
Collecting values after isel in _slice_from_grid needs to be avoided to keep the data in xarray/dask.

Fix UXARRAY/uxarray#889

## Overview
See #889 

## PR Checklist

**General**
- [x] An issue is linked created and linked
- [x] Add appropriate labels
- [x] Filled out Overview and Expected Usage (if applicable) sections

**Testing**
- [ ] Adequate tests are created if there is new functionality
- [ ] Tests cover all possible logical paths in your function
- [ ] Tests are not too basic (such as simply calling a function and nothing else)

**Documentation**
- [ ] Docstrings have been added to all new functions
- [ ] Docstrings have updated with any function changes
- [ ] Internal functions have a preceding underscore (`_`) and have been added to `docs/internal_api/index.rst`
- [ ] User functions have been added to `docs/user_api/index.rst`

**Examples**
- [ ] Any new notebook examples added to `docs/examples/` folder
- [ ] Clear the output of all cells before committing
- [ ] New notebook files added to `docs/examples.rst` toctree
- [ ] New notebook files added to new entry in `docs/gallery.yml` with appropriate thumbnail photo in `docs/_static/thumbnails/`
