### PR TITLE
Fix Typo in Grid Formats User Guide

### DIFF
--- a/docs/user-guide/grid-formats.rst
+++ b/docs/user-guide/grid-formats.rst
@@ -120,6 +120,11 @@ The Goddard Earth Observing System (GEOS) Cube Sphere (CS) grid format is equidi
 6 identical faces that wrap a sphere, with some number of grid cells per face. For example, a C720 GEOS-CS grid has
 6 faces, each with 720x720 elements.
 
+References
+----------
+* https://gmao.gsfc.nasa.gov/gmaoftp/ops/GEOSIT_sample/doc/CS_Description_c180_v1.pdf
+
+
 ICON
 ====
 The climate model ICON is the central research tool at the Max Planck Institute for Meteorology (MPI-M). CON, which
@@ -136,10 +141,6 @@ References
 ----------
 * https://mpimet.mpg.de/en/research/modeling
 * https://scivis2017.dkrz.de/hd-cp-2/en-icon_grid.pdf
-
-References
-----------
-* https://gmao.gsfc.nasa.gov/gmaoftp/ops/GEOSIT_sample/doc/CS_Description_c180_v1.pdf
 
 Parsed Variables
 ================


### PR DESCRIPTION
The references for the GEOS-CS grid were in the wrong spot.

<img width="845" alt="image" src="https://github.com/user-attachments/assets/e7f1a244-04b8-4805-8fbf-7c0303dd0792">
