### PR TITLE
[DRAFT] Feature/cartesian spatial hash - Add support for computing barycentric coordinates from Cartesian coordinates

### DIFF
--- a/test/test_spatial_hashing.py
+++ b/test/test_spatial_hashing.py
@@ -141,3 +141,12 @@ def test_list_of_coords_mpas_primal():
     assert bcoords.shape[0] == num_particles
     assert bcoords.shape[1] == 6 # max sides of an element
     assert np.all(face_ids >= 0) # All particles should be inside an element
+
+def test_colinear_latlon():
+    """Verifies valid spatial hashing for colinear points in latlon coordinates"""
+
+    from uxarray.grid.neighbors import _barycentric_coordinates
+
+    polygon = np.array([[-45, 87.87916205], [45, 87.87916205], [135, 87.87916205], [-135, 87.87916205]])
+    point = np.array([-45, -87.87916205])
+    weights = _barycentric_coordinates(polygon, point)

--- a/test/test_spatial_hashing.py
+++ b/test/test_spatial_hashing.py
@@ -142,11 +142,22 @@ def test_list_of_coords_mpas_primal():
     assert bcoords.shape[1] == 6 # max sides of an element
     assert np.all(face_ids >= 0) # All particles should be inside an element
 
-def test_colinear_latlon():
+def test_barycentric_coordinates_colinear_latlon():
     """Verifies valid spatial hashing for colinear points in latlon coordinates"""
 
-    from uxarray.grid.neighbors import _barycentric_coordinates
+    from uxarray.grid.neighbors import _barycentric_coordinates, _barycentric_coordinates_cartesian
+    from uxarray.grid.coordinates import _lonlat_rad_to_xyz
 
     polygon = np.array([[-45, 87.87916205], [45, 87.87916205], [135, 87.87916205], [-135, 87.87916205]])
     point = np.array([-45, -87.87916205])
-    weights = _barycentric_coordinates(polygon, point)
+    #weights = _barycentric_coordinates(polygon, point)
+
+    # Convert to Cartesian coordinates
+    polygon_rad = np.deg2rad(polygon)
+    point_rad = np.deg2rad(point)
+    x, y, z = _lonlat_rad_to_xyz(polygon_rad[:,0], polygon_rad[:,1])
+    polygon_cartesian = np.array([x, y, z]).T
+    x, y, z = _lonlat_rad_to_xyz(point_rad[0], point_rad[1])
+    point_cartesian = np.array([x, y, z])
+    weights = _barycentric_coordinates_cartesian(polygon_cartesian, point_cartesian)
+    print(weights)


### PR DESCRIPTION
<!--  The PR title should summarize the changes, for example "Add `Grid._build_face_dimension` function".
      Avoid non-descriptive titles such as "Addresses issue #229". -->

<!--  Replace XXX with the number of the issue that this PR will resolve. If this PR closed more than one,
      you may add a comma separated sequence-->
Closes #1187

## Overview
<!--  Please provide a few bullet points summarizing the changes in this PR. This should include
      points on any bug fixes, new functions, or other changes that have been made. -->
This PR provides an option to set the `coordinate_system` for the `SpatialHash` class. This is specifically used to control how the barycentric coordinates are calculated. When set to `cartesian` we use the cartesian coordinates to compute the barycentric coordinates. 

This algorithm assumes faces are planar (linear), which is equivalent to using a local linearization of the spherical coordinates transformation to compute the barycentric coordinates. Determining if a point is in a face requires (1) valid barycentric coordinates and (2) the point is in the plane spanned by the planar face. Meeting these two criteria reduces to ensuring that the projection error of a query point onto the planar face is bounded by the local spherical coordinate linearization error. Because of this, the `SpatialHash` object now has a new attribute `_ll_tolerance` that is initialized in the private `SpatialHash._local_linearization_tolerance` method.

Additional private methods include
* `uxarray.grid.neighbors._barycentric_coordinates_cartesian`
* `uxarray.grid.neighbors._triangle_area_cartesian`
*  `uxarray.grid.neighbors._local_projection_error`

### For end users : 
* `SpatialHash.coordinate_system = 'cartesian'`  should be used when grids are global or cross the antimeridian.


**DRAFT WORK IN PROGRESS**

## Expected Usage


## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->

**General**
- [ X ] An issue is linked created and linked
- [ X ] Add appropriate labels
- [ ] Filled out Overview and Expected Usage (if applicable) sections **WIP**

**Testing**
- [ ] Adequate tests are created if there is new functionality
- [ ] Tests cover all possible logical paths in your function
- [ ] Tests are not too basic (such as simply calling a function and nothing else)

**Documentation**
- [ ] Docstrings have been added to all new functions
- [ ] Docstrings have updated with any function changes
- [ ] Internal functions have a preceding underscore (`_`) and have been added to `docs/internal_api/index.rst`
- [ ] User functions have been added to `docs/user_api/index.rst`

**Examples**
- [ ] Any new notebook examples added to `docs/examples/` folder
- [ ] Clear the output of all cells before committing
- [ ] New notebook files added to `docs/examples.rst` toctree
- [ ] New notebook files added to new entry in `docs/gallery.yml` with appropriate thumbnail photo in `docs/_static/thumbnails/`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

**PR Etiquette Reminders**
- This PR should be listed as a draft PR until you are ready to request reviewers

- After making changes in accordance with the reviews, re-request your reviewers

- Do *not* mark conversations as resolved if you didn't start them

- Do mark conversations as resolved *if you opened them* and are satisfied with the changes/discussion.
-->
