### PR TITLE
Use `n_max_face_nodes` instead of `n_max_face_edges` in Bounds construction 

### DIFF
--- a/uxarray/grid/geometry.py
+++ b/uxarray/grid/geometry.py
@@ -1413,7 +1413,7 @@ def _populate_bounds(
     faces_edges_cartesian = _get_cartesian_face_edge_nodes(
         grid.face_node_connectivity.values,
         grid.n_face,
-        grid.n_max_face_edges,
+        grid.n_max_face_nodes,
         grid.node_x.values,
         grid.node_y.values,
         grid.node_z.values,
@@ -1422,7 +1422,7 @@ def _populate_bounds(
     faces_edges_lonlat_rad = _get_lonlat_rad_face_edge_nodes(
         grid.face_node_connectivity.values,
         grid.n_face,
-        grid.n_max_face_edges,
+        grid.n_max_face_nodes,
         grid.node_lon.values,
         grid.node_lat.values,
     )


### PR DESCRIPTION
<!--  The PR title should summarize the changes, for example "Add `Grid._build_face_dimension` function".
      Avoid non-descriptive titles such as "Addresses issue #229". -->

<!--  Replace XXX with the number of the issue that this PR will resolve. If this PR closed more than one,
      you may add a comma separated sequence-->
Closes #1202 

## Overview
<!--  Please provide a few bullet points summarizing the changes in this PR. This should include
      points on any bug fixes, new functions, or other changes that have been made. -->
- Avoids triggering the computation of `Grid.face_edge_connectivity` when constructing the face edge coordinates.
- Improves the execution time (see #1202) when the connectivity is not present 