### PR TITLE
CI Failure Fix: install-upstream.sh

### DIFF
--- a/ci/install-upstream.sh
+++ b/ci/install-upstream.sh
@@ -24,15 +24,17 @@ conda list
 
 # if available install from scientific-python nightly wheels
 # constrain numpy to <=2.3 until numba supports newer versions
+# use stable pandas (not nightly) due to geopandas incompatibility with pandas nightly internals
+# (see: https://github.com/UXARRAY/uxarray/issues/1414)
 python -m pip install \
-    'numpy<=2.3'
+    'numpy<=2.3' \
+    'pandas>=2.0.0'
 
 python -m pip install \
     -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
     --no-deps \
     --pre \
     --upgrade \
-    pandas \
     scikit-learn \
     scipy \
     xarray


### PR DESCRIPTION
Fix #1414 Separating dask/distributed installation with --no-deps bypasses pip's dependency resolution, allowing both development versions to install simultaneously despite version drift between their pinned dependencies (dask 2025.11.0 vs 2025.11.1.dev19+). 

This is a known issue with dev versions as documented in [dask/community#150](https://github.com/dask/community/issues/150) and addressed in [dask/distributed#5802](https://github.com/dask/distributed/pull/5802).