### PR TITLE
Derive HEALPix area and add missing parameter to `UxDataset.from_healpix()`

### DIFF
--- a/test/test_healpix.py
+++ b/test/test_healpix.py
@@ -3,6 +3,7 @@ import healpix as hp
 import pytest
 import os
 from pathlib import Path
+import numpy as np
 
 
 current_path = Path(os.path.dirname(os.path.realpath(__file__)))
@@ -18,6 +19,10 @@ def test_to_ugrid(resolution_level):
     expected_n_face = hp.nside2npix(hp.order2nside(resolution_level))
 
     assert uxgrid.n_face == expected_n_face
+
+    n_side = uxgrid._ds.attrs["n_side"]
+    expected_area = np.ones(uxgrid.n_face) * np.pi / 3 * n_side**2
+    assert np.array_equal(uxgrid.face_areas.values, expected_area)
 
 @pytest.mark.parametrize("resolution_level", [0, 1, 2, 3])
 def test_boundaries(resolution_level):
@@ -41,6 +46,9 @@ def test_dataset():
 
     assert uxds.uxgrid.source_grid_spec == "HEALPix"
     assert "n_face" in uxds.dims
+
+    uxds = ux.UxDataset.from_healpix(ds_path, pixels_only=False)
+    assert "face_node_connectivity" in uxds.uxgrid._ds
 
 
 

--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -282,7 +282,9 @@ class UxDataset(xr.Dataset):
         return cls(ds, uxgrid=uxgrid)
 
     @classmethod
-    def from_healpix(cls, ds: Union[str, os.PathLike, xr.Dataset], **kwargs):
+    def from_healpix(
+        cls, ds: Union[str, os.PathLike, xr.Dataset], pixels_only: bool = True, **kwargs
+    ):
         """
         Loads a dataset represented in the HEALPix format into a ``ux.UxDataSet``, paired
         with a ``Grid`` containing information about the HEALPix definition.
@@ -291,6 +293,8 @@ class UxDataset(xr.Dataset):
         ----------
         ds: str, os.PathLike, xr.Dataset
             Reference to a HEALPix Dataset
+                pixels_only : bool
+        Whether to only compute pixels (`face_lon`, `face_lat`) or to also construct boundaries (`face_node_connectivity`, `node_lon`, `node_lat`)
 
         Returns
         -------
@@ -308,7 +312,7 @@ class UxDataset(xr.Dataset):
         zoom = np.emath.logn(4, (ds.sizes["cell"] / 12)).astype(int)
 
         # Attach a  HEALPix Grid
-        uxgrid = Grid.from_healpix(zoom)
+        uxgrid = Grid.from_healpix(zoom, pixels_only=pixels_only)
 
         return cls.from_xarray(ds, uxgrid, {"cell": "n_face"})
 

--- a/uxarray/grid/grid.py
+++ b/uxarray/grid/grid.py
@@ -1902,8 +1902,11 @@ class Grid:
         array([0.00211174, 0.00211221, 0.00210723, ..., 0.00210723, 0.00211221,
             0.00211174])
         """
-        # if self._face_areas is None: # this allows for using the cached result,
-        # but is not the expected behavior behavior as we are in need to recompute if this function is called with different quadrature_rule or order
+        if self.source_grid_spec == "HEALPix":
+            # Derive HEALPix Area
+            n_side = self._ds.attrs["n_side"]
+            face_area = np.pi / 3 * n_side**2
+            return np.ones(self.n_face) * face_area, None
 
         self.normalize_cartesian_coordinates()
         x = self.node_x.values


### PR DESCRIPTION
<!--  The PR title should summarize the changes, for example "Add `Grid._build_face_dimension` function".
      Avoid non-descriptive titles such as "Addresses issue #229". -->

<!--  Replace XXX with the number of the issue that this PR will resolve. If this PR closed more than one,
      you may add a comma separated sequence-->
Closes #XXX

## Overview
<!--  Please provide a few bullet points summarizing the changes in this PR. This should include
      points on any bug fixes, new functions, or other changes that have been made. -->
- Derives the HEALPix area for each pixel instead of computing it internally
- Adds the `pixels_only` parameter to `UxDataset.from_healpix()`