### PR TITLE
Fix Numba Compilation Timeout in Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ build:
     post_checkout:
       - git fetch --unshallow || true
     pre_install:
-      - git update-index --assume-unchanged doc/conf.py ci/docs.yml
+      - git update-index --assume-unchanged docs/conf.py ci/docs.yml
     post_create_environment:
       - pip install . --no-deps -vv
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,7 +13,7 @@ build:
       - pip install . --no-deps -vv
 
 sphinx:
-  configuration: doc/conf.py
+  configuration: docs/conf.py
   fail_on_warning: false
 
 conda:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,21 +1,22 @@
-# .readthedocs.yml
-# Read the Docs configuration file
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
-
-# Required
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: ubuntu-lts-latest
   tools:
-    python: "mambaforge-4.10"
+    python: mambaforge-latest
   jobs:
+    post_checkout:
+      - git fetch --unshallow || true
+    pre_install:
+      - git update-index --assume-unchanged doc/conf.py ci/docs.yml
     post_create_environment:
       - pip install . --no-deps -vv
 
-# Build documentation in the docs/ directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: doc/conf.py
+  fail_on_warning: false
 
 conda:
   environment: ci/docs.yml
+
+formats: []

--- a/ci/docs.yml
+++ b/ci/docs.yml
@@ -2,7 +2,7 @@ name: uxarray-docs
 channels:
     - conda-forge
 dependencies:
-    - python=3.12
+    - python
     - dask
     - netcdf4
     - numba

--- a/ci/docs.yml
+++ b/ci/docs.yml
@@ -2,7 +2,7 @@ name: uxarray-docs
 channels:
     - conda-forge
 dependencies:
-    - python
+    - python=3.12
     - dask
     - netcdf4
     - numba

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,6 +80,9 @@ intersphinx_mapping = {
     "xarray": ("http://xarray.pydata.org/en/stable/", None),
 }
 
+# TODO: Update the timeout to allow for longer Numba functions to compile
+nbsphinx_timeout = -1
+
 remove_from_toctrees = ["generated/*"]
 
 napoleon_use_admonition_for_examples = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,8 +80,11 @@ intersphinx_mapping = {
     "xarray": ("http://xarray.pydata.org/en/stable/", None),
 }
 
-# TODO: Update the timeout to allow for longer Numba functions to compile
-nbsphinx_timeout = -1
+
+# Notebook execution
+nb_execution_timeout = 120
+nbsphinx_timeout = 120  # TODO
+
 
 remove_from_toctrees = ["generated/*"]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,10 +81,8 @@ intersphinx_mapping = {
 }
 
 
-# Notebook execution
+# Notebook execution (per cell)
 nb_execution_timeout = 120
-nbsphinx_timeout = 120  # TODO
-
 
 remove_from_toctrees = ["generated/*"]
 


### PR DESCRIPTION
<!--  The PR title should summarize the changes, for example "Add `Grid._build_face_dimension` function".
      Avoid non-descriptive titles such as "Addresses issue #229". -->

<!--  Replace XXX with the number of the issue that this PR will resolve. If this PR closed more than one,
      you may add a comma separated sequence-->

## Overview
<!--  Please provide a few bullet points summarizing the changes in this PR. This should include
      points on any bug fixes, new functions, or other changes that have been made. -->
- Resolves certain Numba cells timing out by increasing `nb_execution_timeout` value
  - [Bounding Box Subset](https://uxarray--1223.org.readthedocs.build/en/1223/user-guide/subset.html#bounding-box)
  - [Zonal Average](https://uxarray--1223.org.readthedocs.build/en/1223/user-guide/zonal-average.html)
- Updates RTD config to use the latest OS and Mamba version, consistent with [Xarray](https://github.com/pydata/xarray/blob/main/.readthedocs.yaml) 
