### PR TITLE
Keep attrs when slicing a grid (feature #908)

### DIFF
--- a/uxarray/grid/slice.py
+++ b/uxarray/grid/slice.py
@@ -125,6 +125,7 @@ def _slice_face_indices(grid, indices, inclusive=True):
                     ds[conn_name].values
                 ),
                 dims=ds[conn_name].dims,
+                attrs=ds[conn_name].attrs,
             )
 
         elif "_connectivity" in conn_name:


### PR DESCRIPTION
The current `_slice_face_indices` does not copy dataarray attributes to a sliced grid. This change copies the attrs from the original dataarray to a sliced grid.

Closes #908

## Overview
As stated above.

## Expected Usage
No changes in usage

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->

**General**
- [x] An issue is linked created and linked
- [x] Add appropriate labels
- [x] Filled out Overview and Expected Usage (if applicable) sections

**Testing**
- [ ] Adequate tests are created if there is new functionality
- [ ] Tests cover all possible logical paths in your function
- [ ] Tests are not too basic (such as simply calling a function and nothing else)

**Documentation**
- [ ] Docstrings have been added to all new functions
- [ ] Docstrings have updated with any function changes
- [ ] Internal functions have a preceding underscore (`_`) and have been added to `docs/internal_api/index.rst`
- [ ] User functions have been added to `docs/user_api/index.rst`

**Examples**
- [ ] Any new notebook examples added to `docs/examples/` folder
- [ ] Clear the output of all cells before committing
- [ ] New notebook files added to `docs/examples.rst` toctree
- [ ] New notebook files added to new entry in `docs/gallery.yml` with appropriate thumbnail photo in `docs/_static/thumbnails/`