### PR TITLE
Ensure cartesian coordinates are normalized when constructing a KDTree

### DIFF
--- a/uxarray/grid/grid.py
+++ b/uxarray/grid/grid.py
@@ -1737,6 +1737,7 @@ class Grid:
             )
 
         if reconstruct or coordinates not in self._kdtrees:
+            self.normalize_cartesian_coordinates()
             x = getattr(self, f"{coordinates}_x").values
             y = getattr(self, f"{coordinates}_y").values
             z = getattr(self, f"{coordinates}_z").values

--- a/uxarray/remap/utils.py
+++ b/uxarray/remap/utils.py
@@ -176,6 +176,7 @@ def _prepare_points(grid, element_dim):
     ValueError
         If `element_dim` is not in `KDTREE_DIM_MAP`.
     """
+    grid.normalize_cartesian_coordinates()
     element_dim = KDTREE_DIM_MAP[element_dim]
     return np.vstack(
         [


### PR DESCRIPTION
## Overview
- Fixes a critical bug that would allow for a `KDTree` to be build with un-normalized cartesian coordinates, which would cause severe performance issues when doing a query with normalized coordinates 