### PR TITLE
Remove min/max lat/lon print statement in spatialhash initialization

### DIFF
--- a/uxarray/grid/neighbors.py
+++ b/uxarray/grid/neighbors.py
@@ -822,9 +822,6 @@ class SpatialHash:
         self._xmax = lon_max + self._dh
         self._ymax = lat_max + self._dh
 
-        print(self._xmin, self._xmax)
-        print(self._ymin, self._ymax)
-
         # Number of x points in the hash grid; used for
         # array flattening
         Lx = self._xmax - self._xmin


### PR DESCRIPTION
## Overview
This PR is a simple patch that removes an annoying print statement in the spatial hash initialization that prints the min/max lat/lon values.