### PR TITLE
Fix `edge_node_connectivity.fill_value_mask` error 

### DIFF
--- a/uxarray/grid/connectivity.py
+++ b/uxarray/grid/connectivity.py
@@ -168,7 +168,7 @@ def _populate_edge_node_connectivity(grid):
 
     edge_node_attrs = ugrid.EDGE_NODE_CONNECTIVITY_ATTRS
     edge_node_attrs["inverse_indices"] = inverse_indices
-    edge_node_attrs["fill_value_mask"] = fill_value_mask
+    # edge_node_attrs["fill_value_mask"] = fill_value_mask
 
     # add edge_node_connectivity to internal dataset
     grid._ds["edge_node_connectivity"] = xr.DataArray(

--- a/uxarray/grid/connectivity.py
+++ b/uxarray/grid/connectivity.py
@@ -168,7 +168,6 @@ def _populate_edge_node_connectivity(grid):
 
     edge_node_attrs = ugrid.EDGE_NODE_CONNECTIVITY_ATTRS
     edge_node_attrs["inverse_indices"] = inverse_indices
-    # edge_node_attrs["fill_value_mask"] = fill_value_mask
 
     # add edge_node_connectivity to internal dataset
     grid._ds["edge_node_connectivity"] = xr.DataArray(


### PR DESCRIPTION
# Overview
- Fixes a bug which causes `to_xarray().to_netcdf()` to fail.

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[144], line 1
----> 1 uxds.uxgrid.to_xarray().to_netcdf("test.nc")

File ~\anaconda3\envs\uxarray\Lib\site-packages\xarray\core\dataset.py:2021, in Dataset.to_netcdf(self, path, mode, format, group, engine, encoding, unlimited_dims, compute, invalid_netcdf, auto_complex)
   2018     encoding = {}
   2019 from xarray.backends.api import to_netcdf
-> 2021 return to_netcdf(  # type: ignore[return-value]  # mypy cannot resolve the overloads:(
   2022     self,
   2023     path,
   2024     mode=mode,
   2025     format=format,
   2026     group=group,
   2027     engine=engine,
   2028     encoding=encoding,
   2029     unlimited_dims=unlimited_dims,
   2030     compute=compute,
   2031     multifile=False,
   2032     invalid_netcdf=invalid_netcdf,
   2033     auto_complex=auto_complex,
   2034 )

File ~\anaconda3\envs\uxarray\Lib\site-packages\xarray\backends\api.py:1928, in to_netcdf(dataset, path_or_file, mode, format, group, engine, encoding, unlimited_dims, compute, multifile, invalid_netcdf, auto_complex)
   1923 # TODO: figure out how to refactor this logic (here and in save_mfdataset)
   1924 # to avoid this mess of conditionals
   1925 try:
   1926     # TODO: allow this work (setting up the file for writing array data)
   1927     # to be parallelized with dask
-> 1928     dump_to_store(
   1929         dataset, store, writer, encoding=encoding, unlimited_dims=unlimited_dims
   1930     )
   1931     if autoclose:
   1932         store.close()

File ~\anaconda3\envs\uxarray\Lib\site-packages\xarray\backends\api.py:1975, in dump_to_store(dataset, store, writer, encoder, encoding, unlimited_dims)
   1972 if encoder:
   1973     variables, attrs = encoder(variables, attrs)
-> 1975 store.store(variables, attrs, check_encoding, writer, unlimited_dims=unlimited_dims)

File ~\anaconda3\envs\uxarray\Lib\site-packages\xarray\backends\common.py:458, in AbstractWritableDataStore.store(self, variables, attributes, check_encoding_set, writer, unlimited_dims)
    456 self.set_attributes(attributes)
    457 self.set_dimensions(variables, unlimited_dims=unlimited_dims)
--> 458 self.set_variables(
    459     variables, check_encoding_set, writer, unlimited_dims=unlimited_dims
    460 )

File ~\anaconda3\envs\uxarray\Lib\site-packages\xarray\backends\common.py:496, in AbstractWritableDataStore.set_variables(self, variables, check_encoding_set, writer, unlimited_dims)
    494 name = _encode_variable_name(vn)
    495 check = vn in check_encoding_set
--> 496 target, source = self.prepare_variable(
    497     name, v, check, unlimited_dims=unlimited_dims
    498 )
    500 writer.add(source, target)

File ~\anaconda3\envs\uxarray\Lib\site-packages\xarray\backends\netCDF4_.py:587, in NetCDF4DataStore.prepare_variable(self, name, variable, check_encoding, unlimited_dims)
    584     default_args.pop("_FillValue", None)
    585     nc4_var = self.ds.createVariable(**default_args)
--> 587 nc4_var.setncatts(attrs)
    589 target = NetCDF4ArrayWrapper(name, self)
    591 return target, variable.data

File src\\netCDF4\\_netCDF4.pyx:4739, in netCDF4._netCDF4.Variable.setncatts()

File src\\netCDF4\\_netCDF4.pyx:1888, in netCDF4._netCDF4._set_att()

TypeError: illegal data type for attribute b'fill_value_mask', must be one of dict_keys(['S1', 'i1', 'u1', 'i2', 'u2', 'i4', 'u4', 'i8', 'u8', 'f4', 'f8']), got b1
```