### PR TITLE
Add files to support git archives

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,3 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# allow installing from git archives
+.git_archival.txt  export-subst


### PR DESCRIPTION
Relates to #919

## Overview
Adds files to support using setuptools-scm on git archives to hopefully address the Conda versioning snafu.  These should prompt some metadata to be populated when archives are created allowing for things like the version info to be available when building from an archive. 

Related docs here: https://setuptools-scm.readthedocs.io/en/latest/usage/#git-archives

The contents differ slightly from what xarray does based on the current guidance in the docs.

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->

**General**
- [x] An issue is linked created and linked
- [ ] Add appropriate labels
- [ ] Filled out Overview and Expected Usage (if applicable) sections