### PR TITLE
Pandas and Xarray deprecations

### DIFF
--- a/test/core/test_accessors.py
+++ b/test/core/test_accessors.py
@@ -166,7 +166,7 @@ def test_resample_with_cftime(gridpath):
     uxds = ux.UxDataset(ds, uxgrid=ux.open_grid(gridpath("ugrid", "outCSne30", "outCSne30.ug")))
 
     # Test that quarterly resampling works with cftime
-    quarterly = uxds.resample(time="Q").mean()
+    quarterly = uxds.resample(time="QE").mean()
     assert hasattr(quarterly, "uxgrid"), "uxgrid not preserved with cftime resampling"
     assert "time" in quarterly.dims, "time dimension missing after cftime resample"
     assert quarterly.dims["time"] < uxds.dims["time"], "time dimension not reduced with cftime"

--- a/test/core/test_accessors.py
+++ b/test/core/test_accessors.py
@@ -140,8 +140,8 @@ def test_resample_reduces_time_dimension(gridpath):
     # Test monthly resampling reduces from 365 days to 12 months
     monthly = uxds.resample(time="1ME").mean()
     assert "time" in monthly.dims, "time dimension missing after resample"
-    assert monthly.dims["time"] < uxds.dims["time"], "time dimension not reduced"
-    assert monthly.dims["time"] <= 12, "monthly resampling should give 12 or fewer time points"
+    assert monthly.sizes["time"] < uxds.sizes["time"], "time dimension not reduced"
+    assert monthly.sizes["time"] <= 12, "monthly resampling should give 12 or fewer time points"
 
 
 def test_resample_with_cftime(gridpath):
@@ -169,7 +169,7 @@ def test_resample_with_cftime(gridpath):
     quarterly = uxds.resample(time="QE").mean()
     assert hasattr(quarterly, "uxgrid"), "uxgrid not preserved with cftime resampling"
     assert "time" in quarterly.dims, "time dimension missing after cftime resample"
-    assert quarterly.dims["time"] < uxds.dims["time"], "time dimension not reduced with cftime"
+    assert quarterly.sizes["time"] < uxds.sizes["time"], "time dimension not reduced with cftime"
 
 
 def test_rolling_preserves_uxgrid(gridpath):
@@ -237,7 +237,7 @@ def test_coarsen_preserves_uxgrid(gridpath):
 
     # Test that coarsen reduces dimension correctly
     assert len(da_result.time) == 8, "coarsen by 3 should reduce 24 points to 8"
-    assert ds_result.dims["time"] == 8, "coarsen should reduce time dimension"
+    assert ds_result.sizes["time"] == 8, "coarsen should reduce time dimension"
 
 
 def test_weighted_preserves_uxgrid(gridpath, datasetpath):
@@ -251,7 +251,7 @@ def test_weighted_preserves_uxgrid(gridpath, datasetpath):
         gridpath("ugrid", "outCSne30", "outCSne30.ug"),
         datasetpath("ugrid", "outCSne30", "outCSne30_var2.nc")
     )
-    n_face = uxds_base.dims["n_face"]
+    n_face = uxds_base.sizes["n_face"]
 
     # Create data with time and face dimensions
     temp_data = np.random.rand(10, n_face)

--- a/test/core/test_accessors.py
+++ b/test/core/test_accessors.py
@@ -138,7 +138,7 @@ def test_resample_reduces_time_dimension(gridpath):
     uxds = ux.UxDataset(ds, uxgrid=ux.open_grid(gridpath("ugrid", "outCSne30", "outCSne30.ug")))
 
     # Test monthly resampling reduces from 365 days to 12 months
-    monthly = uxds.resample(time="1M").mean()
+    monthly = uxds.resample(time="1ME").mean()
     assert "time" in monthly.dims, "time dimension missing after resample"
     assert monthly.dims["time"] < uxds.dims["time"], "time dimension not reduced"
     assert monthly.dims["time"] <= 12, "monthly resampling should give 12 or fewer time points"

--- a/test/core/test_inheritance.py
+++ b/test/core/test_inheritance.py
@@ -16,7 +16,7 @@ def ds():
 
     uxds["fc"] = uxds["fc"].assign_coords(face_id=("n_face", np.arange(uxgrid.n_face)))
     uxds["nc"] = uxds["nc"].assign_coords(node_id=("n_node", np.arange(uxgrid.n_node)))
-    uxds["t"] = uxds["t"].assign_coords(time_id=("time", np.arange(uxds.dims["time"])))
+    uxds["t"] = uxds["t"].assign_coords(time_id=("time", np.arange(uxds.sizes["time"])))
 
     return uxds
 
@@ -109,7 +109,7 @@ class TestInheritedMethods:
         assert hasattr(grouped, 'uxgrid')
 
     def test_assign_coords(self, ds):
-        n = ds.dims['n_face']
+        n = ds.sizes['n_face']
         new_coord = xr.DataArray(np.arange(n) * 10, dims=['n_face'])
         out = ds.assign_coords(scaled_id=new_coord)
         assert isinstance(out, ux.UxDataset)
@@ -121,7 +121,7 @@ class TestInheritedMethods:
         out = ds.expand_dims({'member': 1})
         assert isinstance(out, ux.UxDataset)
         assert hasattr(out, 'uxgrid') and out.uxgrid is ds.uxgrid
-        assert 'member' in out.dims and out.dims['member'] == 1
+        assert 'member' in out.dims and out.sizes['member'] == 1
         assert 'member' in out['t'].dims and out['t'].sizes['member'] == 1
 
     def test_method_chaining(self, ds):
@@ -147,7 +147,7 @@ class TestInheritedMethods:
         assert unstacked['fc'].shape == ds_fc['fc'].shape
 
     def test_sortby(self, ds):
-        n = ds.dims['n_face']
+        n = ds.sizes['n_face']
         ds_fc = ds[['fc']].assign_coords(reverse_id=('n_face', np.arange(n)[::-1]))
         out = ds_fc.sortby('reverse_id')
         assert isinstance(out, ux.UxDataset)


### PR DESCRIPTION
Closes #1371

## Overview

Addresses deprecations from Pandas and Xarray causing warnings and/or failures in the test suite.

In particular, the use of several Pandas offset aliases ([see here for more info from Pandas](https://pandas.pydata.org/docs/dev/whatsnew/v3.0.0.html#removal-of-prior-version-deprecations-changes)) and the use of Dataset.dims as a mapping from dimension names to lengths ([see here](https://docs.xarray.dev/en/latest/generated/xarray.Dataset.dims.html)).

It's worth noting that I didn't make an effort to make these changes backwards compatible with versions of Pandas and Xarray before the suggested replacements existed.  For Pandas, [this has been working since v2.2.0](https://pandas.pydata.org/docs/dev/whatsnew/v2.2.0.html#deprecate-aliases-m-q-y-etc-in-favour-of-me-qe-ye-etc-for-offsets) released in January, 2024 and for Xarray `Dataset.sizes` has been around since well before they adopted CalVer so probably less of a concern.  Not sure if you all have thoughts / policies on this. 

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->

**General**
- [x] An issue is linked created and linked
- [x] Add appropriate labels
- [x] Filled out Overview and Expected Usage (if applicable) sections