### PR TITLE
Add `UxDataArray.from_healpix()` and support different face dimensions 

### DIFF
--- a/test/test_healpix.py
+++ b/test/test_healpix.py
@@ -1,7 +1,9 @@
 import uxarray as ux
 import healpix as hp
+import numpy as np
 import pytest
 import os
+import xarray as xr
 from pathlib import Path
 
 
@@ -54,3 +56,27 @@ def test_number_of_boundary_nodes():
 
     assert n_face == uxgrid.n_face
     assert n_max_face_nodes == uxgrid.n_max_face_nodes
+
+
+def test_from_healpix_healpix():
+    xrda = xr.DataArray(data=np.ones(12), dims=['cell'])
+    uxda = ux.UxDataArray.from_healpix(xrda)
+    assert isinstance(uxda, ux.UxDataArray)
+    xrda = xrda.rename({'cell': 'n_face'})
+    with pytest.raises(ValueError):
+        uxda = ux.UxDataArray.from_healpix(xrda)
+
+
+    uxda = ux.UxDataArray.from_healpix(xrda, face_dim="n_face")
+    assert isinstance(uxda, ux.UxDataArray)
+
+def test_from_healpix_dataset():
+    xrda = xr.DataArray(data=np.ones(12), dims=['cell']).to_dataset(name='cell')
+    uxda = ux.UxDataset.from_healpix(xrda)
+    assert isinstance(uxda, ux.UxDataset)
+    xrda = xrda.rename({'cell': 'n_face'})
+    with pytest.raises(ValueError):
+        uxda = ux.UxDataset.from_healpix(xrda)
+
+    uxda = ux.UxDataset.from_healpix(xrda, face_dim="n_face")
+    assert isinstance(uxda, ux.UxDataset)

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -1309,6 +1309,50 @@ class UxDataArray(xr.DataArray):
 
         return cls(ds, uxgrid=uxgrid)
 
+    @classmethod
+    def from_healpix(
+        cls,
+        da: xr.DataArray,
+        pixels_only: bool = True,
+        face_dim: str = "cell",
+        **kwargs,
+    ):
+        """
+        Loads a data array represented in the HEALPix format into a ``ux.UxDataArray``, paired
+        with a ``Grid`` containing information about the HEALPix definition.
+
+        Parameters
+        ----------
+        da: xr.DataArray
+            Reference to a HEALPix DataArray
+        pixels_only : bool, optional
+            Whether to only compute pixels (`face_lon`, `face_lat`) or to also construct boundaries (`face_node_connectivity`, `node_lon`, `node_lat`)
+        face_dim: str, optional
+            Data dimension corresponding to the HEALPix face mapping. Typically, is set to "cell", but may differ.
+
+        Returns
+        -------
+        cls
+            A ``ux.UxDataArray`` instance
+        """
+
+        if not isinstance(da, xr.DataArray):
+            raise ValueError("`da` must be a xr.DataArray")
+
+        if face_dim not in da.dims:
+            raise ValueError(
+                f"The provided face dimension '{face_dim}' is present in the provided healpix data array."
+                f"Please set 'face_dim' to the dimension corresponding to the healpix face dimension."
+            )
+
+        # Compute the HEALPix Zoom Level
+        zoom = np.emath.logn(4, (da.sizes[face_dim] / 12)).astype(int)
+
+        # Attach a  HEALPix Grid
+        uxgrid = Grid.from_healpix(zoom, pixels_only=pixels_only, **kwargs)
+
+        return cls.from_xarray(da, uxgrid, {face_dim: "n_face"})
+
     def _slice_from_grid(self, sliced_grid):
         """Slices a  ``UxDataArray`` from a sliced ``Grid``, using cached
         indices to correctly slice the data variable."""

--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -283,7 +283,11 @@ class UxDataset(xr.Dataset):
 
     @classmethod
     def from_healpix(
-        cls, ds: Union[str, os.PathLike, xr.Dataset], pixels_only: bool = True, **kwargs
+        cls,
+        ds: Union[str, os.PathLike, xr.Dataset],
+        pixels_only: bool = True,
+        face_dim: str = "cell",
+        **kwargs,
     ):
         """
         Loads a dataset represented in the HEALPix format into a ``ux.UxDataSet``, paired
@@ -293,8 +297,10 @@ class UxDataset(xr.Dataset):
         ----------
         ds: str, os.PathLike, xr.Dataset
             Reference to a HEALPix Dataset
-        pixels_only : bool
+        pixels_only : bool, optional
             Whether to only compute pixels (`face_lon`, `face_lat`) or to also construct boundaries (`face_node_connectivity`, `node_lon`, `node_lat`)
+        face_dim: str, optional
+            Data dimension corresponding to the HEALPix face mapping. Typically, is set to "cell", but may differ.
 
         Returns
         -------
@@ -305,16 +311,19 @@ class UxDataset(xr.Dataset):
         if not isinstance(ds, xr.Dataset):
             ds = xr.open_dataset(ds, **kwargs)
 
-        if "cell" not in ds.dims:
-            raise ValueError("Healpix dataset must contain a 'cell' dimension.")
+        if face_dim not in ds.dims:
+            raise ValueError(
+                f"The provided face dimension '{face_dim}' is present in the provided healpix dataset."
+                f"Please set 'face_dim' to the dimension corresponding to the healpix face dimension."
+            )
 
         # Compute the HEALPix Zoom Level
-        zoom = np.emath.logn(4, (ds.sizes["cell"] / 12)).astype(int)
+        zoom = np.emath.logn(4, (ds.sizes[face_dim] / 12)).astype(int)
 
         # Attach a  HEALPix Grid
         uxgrid = Grid.from_healpix(zoom, pixels_only=pixels_only, **kwargs)
 
-        return cls.from_xarray(ds, uxgrid, {"cell": "n_face"})
+        return cls.from_xarray(ds, uxgrid, {face_dim: "n_face"})
 
     def info(self, buf: IO = None, show_attrs=False) -> None:
         """Concise summary of Dataset variables and attributes including grid

--- a/uxarray/core/utils.py
+++ b/uxarray/core/utils.py
@@ -12,10 +12,7 @@ def _map_dims_to_ugrid(
     remaps the original dimension name to match the UGRID conventions (i.e.
     "nCell": "n_face")"""
 
-    if grid.source_grid_spec == "HEALPix":
-        ds = ds.swap_dims({"cell": "n_face"})
-
-    elif grid.source_grid_spec == "Structured":
+    if grid.source_grid_spec == "Structured":
         # Case for structured grids, flatten bottom two sptial dimensions
 
         lon_name, lat_name = _source_dims_dict["n_face"]


### PR DESCRIPTION
## Overview
- Adds a `ux.UxDataArray.from_healpix()` method
- Allows the user to specify the HEALPix face dimension, which was hard coded as `cell` 