### PR TITLE
dimension name should be lat_lon because lat comes before lon

### DIFF
--- a/uxarray/grid/bounds.py
+++ b/uxarray/grid/bounds.py
@@ -97,7 +97,7 @@ def _populate_face_bounds(
 
     bounds_da = xr.DataArray(
         bounds_array,
-        dims=["n_face", "lon_lat", "min_max"],
+        dims=["n_face", "lat_lon", "min_max"],
         attrs={
             "cf_role": "face_latlon_bounds",
             "_FillValue": INT_FILL_VALUE,


### PR DESCRIPTION
This came up when dealing with #1332.

The dimension `lon_lat` should be named `lat_lon` because latitude is in the zero-index and longitude is in the one-index.
This is analogous to how the `min_max` dimension contains the minimum value in the zero-index and maximum value in the one-index. You wouldn't want to have a dimension name like `max_min` because min comes first.

## Overview
rename dimension `lon_lat` -> `lat_lon` because the latitude index comes before longitude.

After tracing the way `bounds_array` is constructed in `_populate_face_bounds` it is likely that latitude comes first and longitude comes second. That's why it should be renamed.

All the other variables with lat and lon in their names seems to be consistent with the order of lat and lon in their data.
