### PR TITLE
Keep NumPy unchanged in upstream CI

### DIFF
--- a/ci/install-upstream.sh
+++ b/ci/install-upstream.sh
@@ -8,7 +8,6 @@ conda remove -y --force \
     datashader \
     distributed \
     holoviews \
-    numpy \
     pandas \
     scikit-learn \
     scipy \
@@ -26,7 +25,6 @@ conda list
 # use stable pandas (not nightly) due to geopandas incompatibility with pandas nightly internals
 # (see: https://github.com/UXARRAY/uxarray/issues/1414)
 python -m pip install \
-    'numpy<2.5' \
     'pandas>=2.0.0'
 
 python -m pip install \

--- a/ci/install-upstream.sh
+++ b/ci/install-upstream.sh
@@ -26,6 +26,7 @@ conda list
 # use stable pandas (not nightly) due to geopandas incompatibility with pandas nightly internals
 # (see: https://github.com/UXARRAY/uxarray/issues/1414)
 python -m pip install \
+    'numpy<2.5' \
     'pandas>=2.0.0'
 
 python -m pip install \
@@ -33,7 +34,6 @@ python -m pip install \
     --no-deps \
     --pre \
     --upgrade \
-    numpy \
     scikit-learn \
     scipy \
     xarray


### PR DESCRIPTION
Leaves the conda-resolved NumPy in upstream-dev so Numba stays importable while still testing newer upstream packages.