### PR TITLE
Add safeguards to only allow global HEALPix data

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -201,6 +201,7 @@ I/O & Conversion
    UxDataArray.to_polycollection
    UxDataArray.to_dataset
    UxDataArray.from_xarray
+   UxDataArray.from_healpix
 
 
 UxDataset

--- a/test/test_healpix.py
+++ b/test/test_healpix.py
@@ -80,3 +80,10 @@ def test_from_healpix_dataset():
 
     uxda = ux.UxDataset.from_healpix(xrda, face_dim="n_face")
     assert isinstance(uxda, ux.UxDataset)
+
+
+def test_invalid_cells():
+    # 11 is not a valid number of global cells
+    xrda = xr.DataArray(data=np.ones(11), dims=['cell']).to_dataset(name='cell')
+    with pytest.raises(ValueError):
+        uxda = ux.UxDataset.from_healpix(xrda)

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -26,6 +26,7 @@ from uxarray.formatting_html import array_repr
 from uxarray.grid import Grid
 from uxarray.grid.dual import construct_dual
 from uxarray.grid.validation import _check_duplicate_nodes_indices
+from uxarray.io._healpix import get_zoom_from_cells
 from uxarray.plot.accessor import UxDataArrayPlotAccessor
 from uxarray.remap.accessor import RemapAccessor
 from uxarray.subset import DataArraySubsetAccessor
@@ -1345,11 +1346,12 @@ class UxDataArray(xr.DataArray):
                 f"Please set 'face_dim' to the dimension corresponding to the healpix face dimension."
             )
 
-        # Compute the HEALPix Zoom Level
-        zoom = np.emath.logn(4, (da.sizes[face_dim] / 12)).astype(int)
-
-        # Attach a  HEALPix Grid
-        uxgrid = Grid.from_healpix(zoom, pixels_only=pixels_only, **kwargs)
+        # Attach a HEALPix Grid
+        uxgrid = Grid.from_healpix(
+            zoom=get_zoom_from_cells(da.sizes[face_dim]),
+            pixels_only=pixels_only,
+            **kwargs,
+        )
 
         return cls.from_xarray(da, uxgrid, {face_dim: "n_face"})
 

--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -19,6 +19,7 @@ from uxarray.formatting_html import dataset_repr
 from uxarray.grid import Grid
 from uxarray.grid.dual import construct_dual
 from uxarray.grid.validation import _check_duplicate_nodes_indices
+from uxarray.io._healpix import get_zoom_from_cells
 from uxarray.plot.accessor import UxDatasetPlotAccessor
 from uxarray.remap.accessor import RemapAccessor
 
@@ -317,11 +318,12 @@ class UxDataset(xr.Dataset):
                 f"Please set 'face_dim' to the dimension corresponding to the healpix face dimension."
             )
 
-        # Compute the HEALPix Zoom Level
-        zoom = np.emath.logn(4, (ds.sizes[face_dim] / 12)).astype(int)
-
-        # Attach a  HEALPix Grid
-        uxgrid = Grid.from_healpix(zoom, pixels_only=pixels_only, **kwargs)
+        # Attach a HEALPix Grid
+        uxgrid = Grid.from_healpix(
+            zoom=get_zoom_from_cells(ds.sizes[face_dim]),
+            pixels_only=pixels_only,
+            **kwargs,
+        )
 
         return cls.from_xarray(ds, uxgrid, {face_dim: "n_face"})
 

--- a/uxarray/io/_healpix.py
+++ b/uxarray/io/_healpix.py
@@ -1,3 +1,4 @@
+import math
 from typing import Any, Tuple
 
 import healpix as hp
@@ -7,6 +8,29 @@ import xarray as xr
 
 import uxarray.conventions.ugrid as ugrid
 from uxarray.constants import INT_DTYPE
+
+
+def get_zoom_from_cells(cells):
+    """
+    Compute zoom level n such that cells == 12 * 4**n.
+    Raises ValueError if log4(cells/12) is not an exact integer.
+    """
+    # guard against non‐positive or non‐numeric input
+    ratio = float(cells) / 12.0
+
+    # raw log base 4
+    raw = math.log(ratio, 4)
+    # nearest integer
+    zoom = round(raw)
+    # verify exactness up to a tiny tolerance
+    if not raw == zoom:
+        raise ValueError(
+            f"cells={cells} does not equal the expected number of cells "
+            f"for a global zoom level. UXarray does not currently support "
+            f"regional HEALPix grids"
+        )
+
+    return zoom
 
 
 def pix2corner_ang(


### PR DESCRIPTION
## Overview
- We currently only support global HEALPix data, so it is necessary to add a safeguard to ensure that we don't round the zoom level. 