### PR TITLE
Use `isel` in Zonal Average 

### DIFF
--- a/test/test_zonal.py
+++ b/test/test_zonal.py
@@ -88,3 +88,14 @@ class TestZonalCSne30:
 
         assert len(uxds['psi'].zonal_mean(lat=1)) == 1
         assert len(uxds['psi'].zonal_mean(lat=(-90, 90, 1))) == 181
+
+
+
+def test_mismatched_dims():
+    uxgrid = ux.Grid.from_healpix(zoom=0)
+    uxda = ux.UxDataArray(np.ones((10, uxgrid.n_face, 5)), dims=['a', 'n_face', 'b'], uxgrid=uxgrid)
+
+    za = uxda.zonal_average()
+
+    assert za.shape == (10, 19, 5)
+    assert za.dims[1] == "latitudes"

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -482,14 +482,16 @@ class UxDataArray(xr.DataArray):
             uxda=self, latitudes=latitudes, **kwargs
         )
 
-        dims = list(self.dims[:-1]) + ["latitudes"]
+        face_axis = self.dims.index("n_face")
+        dims = list(self.dims)
+        dims[face_axis] = "latitudes"
 
         uxda = UxDataArray(
             res,
             uxgrid=self.uxgrid,
             dims=dims,
             coords={"latitudes": latitudes},
-            name=self.name + "_zonal_mean" if self.name is not None else "zonal_mean",
+            name=(self.name or "data") + "_zonal_mean",
             attrs={"zonal_mean": True},
         )
 

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -491,7 +491,7 @@ class UxDataArray(xr.DataArray):
             uxgrid=self.uxgrid,
             dims=dims,
             coords={"latitudes": latitudes},
-            name=(self.name or "data") + "_zonal_mean",
+            name=self.name + "_zonal_mean" if self.name is not None else "zonal_mean",
             attrs={"zonal_mean": True},
         )
 

--- a/uxarray/core/zonal.py
+++ b/uxarray/core/zonal.py
@@ -9,13 +9,20 @@ def _compute_non_conservative_zonal_mean(uxda, latitudes, use_robust_weights=Fal
     """Computes the non-conservative zonal mean across one or more latitudes."""
     uxgrid = uxda.uxgrid
     n_nodes_per_face = uxgrid.n_nodes_per_face.values
-    shape = uxda.shape[:-1] + (len(latitudes),)
+
+    face_axis = uxda.get_axis_num("n_face")
+
+    shape = list(uxda.shape)
+    shape[face_axis] = len(latitudes)
+
     if isinstance(uxda.data, da.Array):
         # Create a Dask array for storing results
         result = da.zeros(shape, dtype=uxda.dtype)
     else:
         # Create a NumPy array for storing results
         result = np.zeros(shape, dtype=uxda.dtype)
+
+    print(result.shape)
 
     faces_edge_nodes_xyz = _get_cartesian_face_edge_nodes_array(
         uxgrid.face_node_connectivity.values,
@@ -30,30 +37,27 @@ def _compute_non_conservative_zonal_mean(uxda, latitudes, use_robust_weights=Fal
 
     for i, lat in enumerate(latitudes):
         face_indices = uxda.uxgrid.get_faces_at_constant_latitude(lat)
-
         z = np.sin(np.deg2rad(lat))
 
-        faces_edge_nodes_xyz_candidate = faces_edge_nodes_xyz[face_indices, :, :, :]
-
-        n_nodes_per_face_candidate = n_nodes_per_face[face_indices]
-
-        bounds_candidate = bounds[face_indices]
+        fe = faces_edge_nodes_xyz[face_indices]
+        nn = n_nodes_per_face[face_indices]
+        b = bounds[face_indices]
 
         if use_robust_weights:
-            weights = _zonal_face_weights_robust(
-                faces_edge_nodes_xyz_candidate, z, bounds_candidate
-            )["weight"].to_numpy()
+            w = _zonal_face_weights_robust(fe, z, b)["weight"].to_numpy()
         else:
-            weights = _zonal_face_weights(
-                faces_edge_nodes_xyz_candidate,
-                bounds_candidate,
-                n_nodes_per_face_candidate,
-                z,
-            )
+            w = _zonal_face_weights(fe, b, nn, z)
 
-        total_weight = weights.sum()
-        result[..., i] = ((uxda.data[..., face_indices] * weights) / total_weight).sum(
-            axis=-1
-        )
+        total = w.sum()
+
+        data_slice = uxda.isel(n_face=face_indices, ignore_grid=True).data
+        w_shape = [1] * data_slice.ndim
+        w_shape[face_axis] = w.size
+        w_reshaped = w.reshape(w_shape)
+        weighted = (data_slice * w_reshaped).sum(axis=face_axis) / total
+
+        idx = [slice(None)] * result.ndim
+        idx[face_axis] = i
+        result[tuple(idx)] = weighted
 
     return result

--- a/uxarray/core/zonal.py
+++ b/uxarray/core/zonal.py
@@ -22,8 +22,6 @@ def _compute_non_conservative_zonal_mean(uxda, latitudes, use_robust_weights=Fal
         # Create a NumPy array for storing results
         result = np.zeros(shape, dtype=uxda.dtype)
 
-    print(result.shape)
-
     faces_edge_nodes_xyz = _get_cartesian_face_edge_nodes_array(
         uxgrid.face_node_connectivity.values,
         uxgrid.n_face,


### PR DESCRIPTION
## Overview 
- Fixes a bug in `zonal_average()` that would cause it to fail if the final dimension was not `n_face`