### PR TITLE
avoid duplicate 'two' dimensions

### DIFF
--- a/uxarray/io/_ugrid.py
+++ b/uxarray/io/_ugrid.py
@@ -80,10 +80,6 @@ def _read_ugrid(ds):
 
     dim_dict[ds["face_node_connectivity"].dims[1]] = ugrid.N_MAX_FACE_NODES_DIM
 
-    for dim in ds.dims:
-        if ds.sizes[dim] == 2:
-            dim_dict[dim] = "two"
-
     ds = ds.swap_dims(dim_dict)
 
     return ds, dim_dict


### PR DESCRIPTION
Closes #1332

Maybe related to issue #1189

Avoid xarray UserWarnings like

```
uxarray/lib/python3.12/site-packages/xarray/namedarray/core.py:503: UserWarning: Duplicate dimension names present: dimensions {'two'} appear more than once in dims=('n_face', 'two', 'two'). We do not yet support duplicate dimension names, but we do allow initial construction of the object. We recommend you rename the dims immediately to become distinct, as most xarray functionality is likely to fail silently if you do not. To rename the dimensions you will need to set the ``.dims`` attribute of each variable, ``e.g. var.dims=('x0', 'x1')``.
  self._dims = self._parse_dimensions(value)
/glade/work/ahijevyc/conda-envs/uxarray/lib/python3.12/site-packages/xarray/namedarray/core.py:264: UserWarning: Duplicate dimension names present: dimensions {'two'} appear more than once in dims=('n_face', 'two', 'two'). We do not yet support duplicate dimension names, but we do allow initial construction of the object. We recommend you rename the dims immediately to become distinct, as most xarray functionality is likely to fail silently if you do not. To rename the dimensions you will need to set the ``.dims`` attribute of each variable, ``e.g. var.dims=('x0', 'x1')``.
  self._dims = self._parse_dimensions(dims)
```


## Overview
Don't rename size-2 dimensions in io/_ugrid.py.

The original renaming logic might reflect MPAS's convention of naming dimensions of size 2 'TWO'. While this assumption may hold for MPAS-generated files, it causes dimension name collisions when reading other valid UGRID-compliant files (e.g., SCRIP) that use multiple, descriptively-named dimensions of size 2, like `lon_lat` and `min_max`.

## PR Checklist

**General**
- [x] An issue is linked created and linked
- [x] Add appropriate labels
- [x] Filled out Overview and Expected Usage (if applicable) sections

**Testing**
- [ ] Adequate tests are created if there is new functionality
- [N/A] Tests cover all possible logical paths in your function
- [N/A] Tests are not too basic (such as simply calling a function and nothing else)