### PR TITLE
Add `pull-request` permissions to ASV PR Workflow 

### DIFF
--- a/.github/workflows/asv-benchmarking-pr.yml
+++ b/.github/workflows/asv-benchmarking-pr.yml
@@ -2,6 +2,7 @@ name: ASV Benchmarking (PR)
 
 permissions:
   issues: write
+  pull-requests: write
 
 on:
   pull_request:


### PR DESCRIPTION
Adds `pull-request` permissions to `asv-benchmarking-pr.yml`