### PR TITLE
Add warning when constructing a PolyCollection/LineCollection with a projection

### DIFF
--- a/test/test_plot.py
+++ b/test/test_plot.py
@@ -110,3 +110,12 @@ def test_to_raster():
     raster = uxds['bottomDepth'].to_raster(ax=ax)
 
     assert isinstance(raster, np.ndarray)
+
+
+def test_collections_projection_kwarg():
+    import cartopy.crs as ccrs
+    uxgrid = ux.open_grid(gridfile_ne30)
+
+    with pytest.warns(UserWarning):
+        pc = uxgrid.to_polycollection(projection=ccrs.PlateCarree())
+        lc = uxgrid.to_linecollection(projection=ccrs.PlateCarree())

--- a/uxarray/grid/grid.py
+++ b/uxarray/grid/grid.py
@@ -2217,6 +2217,14 @@ class Grid:
         """
         import cartopy.crs as ccrs
 
+        if kwargs.get("projection", False):
+            warn(
+                "Explicit providing a projection when construction a PolyCollection has been deprecated. Please provide a projection when"
+                "constructing a GeoAxes instead.",
+                stacklevel=2,
+            )
+            kwargs.pop("projection")
+
         if self._cached_poly_collection:
             return copy.deepcopy(self._cached_poly_collection)
 
@@ -2237,14 +2245,22 @@ class Grid:
         **kwargs,
     ):
         """Constructs a ``matplotlib.collections.LineCollection``` consisting
-        of lines representing the edges of the current ``Grid``
+        of lines representing the edges of the unstructured grid.
 
         Parameters
         ----------
         **kwargs: dict
-            Key word arguments to pass into the construction of a PolyCollection
+            Key word arguments to pass into the construction of a LineCollection
         """
         import cartopy.crs as ccrs
+
+        if kwargs.get("projection", False):
+            warn(
+                "Explicit providing a projection when construction a LineCollection has been deprecated. Please provide a projection when"
+                "constructing a GeoAxes instead.",
+                stacklevel=2,
+            )
+            kwargs.pop("projection")
 
         if self._cached_line_collection:
             return copy.deepcopy(self._cached_line_collection)

--- a/uxarray/grid/grid.py
+++ b/uxarray/grid/grid.py
@@ -2219,8 +2219,8 @@ class Grid:
 
         if kwargs.get("projection", False):
             warn(
-                "Explicit providing a projection when construction a PolyCollection has been deprecated. Please provide a projection when"
-                "constructing a GeoAxes instead.",
+                "Explicitly providing a projection when construction a PolyCollection has been deprecated. Please provide a projection when"
+                " a GeoAxes instead.",
                 stacklevel=2,
             )
             kwargs.pop("projection")
@@ -2256,8 +2256,8 @@ class Grid:
 
         if kwargs.get("projection", False):
             warn(
-                "Explicit providing a projection when construction a LineCollection has been deprecated. Please provide a projection when"
-                "constructing a GeoAxes instead.",
+                "Explicitly providing a projection when construction a LolyCollection has been deprecated. Please provide a projection when"
+                " a GeoAxes instead.",
                 stacklevel=2,
             )
             kwargs.pop("projection")


### PR DESCRIPTION
# Overview
- Adds a warning when a user provides a projection to `to_polycollection()` and `to_linecollection()` calls. 
- Updates logic to prevent duplicate projection arguments from being passed in, which caused errors 