### PR TITLE
Fix `vdim` Error in Plotting Routines 

### DIFF
--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -174,12 +174,14 @@ class UxDataArray(xr.DataArray):
                 exclude_antimeridian=exclude_antimeridian,
             )
 
+            var_name = self.name if self.name is not None else "var"
+
             if exclude_antimeridian:
-                gdf[self.name] = np.delete(
+                gdf[var_name] = np.delete(
                     self.values, self.uxgrid.antimeridian_face_indices, axis=0
                 )
             else:
-                gdf[self.name] = self.values
+                gdf[var_name] = self.values
             return gdf
 
         elif self.values.size == self.uxgrid.n_node:

--- a/uxarray/plot/dataarray_plot.py
+++ b/uxarray/plot/dataarray_plot.py
@@ -310,7 +310,9 @@ def _polygon_raster(
         exclude_antimeridian=exclude_antimeridian, cache=cache, override=override
     )
 
-    hv_polygons = hv.Polygons(gdf, vdims=[uxda.name])
+    hv_polygons = hv.Polygons(
+        gdf, vdims=[uxda.name if uxda.name is not None else "var"]
+    )
 
     uxarray.plot.utils.backend.assign(backend=backend)
 
@@ -393,7 +395,9 @@ def polygons(
         exclude_antimeridian=exclude_antimeridian, cache=cache, override=override
     )
 
-    hv_polygons = hv.Polygons(gdf, vdims=[uxda.name])
+    hv_polygons = hv.Polygons(
+        gdf, vdims=[uxda.name if uxda.name is not None else "var"]
+    )
 
     uxarray.plot.utils.backend.assign(backend=backend)
     if backend == "matplotlib":


### PR DESCRIPTION
<!--  The PR title should summarize the changes, for example "Add `Grid._build_face_dimension` function".
      Avoid non-descriptive titles such as "Addresses issue #229". -->

<!--  Replace XXX with the number of the issue that this PR will resolve. If this PR closed more than one,
      you may add a comma separated sequence-->

Fixes a plotting error when a `UxDataArray` has no name attached to it. Uses a default name for HoloViews compatibility. 

