### PR TITLE
Add `pixels_only` parameter to `UxDataset.from_healpix()`

### DIFF
--- a/test/test_healpix.py
+++ b/test/test_healpix.py
@@ -42,6 +42,9 @@ def test_dataset():
     assert uxds.uxgrid.source_grid_spec == "HEALPix"
     assert "n_face" in uxds.dims
 
+    uxds = ux.UxDataset.from_healpix(ds_path, pixels_only=False)
+    assert "face_node_connectivity" in uxds.uxgrid._ds
+
 
 
 def test_number_of_boundary_nodes():

--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -282,7 +282,9 @@ class UxDataset(xr.Dataset):
         return cls(ds, uxgrid=uxgrid)
 
     @classmethod
-    def from_healpix(cls, ds: Union[str, os.PathLike, xr.Dataset], **kwargs):
+    def from_healpix(
+        cls, ds: Union[str, os.PathLike, xr.Dataset], pixels_only: bool = True, **kwargs
+    ):
         """
         Loads a dataset represented in the HEALPix format into a ``ux.UxDataSet``, paired
         with a ``Grid`` containing information about the HEALPix definition.
@@ -291,6 +293,8 @@ class UxDataset(xr.Dataset):
         ----------
         ds: str, os.PathLike, xr.Dataset
             Reference to a HEALPix Dataset
+        pixels_only : bool
+            Whether to only compute pixels (`face_lon`, `face_lat`) or to also construct boundaries (`face_node_connectivity`, `node_lon`, `node_lat`)
 
         Returns
         -------
@@ -308,7 +312,7 @@ class UxDataset(xr.Dataset):
         zoom = np.emath.logn(4, (ds.sizes["cell"] / 12)).astype(int)
 
         # Attach a  HEALPix Grid
-        uxgrid = Grid.from_healpix(zoom)
+        uxgrid = Grid.from_healpix(zoom, pixels_only=pixels_only, **kwargs)
 
         return cls.from_xarray(ds, uxgrid, {"cell": "n_face"})
 


### PR DESCRIPTION
<!--  The PR title should summarize the changes, for example "Add `Grid._build_face_dimension` function".
      Avoid non-descriptive titles such as "Addresses issue #229". -->

<!--  Replace XXX with the number of the issue that this PR will resolve. If this PR closed more than one,
      you may add a comma separated sequence-->

## Overview
<!--  Please provide a few bullet points summarizing the changes in this PR. This should include
      points on any bug fixes, new functions, or other changes that have been made. -->
- Adds the `pixels_only` parameter, which was previously left out. 
