### PR TITLE
DRAFT: Support `ccrs.Geodetic` source projection, add Polygon plot to Grid 

### DIFF
--- a/test/test_plot.py
+++ b/test/test_plot.py
@@ -3,6 +3,7 @@ import uxarray as ux
 import holoviews as hv
 import pytest
 from pathlib import Path
+import cartopy.crs as ccrs
 
 current_path = Path(os.path.dirname(os.path.realpath(__file__)))
 
@@ -24,6 +25,7 @@ def test_topology():
         uxgrid.plot.mesh(backend=backend)
         uxgrid.plot.edges(backend=backend)
         uxgrid.plot.nodes(backend=backend)
+        uxgrid.plot.polygons(backend=backend)
         uxgrid.plot.node_coords(backend=backend)
         uxgrid.plot.corner_nodes(backend=backend)
         uxgrid.plot.face_centers(backend=backend)
@@ -97,3 +99,16 @@ def test_scatter():
     uxds = ux.open_dataset(gridfile_mpas, gridfile_mpas)
     _plot_line = uxds['bottomDepth'].zonal_average().plot.scatter()
     assert isinstance(_plot_line, hv.Scatter)
+
+
+def test_geodetic():
+    uxds = ux.open_dataset(gridfile_mpas, gridfile_mpas)
+    crs = ccrs.Geodetic()
+
+    _plot_grid = uxds.uxgrid.plot(crs=crs)
+
+    assert isinstance(_plot_grid, hv.Path)
+
+    _plot_da =  uxds['bottomDepth'].plot(crs=crs)
+
+    assert isinstance(_plot_da, hv.Image)

--- a/uxarray/plot/accessor.py
+++ b/uxarray/plot/accessor.py
@@ -250,9 +250,10 @@ class GridPlotAccessor:
             engine=engine,
             project=False,
         )
-
-        # Use the index of each face as its color
         data = np.arange(self._uxgrid.n_face)
+        if periodic_elements == "exclude":
+            data = np.delete(data, self._uxgrid.antimeridian_face_indices)
+
         gdf = gdf.assign(data=data)
 
         return gdf.hvplot.polygons(

--- a/uxarray/plot/accessor.py
+++ b/uxarray/plot/accessor.py
@@ -235,11 +235,10 @@ class GridPlotAccessor:
         engine="spatialpandas",
         rasterize=False,
         geo=True,
-        clabel="face index",
-        cmap="viridis",
+        fill=None,
         **kwargs,
     ):
-        """Plots the faces of the grid as polygons, shaded by their index."""
+        """Plots the faces of the grid as polygons, shaded by their face index."""
         uxarray.plot.utils.backend.assign(backend)
 
         kwargs, periodic_elements = check_crs(kwargs, periodic_elements)
@@ -250,15 +249,20 @@ class GridPlotAccessor:
             engine=engine,
             project=False,
         )
-        data = np.arange(self._uxgrid.n_face)
-        if periodic_elements == "exclude":
-            data = np.delete(data, self._uxgrid.antimeridian_face_indices)
 
-        gdf = gdf.assign(data=data)
+        if fill == "face_index":
+            data = np.arange(self._uxgrid.n_face)
+            if periodic_elements == "exclude":
+                data = np.delete(data, self._uxgrid.antimeridian_face_indices)
 
-        return gdf.hvplot.polygons(
-            c="data", cmap=cmap, rasterize=rasterize, geo=geo, clabel=clabel, **kwargs
-        )
+            kwargs["clabel"] = kwargs.get("clabel", "face index")
+            kwargs["title"] = kwargs.get("title", "Polygons shaded by face index")
+            kwargs["colorbar"] = kwargs.get("colorbar", True)
+            kwargs["cmap"] = kwargs.get("cmap", "viridis")
+            gdf = gdf.assign(polygons=data)
+            kwargs["c"] = "polygons"
+
+        return gdf.hvplot.polygons(rasterize=rasterize, geo=geo, **kwargs)
 
     def face_degree_distribution(
         self,

--- a/uxarray/plot/utils.py
+++ b/uxarray/plot/utils.py
@@ -1,5 +1,20 @@
+import cartopy.crs as ccrs
 import holoviews as hv
 import matplotlib as mpl
+
+
+def check_crs(kwargs, periodic_elements="exclude"):
+    """Sets default parameters based off the crs that is passed in."""
+    if "crs" in kwargs:
+        if kwargs["crs"] == ccrs.Geodetic():
+            kwargs["projection"] = kwargs.get("projection", ccrs.PlateCarree())
+            kwargs["project"] = True
+            # Allows geodetic crs to handle antimeridian wrapping
+            periodic_elements = "ignore"
+        else:
+            kwargs["crs"] = ccrs.PlateCarree()
+
+    return kwargs, periodic_elements
 
 
 class HoloviewsBackend:

--- a/uxarray/plot/utils.py
+++ b/uxarray/plot/utils.py
@@ -6,7 +6,7 @@ import matplotlib as mpl
 def check_crs(kwargs, periodic_elements="exclude"):
     """Sets default parameters based off the crs that is passed in."""
     if "crs" in kwargs:
-        if kwargs["crs"] == ccrs.Geodetic():
+        if isinstance(kwargs["crs"], ccrs.Geodetic):
             kwargs["projection"] = kwargs.get("projection", ccrs.PlateCarree())
             kwargs["project"] = True
             # Allows geodetic crs to handle antimeridian wrapping


### PR DESCRIPTION
<!--  The PR title should summarize the changes, for example "Add `Grid._build_face_dimension` function".
      Avoid non-descriptive titles such as "Addresses issue #229". -->

<!--  Replace XXX with the number of the issue that this PR will resolve. If this PR closed more than one,
      you may add a comma separated sequence-->
Closes #1230

## Overview
<!--  Please provide a few bullet points summarizing the changes in this PR. This should include
      points on any bug fixes, new functions, or other changes that have been made. -->
- Adds support for using Cartopy's `Geodetic` projection as a source projection, allowing for better visualization of grids on the surface of a sphere and for handling splitting along the dateline: https://github.com/holoviz/geoviews/issues/107
- Using the Geodetic projection is especially useful for coarser grids where the distortion is more noticeable, and over the poles 
- Implements a `Grid.plot.polygons()` method that plots shaded polygons using the index of each face. 

## Examples

### No Source Projection

![image](https://github.com/user-attachments/assets/60f2d66e-7fe0-4816-b96b-7b65141b7819)


### Geodetic Source Projection

![image](https://github.com/user-attachments/assets/5d1b84e3-2226-469d-8aeb-e2cb94eaea66)


