### PR TITLE
Update `environment.yml` to fix ASV PR workflow 

### DIFF
--- a/benchmarks/mpas_ocean.py
+++ b/benchmarks/mpas_ocean.py
@@ -3,7 +3,6 @@ import urllib.request
 from pathlib import Path
 
 import numpy as np
-from polars.testing.parametric import dtypes
 
 import uxarray as ux
 

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - healpix
   - holoviews
   - hvplot
+  - hypothesis
   - matplotlib-base
   - matplotlib-inline
   - netcdf4


### PR DESCRIPTION
<!--  The PR title should summarize the changes, for example "Add `Grid._build_face_dimension` function".
      Avoid non-descriptive titles such as "Addresses issue #229". -->

<!--  Replace XXX with the number of the issue that this PR will resolve. If this PR closed more than one,
      you may add a comma separated sequence-->
Closes #XXX

## Overview
<!--  Please provide a few bullet points summarizing the changes in this PR. This should include
      points on any bug fixes, new functions, or other changes that have been made. -->
* Updates `enviroment.yml` to fix the failing ASV PR workflow 

## Failing Logs

<details>
  <summary>Click to expand</summary>

```bash
Run set -x
+ asv machine --yes
Couldn't load asv.plugins._mamba_helpers because
No module named 'libmambapy'
· No information stored about machine 'fv-az1951-526'. I know about nothing.
  

I will now ask you some questions about this machine to identify it in the benchmarks.

1. machine:  A unique name to identify this machine in the results.
   May be anything, as long as it is unique across all the machines
   used to benchmark this project.  NOTE: If changed from the default,
   it will no longer match the hostname of this machine, and you may
   need to explicitly use the --machine argument to asv.
machine [fv-az1951-526]: 2. os:  The OS type and version of this machine.  For example,
   'Macintosh OS-X 10.8'.
os [Linux 6.8.0-1021-azure]: 3. arch:  The generic CPU architecture of this machine.  For example,
   'i386' or 'x86_64'.
arch [x86_64]: 4. cpu:  A specific description of the CPU of this machine, including
   its speed and class.  For example, 'Intel(R) Core(TM) i5-25[20](https://github.com/UXARRAY/uxarray/actions/runs/13868139345/job/38811024639#step:4:21)M CPU
   @ 2.50GHz (4 cores)'.
cpu [AMD EPYC 7763 64-Core Processor]: 5. num_cpu:  The number of CPUs in the system. For example, '4'.
num_cpu [4]: 6. ram:  The amount of physical RAM on this machine.  For example,
   '4GB'.
+ echo 'Baseline:  33e0268ab377f79339c65137d68cca0052b024f6 (UXARRAY:main)'
ram [16373792]: Baseline:  33e0268ab377f79339c65137d68cca0052b024f6 (UXARRAY:main)
+ echo 'Contender: 011c031d8860a0ce9a64f31dbc[21](https://github.com/UXARRAY/uxarray/actions/runs/13868139345/job/38811024639#step:4:22)a1ee11a9c988 (hongyuchen1030:optimized_nonconservative_avg)'
+ ASV_OPTIONS='--split --show-stderr'
+ asv continuous --split --show-stderr 33e0268ab377f79339c65137d68cca0052b0[24](https://github.com/UXARRAY/uxarray/actions/runs/13868139345/job/38811024639#step:4:25)f6 011c031d8860a0ce9a64f31dbc21a1ee11a9c988
Contender: 011c031d8860a0ce9a64f31dbc21a1ee11a9c988 (hongyuchen1030:optimized_nonconservative_avg)
Couldn't load asv.plugins._mamba_helpers because
No module named 'libmambapy'
· Creating environments
· Discovering benchmarks
·· Uninstalling from conda-py3.11-netcdf4-pip+pyfma-setuptools_scm-xarray
·· Building 011c031d for conda-py3.11-netcdf4-pip+pyfma-setuptools_scm-xarray
·· Installing 011c031d into conda-py3.11-netcdf4-pip+pyfma-setuptools_scm-xarray
·· Error running /home/runner/work/uxarray/uxarray/benchmarks/env/15feb14d7498f85aa6c86cf1f9fb99aa/bin/python /home/runner/micromamba/envs/uxarray_build/lib/python3.13/site-packages/asv/benchmark.py discover /home/runner/work/uxarray/uxarray/benchmarks /tmp/tmpirbrswkn/result.json (exit status 1)
   STDOUT -------->
   
   STDERR -------->
   Traceback (most recent call last):
     File "/home/runner/micromamba/envs/uxarray_build/lib/python3.13/site-packages/asv/benchmark.py", line 80, in <module>
       main()
     File "/home/runner/micromamba/envs/uxarray_build/lib/python3.13/site-packages/asv/benchmark.py", line 72, in main
       commands[mode](args)
     File "/home/runner/work/uxarray/uxarray/benchmarks/env/15feb14d7498f85aa6c86cf1f9fb99aa/lib/python3.11/site-packages/asv_runner/discovery.py", line 310, in _discover
       list_benchmarks(benchmark_dir, fp)
     File "/home/runner/work/uxarray/uxarray/benchmarks/env/15feb14d7498f85aa6c86cf1f9fb99aa/lib/python3.11/site-packages/asv_runner/discovery.py", line 278, in list_benchmarks
       for benchmark in disc_benchmarks(root):
     File "/home/runner/work/uxarray/uxarray/benchmarks/env/15feb14d7498f85aa6c86cf1f9fb99aa/lib/python3.11/site-packages/asv_runner/discovery.py", line 144, in disc_benchmarks
       for module in disc_modules(root_name, ignore_import_errors=ignore_import_errors):
     File "/home/runner/work/uxarray/uxarray/benchmarks/env/15feb14d7498f85aa6c86cf1f9fb99aa/lib/python3.11/site-packages/asv_runner/discovery.py", line 109, in disc_modules
       yield from disc_modules(name, ignore_import_errors)
     File "/home/runner/work/uxarray/uxarray/benchmarks/env/15feb14d7498f85aa6c86cf1f9fb99aa/lib/python3.11/site-packages/asv_runner/discovery.py", line 98, in disc_modules
       module = importlib.import_module(module_name)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     File "/home/runner/work/uxarray/uxarray/benchmarks/env/15feb14d7498f85aa6c86cf1f9fb99aa/lib/python3.11/importlib/__init__.py", line 126, in import_module
       return _bootstrap._gcd_import(name[level:], package, level)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
     File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
     File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
     File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
     File "<frozen importlib._bootstrap_external>", line 940, in exec_module
     File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
     File "/home/runner/work/uxarray/uxarray/benchmarks/mpas_ocean.py", line 6, in <module>
       from polars.testing.parametric import dtypes
     File "/home/runner/work/uxarray/uxarray/benchmarks/env/15feb14d7498f85aa6c86cf1f9fb99aa/lib/python3.11/site-packages/polars/testing/parametric/__init__.py", line 8, in <module>
       raise ModuleNotFoundError(msg)
   ModuleNotFoundError: polars.testing.parametric requires the 'hypothesis' module
   Please install it using the command: pip install hypothesis

·· Failed: trying different commit/environment
·· Uninstalling from conda-py3.11-netcdf4-pip+pyfma-setuptools_scm-xarray
·· Building 33e0268a <v20[25](https://github.com/UXARRAY/uxarray/actions/runs/13868139345/job/38811024639#step:4:26).03.0> for conda-py3.11-netcdf4-pip+pyfma-setuptools_scm-xarray
·· Installing 33e0[26](https://github.com/UXARRAY/uxarray/actions/runs/13868139345/job/38811024639#step:4:27)8a <v2025.03.0> into conda-py3.11-netcdf4-pip+pyfma-setuptools_scm-xarray
·· Error running /home/runner/work/uxarray/uxarray/benchmarks/env/15feb14d7498f85aa6c86cf1f9fb99aa/bin/python /home/runner/micromamba/envs/uxarray_build/lib/python3.13/site-packages/asv/benchmark.py discover /home/runner/work/uxarray/uxarray/benchmarks /tmp/tmpwrq45b8j/result.json (exit status 1)
   STDOUT -------->
   
   STDERR -------->
   Traceback (most recent call last):
     File "/home/runner/micromamba/envs/uxarray_build/lib/python3.13/site-packages/asv/benchmark.py", line 80, in <module>
       main()
     File "/home/runner/micromamba/envs/uxarray_build/lib/python3.13/site-packages/asv/benchmark.py", line 72, in main
       commands[mode](args)
     File "/home/runner/work/uxarray/uxarray/benchmarks/env/15feb14d7498f85aa6c86cf1f9fb99aa/lib/python3.11/site-packages/asv_runner/discovery.py", line 310, in _discover
       list_benchmarks(benchmark_dir, fp)
     File "/home/runner/work/uxarray/uxarray/benchmarks/env/15feb14d7498f85aa6c86cf1f9fb99aa/lib/python3.11/site-packages/asv_runner/discovery.py", line [27](https://github.com/UXARRAY/uxarray/actions/runs/13868139345/job/38811024639#step:4:28)8, in list_benchmarks
       for benchmark in disc_benchmarks(root):
     File "/home/runner/work/uxarray/uxarray/benchmarks/env/15feb14d7498f85aa6c86cf1f9fb99aa/lib/python3.11/site-packages/asv_runner/discovery.py", line 144, in disc_benchmarks
       for module in disc_modules(root_name, ignore_import_errors=ignore_import_errors):
     File "/home/runner/work/uxarray/uxarray/benchmarks/env/15feb14d7498f85aa6c86cf1f9fb99aa/lib/python3.11/site-packages/asv_runner/discovery.py", line 109, in disc_modules
       yield from disc_modules(name, ignore_import_errors)
     File "/home/runner/work/uxarray/uxarray/benchmarks/env/15feb14d7498f85aa6c86cf1f9fb99aa/lib/python3.11/site-packages/asv_runner/discovery.py", line 98, in disc_modules
       module = importlib.import_module(module_name)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     File "/home/runner/work/uxarray/uxarray/benchmarks/env/15feb14d7498f85aa6c86cf1f9fb99aa/lib/python3.11/importlib/__init__.py", line 126, in import_module
       return _bootstrap._gcd_import(name[level:], package, level)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
     File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
     File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
     File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
     File "<frozen importlib._bootstrap_external>", line 940, in exec_module
     File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
     File "/home/runner/work/uxarray/uxarray/benchmarks/mpas_ocean.py", line 6, in <module>
       from polars.testing.parametric import dtypes
     File "/home/runner/work/uxarray/uxarray/benchmarks/env/15feb14d7498f85aa6c86cf1f9fb99aa/lib/python3.11/site-packages/polars/testing/parametric/__init__.py", line 8, in <module>
       raise ModuleNotFoundError(msg)
   ModuleNotFoundError: polars.testing.parametric requires the 'hypothesis' module
   Please install it using the command: pip install hypothesis

·· Failed to build the project and import the benchmark suite.
+ asv compare --split 33e0268ab377f79339c65137d68cca0052b024f6 011c0[31](https://github.com/UXARRAY/uxarray/actions/runs/13868139345/job/38811024639#step:4:32)d8860a0ce9a64f31dbc21a1ee11a9c988
Couldn't load asv.plugins._mamba_helpers because
No module named 'libmambapy'
```
</details>