### PR TITLE
Upstream CI fix

### DIFF
--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   upstream-dev:
-    name: upstream-dev-py311
+    name: upstream-dev
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/ci/install-upstream.sh
+++ b/ci/install-upstream.sh
@@ -42,7 +42,6 @@ python -m pip install \
     git+https://github.com/holoviz/datashader.git \
     git+https://github.com/dask/dask.git \
     git+https://github.com/dask/distributed.git \
-    git+https://github.com/aleaxit/gmpy.git \
     git+https://github.com/holoviz/holoviews.git \
     git+https://github.com/shapely/shapely.git \
     git+https://github.com/holoviz/spatialpandas.git


### PR DESCRIPTION
## Overview
I noticed CI upstream was failing again and this was a pretty quick fix so just opened a PR.

Specifically, this PR removes `gmpy` from the upstream-dev CI (which was failing to build and seems like it was already removed elsewhere) and renames the workflow so it no longer includes the incorrect Python version in the name.