### PR TITLE
Fix pickling error in Numba exception handling & improve cache checks

### DIFF
--- a/uxarray/__init__.py
+++ b/uxarray/__init__.py
@@ -1,9 +1,3 @@
-import uxarray.constants
-import sys
-#
-# # TODO: numba recursion limit ?
-
-
 from .core.api import open_grid, open_dataset, open_mfdataset
 
 from .core.dataset import UxDataset
@@ -25,23 +19,6 @@ except Exception:
     __version__ = "999"
 
 
-# Flag for enabling FMA instructions across the package
-def enable_fma():
-    """Enables Fused-Multiply-Add (FMA) instructions using the ``pyfma``
-    package."""
-    uxarray.constants.ENABLE_FMA = True
-
-
-def disable_fma():
-    """Disable Fused-Multiply-Add (FMA) instructions using the ``pyfma``
-    package."""
-    uxarray.constants.ENABLE_FMA = False
-
-
-disable_fma()
-sys.setrecursionlimit(10000)
-
-
 __all__ = (
     "open_grid",
     "open_dataset",
@@ -55,6 +32,4 @@ __all__ = (
     "diverging",
     "sequential_blue",
     "sequential_green",
-    "enable_fma",
-    "disable_fma",
 )

--- a/uxarray/grid/geometry.py
+++ b/uxarray/grid/geometry.py
@@ -827,9 +827,7 @@ def pole_point_inside_polygon(pole, face_edges_xyz, face_edges_lonlat):
         return ((north_intersections + south_intersections) % 2) != 0
 
     else:
-        raise ValueError(
-            f"Invalid pole point query. Current location: {location}, query pole point: {pole}"
-        )
+        raise ValueError("Invalid pole point query.")
 
 
 @njit(cache=True)

--- a/uxarray/grid/grid.py
+++ b/uxarray/grid/grid.py
@@ -95,6 +95,8 @@ from uxarray.grid.validation import (
     _check_normalization,
 )
 
+from uxarray.utils.numba import is_numba_function_cached
+
 
 from uxarray.conventions import ugrid
 
@@ -1367,13 +1369,12 @@ class Grid:
         Dimensions ``(n_face", two, two)``
         """
         if "bounds" not in self._ds:
-            if hasattr(compute_temp_latlon_array, "inspect_llvm"):
-                if len(compute_temp_latlon_array.inspect_llvm()) == 0:
-                    warn(
-                        "Necessary functions for computing face bounds are not translated yet with Numba. This initial"
-                        "translation may take some time.",
-                        RuntimeWarning,
-                    )
+            if not is_numba_function_cached(compute_temp_latlon_array):
+                warn(
+                    "Necessary functions for computing the bounds of each face are not yet compiled with Numba. "
+                    "This initial execution will be significantly longer.",
+                    RuntimeWarning,
+                )
 
             _populate_bounds(self)
 

--- a/uxarray/utils/numba.py
+++ b/uxarray/utils/numba.py
@@ -8,9 +8,13 @@ def is_numba_function_cached(func):
     Determines if a numba function is cached and up-to-date.
 
     Returns:
-        - True if cache exists and is valid
+        - True if cache exists and is valid or the input is not a Numba function.
         - False if cache doesn't exist or needs recompilation
     """
+
+    if not hasattr(func, "_cache"):
+        return True
+
     cache = func._cache
     cache_file = cache._cache_file
 

--- a/uxarray/utils/numba.py
+++ b/uxarray/utils/numba.py
@@ -1,0 +1,40 @@
+import os
+import pickle
+import numba
+
+
+def is_numba_function_cached(func):
+    """
+    Determines if a numba function is cached and up-to-date.
+
+    Returns:
+        - True if cache exists and is valid
+        - False if cache doesn't exist or needs recompilation
+    """
+    cache = func._cache
+    cache_file = cache._cache_file
+
+    # Check if cache file exists
+    full_path = os.path.join(cache._cache_path, cache_file._index_name)
+    if not os.path.isfile(full_path):
+        return False
+
+    try:
+        # Load and check version
+        with open(full_path, "rb") as f:
+            version = pickle.load(f)
+            if version != numba.__version__:
+                return False
+
+            # Load and check source stamp
+            data = f.read()
+            stamp, _ = pickle.loads(data)
+
+            # Get current source stamp
+            current_stamp = cache._impl.locator.get_source_stamp()
+
+            # Compare stamps
+            return stamp == current_stamp
+
+    except (OSError, pickle.PickleError):
+        return False


### PR DESCRIPTION
<!--  The PR title should summarize the changes, for example "Add `Grid._build_face_dimension` function".
      Avoid non-descriptive titles such as "Addresses issue #229". -->

<!--  Replace XXX with the number of the issue that this PR will resolve. If this PR closed more than one,
      you may add a comma separated sequence-->

## Overview
<!--  Please provide a few bullet points summarizing the changes in this PR. This should include
      points on any bug fixes, new functions, or other changes that have been made. -->
- Fixes a Pickle error due to formatted value errors.
- Adds better checks for checking if a Numba function is compiled

## Error
```

/glade/work/oero/conda-envs/hackathon0/lib/python3.12/site-packages/uxarray/grid/grid.py:1372: RuntimeWarning: Necessary functions for computing face bounds are not translated yet with Numba. This initialtranslation may take some time.
  warn(
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
File /glade/work/oero/conda-envs/hackathon0/lib/python3.12/site-packages/numba/core/pythonapi.py:1414, in PythonAPI.serialize_object(self, obj)
   1413 try:
-> 1414     gv = self.module.__serialized[obj]
   1415 except KeyError:

KeyError: (<class 'ValueError'>, (<ir.InsertValue 'inserted.parent.24' of type '{i8*, i64, i32, i32, i64, i8*, i8*}', opname 'insertvalue', operands [<ir.InsertValue 'inserted.meminfo.24' of type '{i8*, i64, i32, i32, i64, i8*, i8*}', opname 'insertvalue', operands [<ir.InsertValue 'inserted.hash.4' of type '{i8*, i64, i32, i32, i64, i8*, i8*}', opname 'insertvalue', operands [<ir.InsertValue 'inserted.is_ascii.4' of type '{i8*, i64, i32, i32, i64, i8*, i8*}', opname 'insertvalue', operands [<ir.InsertValue 'inserted.kind.4' of type '{i8*, i64, i32, i32, i64, i8*, i8*}', opname 'insertvalue', operands [<ir.InsertValue 'inserted.length.4' of type '{i8*, i64, i32, i32, i64, i8*, i8*}', opname 'insertvalue', operands [<ir.InsertValue 'inserted.data.24' of type '{i8*, i64, i32, i32, i64, i8*, i8*}', opname 'insertvalue', operands [<ir.Constant type='{i8*, i64, i32, i32, i64, i8*, i8*}' value=<llvmlite.ir.values._Undefined object at 0x153fcde29670>>, <ir.ExtractValue '.9360' of type 'i8*', opname 'extractvalue', operands [<ir.LoadInstr '.9359' of type '{i8*, i64, i32, i32, i64, i8*, i8*}', opname 'load', operands [<ir.AllocaInstr '.9345' of type '{i8*, i64, i32, i32, i64, i8*, i8*}*', opname 'alloca', operands ()>]>]>]>, <ir.ExtractValue '.9361' of type 'i64', opname 'extractvalue', operands [<ir.LoadInstr '.9359' of type '{i8*, i64, i32, i32, i64, i8*, i8*}', opname 'load', operands [<ir.AllocaInstr '.9345' of type '{i8*, i64, i32, i32, i64, i8*, i8*}*', opname 'alloca', operands ()>]>]>]>, <ir.ExtractValue '.9362' of type 'i32', opname 'extractvalue', operands [<ir.LoadInstr '.9359' of type '{i8*, i64, i32, i32, i64, i8*, i8*}', opname 'load', operands [<ir.AllocaInstr '.9345' of type '{i8*, i64, i32, i32, i64, i8*, i8*}*', opname 'alloca', operands ()>]>]>]>, <ir.ExtractValue '.9363' of type 'i32', opname 'extractvalue', operands [<ir.LoadInstr '.9359' of type '{i8*, i64, i32, i32, i64, i8*, i8*}', opname 'load', operands [<ir.AllocaInstr '.9345' of type '{i8*, i64, i32, i32, i64, i8*, i8*}*', opname 'alloca', operands ()>]>]>]>, <ir.ExtractValue '.9364' of type 'i64', opname 'extractvalue', operands [<ir.LoadInstr '.9359' of type '{i8*, i64, i32, i32, i64, i8*, i8*}', opname 'load', operands [<ir.AllocaInstr '.9345' of type '{i8*, i64, i32, i32, i64, i8*, i8*}*', opname 'alloca', operands ()>]>]>]>, <ir.ExtractValue '.9365' of type 'i8*', opname 'extractvalue', operands [<ir.LoadInstr '.9359' of type '{i8*, i64, i32, i32, i64, i8*, i8*}', opname 'load', operands [<ir.AllocaInstr '.9345' of type '{i8*, i64, i32, i32, i64, i8*, i8*}*', opname 'alloca', operands ()>]>]>]>, <ir.ExtractValue '.9366' of type 'i8*', opname 'extractvalue', operands [<ir.LoadInstr '.9359' of type '{i8*, i64, i32, i32, i64, i8*, i8*}', opname 'load', operands [<ir.AllocaInstr '.9345' of type '{i8*, i64, i32, i32, i64, i8*, i8*}*', opname 'alloca', operands ()>]>]>]>,), ('pole_point_inside_polygon', '/glade/work/oero/conda-envs/hackathon0/lib/python3.12/site-packages/uxarray/grid/geometry.py', 830))

During handling of the above exception, another exception occurred:
```


