### PR TITLE
Changed np.atan2() to np.arctan2() arcs.py

### DIFF
--- a/uxarray/grid/arcs.py
+++ b/uxarray/grid/arcs.py
@@ -366,6 +366,6 @@ def compute_arc_length(pt_a, pt_b):
     rho = np.sqrt(1.0 - z1 * z2)
     cross_2d = x1 * y2 - y1 * x2
     dot_2d = x1 * x2 + y1 * y2
-    delta_theta = np.atan2(cross_2d, dot_2d)
+    delta_theta = np.arctan2(cross_2d, dot_2d)
 
     return rho * abs(delta_theta)

--- a/uxarray/grid/coordinates.py
+++ b/uxarray/grid/coordinates.py
@@ -53,7 +53,7 @@ def _xyz_to_lonlat_rad_no_norm(
         Latitude in radians
     """
 
-    lon = np.atan2(y, x)
+    lon = np.arctan2(y, x)
     lat = np.asin(z)
 
     # set longitude range to [0, pi]
@@ -76,7 +76,7 @@ def _xyz_to_lonlat_rad_scalar(x, y, z, normalize=True):
         y /= denom
         z /= denom
 
-    lon = np.atan2(y, x)
+    lon = np.arctan2(y, x)
     lat = np.asin(z)
 
     # Set longitude range to [0, 2*pi]
@@ -778,7 +778,7 @@ def _xyz_to_lonlat_rad_no_norm(
         Latitude in radians
     """
 
-    lon = np.atan2(y, x)
+    lon = np.arctan2(y, x)
     lat = np.asin(z)
 
     # set longitude range to [0, pi]


### PR DESCRIPTION
Closes #1206

This calls the equivalent underlying function but maintains backwards-compatibility with older numpy versions that didn't have atan2().

