### PR TITLE
Fix #906

### DIFF
--- a/uxarray/io/_ugrid.py
+++ b/uxarray/io/_ugrid.py
@@ -89,7 +89,7 @@ def _encode_ugrid(ds):
 
     grid_topology = ugrid.BASE_GRID_TOPOLOGY_ATTRS
 
-    if "n_edge" in ds:
+    if "n_edge" in ds.dims:
         grid_topology["edge_dimension"] = "n_edge"
 
     if "face_lon" in ds:


### PR DESCRIPTION
`_encode_ugrid` should check if `n_edge` exists in dimensions, not in variables.

Fixes UXARRAY/uxarray#906

## Overview
See the issue #906 

## Expected Usage
No change in usage

## PR Checklist
**General**
- [x] An issue is linked created and linked
- [x] Add appropriate labels
- [x] Filled out Overview and Expected Usage (if applicable) sections

**Testing**
- [ ] Adequate tests are created if there is new functionality
- [ ] Tests cover all possible logical paths in your function
- [ ] Tests are not too basic (such as simply calling a function and nothing else)

**Documentation**
- [ ] Docstrings have been added to all new functions
- [ ] Docstrings have updated with any function changes
- [ ] Internal functions have a preceding underscore (`_`) and have been added to `docs/internal_api/index.rst`
- [ ] User functions have been added to `docs/user_api/index.rst`

**Examples**
- [ ] Any new notebook examples added to `docs/examples/` folder
- [ ] Clear the output of all cells before committing
- [ ] New notebook files added to `docs/examples.rst` toctree
- [ ] New notebook files added to new entry in `docs/gallery.yml` with appropriate thumbnail photo in `docs/_static/thumbnails/`