### PR TITLE
Fix UxDataset constructor and `to_xarray()` that got broken with xarray==2026.4.0

### DIFF
--- a/test/core/test_dataset.py
+++ b/test/core/test_dataset.py
@@ -99,3 +99,16 @@ def test_sel_method_forwarded(gridpath, datasetpath):
         nearest["time"].values,
         np.array(uxds["time"].values[2], dtype="datetime64[ns]"),
     )
+
+def test_uxdataset_init_from_xarray_dataset():
+    ds = xr.Dataset(
+        data_vars={"a": ("x", [1, 2])},
+        coords={"x": [10, 20]},
+        attrs={"source": "testing"},
+    )
+
+    uxds = ux.UxDataset(ds)
+
+    assert "a" in uxds.data_vars
+    assert "x" in uxds.coords
+    assert uxds.attrs["source"] == "testing"

--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -90,7 +90,18 @@ class UxDataset(xr.Dataset):
         else:
             self._uxgrid = uxgrid
 
+        # As of xarray's 2026.4.0, `xr.Dataset(xr.Dataset)` is prohibited;
+        # hence this check, i.e. If we get `xr.Dataset` as input, use its `data_vars`
+        # as `dict` and
+        if args and isinstance(args[0], xr.Dataset):
+            ds = args[0]
+            args = (dict(ds.data_vars),) + args[1:]
+            kwargs.setdefault("coords", dict(ds.coords))
+            kwargs.setdefault("attrs", ds.attrs)
+
         super().__init__(*args, **kwargs)
+
+        # super().__init__(*args, **kwargs)
 
     # declare plotting accessor
     plot = UncachedAccessor(UxDatasetPlotAccessor)
@@ -627,9 +638,9 @@ class UxDataset(xr.Dataset):
         """
         if grid_format == "HEALPix":
             ds = self.rename_dims({"n_face": "cell"})
-            return xr.Dataset(ds)
+            return xr.Dataset(ds.data_vars, coords=ds.coords, attrs=ds.attrs)
 
-        return xr.Dataset(self)
+        return xr.Dataset(self.data_vars, coords=self.coords, attrs=self.attrs)
 
     def get_dual(self):
         """Compute the dual mesh for a dataset, returns a new dataset object.

--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -97,9 +97,16 @@ class UxDataset(xr.Dataset):
             ds = args[0]
             # Replacee only args[0], `ds`, with `ds.data_vars` as `dict`
             args = (dict(ds.data_vars),) + args[1:]
-            # Set `coords` and `attrs` only if they are not explicitly provided
-            kwargs.setdefault("coords", dict(ds.coords))
-            kwargs.setdefault("attrs", ds.attrs)
+            # coords not passed positionally
+            if len(args) < 2:
+                kwargs.setdefault(
+                    "coords", dict(ds.coords)
+                )  # Set it as kwarg only if not explicitly provided
+            # attrs not passed positionally
+            if len(args) < 3:
+                kwargs.setdefault(
+                    "attrs", ds.attrs
+                )  # Set it as kwarg only if not explicitly provided
 
         super().__init__(*args, **kwargs)
 

--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -91,17 +91,17 @@ class UxDataset(xr.Dataset):
             self._uxgrid = uxgrid
 
         # As of xarray's 2026.4.0, `xr.Dataset(xr.Dataset)` is prohibited;
-        # hence this check, i.e. If we get `xr.Dataset` as input, use its `data_vars`
-        # as `dict` and
+        # hence this check, i.e. if we get `xr.Dataset` as input, use its `data_vars`
+        # as `dict` and handle `coords` and `attrs` properly as well
         if args and isinstance(args[0], xr.Dataset):
             ds = args[0]
+            # Replacee only args[0], `ds`, with `ds.data_vars` as `dict`
             args = (dict(ds.data_vars),) + args[1:]
+            # Set `coords` and `attrs` only if they are not explicitly provided
             kwargs.setdefault("coords", dict(ds.coords))
             kwargs.setdefault("attrs", ds.attrs)
 
         super().__init__(*args, **kwargs)
-
-        # super().__init__(*args, **kwargs)
 
     # declare plotting accessor
     plot = UncachedAccessor(UxDatasetPlotAccessor)


### PR DESCRIPTION
Closes #1490 

## Overview
Avoid `xr.Dataset(xr.Dataset)` calls in our constructor and `to_xarray()` as it got prohibited as of xarray's 2026.4.0.


## Expected Usage
No change to the user API.

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->

**General**
- [x] An issue is linked created and linked
- [x] Add appropriate labels
- [ ] Filled out Overview and Expected Usage (if applicable) sections

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

**PR Etiquette Reminders**
- This PR should be listed as a draft PR until you are ready to request reviewers

- After making changes in accordance with the reviews, re-request your reviewers

- Do *not* mark conversations as resolved if you didn't start them

- Do mark conversations as resolved *if you opened them* and are satisfied with the changes/discussion.
-->
