### PR TITLE
take ICON edge node connectivity from grid file

### DIFF
--- a/docs/user-guide/grid-formats.rst
+++ b/docs/user-guide/grid-formats.rst
@@ -328,7 +328,7 @@ Connectivity
        <td class="no-cell">No</td>
        <td class="no-cell">No</td>
        <td class="no-cell">No</td>
-       <td class="no-cell">No</td>
+       <td class="yes-cell">Yes</td>
      </tr>
      <tr>
        <td>edge_edge</td>

--- a/uxarray/io/_icon.py
+++ b/uxarray/io/_icon.py
@@ -75,6 +75,13 @@ def _primal_to_ugrid(in_ds, out_ds):
         attrs=ugrid.EDGE_FACE_CONNECTIVITY_ATTRS,
     )
 
+    edge_node_connectivity = in_ds["edge_vertices"].T - 1
+    out_ds["edge_node_connectivity"] = xr.DataArray(
+        data=edge_node_connectivity,
+        dims=ugrid.EDGE_NODE_CONNECTIVITY_DIMS,
+        attrs=ugrid.EDGE_NODE_CONNECTIVITY_ATTRS,
+    )
+
     return out_ds, source_dims_dict
 
 


### PR DESCRIPTION
Saves a lot of time when reading a big ICON grid, as n_edge is used in _map_dims_to_ugrid, and will call _populate_edge_node_connectivity(self) if "edge_node_connectivity" is not defined.


Closes #XXX

## Overview
<!--  Please provide a few bullet points summarizing the changes in this PR. This should include
      points on any bug fixes, new functions, or other changes that have been made. -->


## Expected Usage
<!--  If you are adding a feature into the Internal API, please produce a short example of it in action.
      You may ignore this step if it is not applicable (comment out this section). -->
```Python
import uxarray as ux

from pathlib import Path
grid_file = Path(ux.__file__).parent.parent / 'test' / 'meshfiles' / "icon" / "R02B04" / 'icon_grid_0010_R02B04_G.nc'
ds = ux.open_dataset(grid_file, grid_file)
ds.uxgrid.edge_node_connectivity
```

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->

**General**
- [ ] An issue is linked created and linked
- [ ] Add appropriate labels
- [ ] Filled out Overview and Expected Usage (if applicable) sections

**Testing**
- [ ] Adequate tests are created if there is new functionality
- [ ] Tests cover all possible logical paths in your function
- [ ] Tests are not too basic (such as simply calling a function and nothing else)

**Documentation**
- [ ] Docstrings have been added to all new functions
- [ ] Docstrings have updated with any function changes
- [ ] Internal functions have a preceding underscore (`_`) and have been added to `docs/internal_api/index.rst`
- [ ] User functions have been added to `docs/user_api/index.rst`

**Examples**
- [ ] Any new notebook examples added to `docs/examples/` folder
- [ ] Clear the output of all cells before committing
- [ ] New notebook files added to `docs/examples.rst` toctree
- [ ] New notebook files added to new entry in `docs/gallery.yml` with appropriate thumbnail photo in `docs/_static/thumbnails/`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

**PR Etiquette Reminders**
- This PR should be listed as a draft PR until you are ready to request reviewers

- After making changes in accordance with the reviews, re-request your reviewers

- Do *not* mark conversations as resolved if you didn't start them

- Do mark conversations as resolved *if you opened them* and are satisfied with the changes/discussion.
-->
