### PR TITLE
Fix raster default extent detection

### DIFF
--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -465,12 +465,7 @@ class UxDataArray(xr.DataArray):
         else:
 
             def _is_default_extent() -> bool:
-                # Default extents are indicated by xlim/ylim being (0, 1)
-                # when autoscale is still on (no extent has been explicitly set)
-                if not ax.get_autoscale_on():
-                    return False
-                xlim, ylim = ax.get_xlim(), ax.get_ylim()
-                return np.allclose(xlim, (0.0, 1.0)) and np.allclose(ylim, (0.0, 1.0))
+                return ax.get_autoscale_on()
 
             if _is_default_extent():
                 try:


### PR DESCRIPTION
Treat fresh GeoAxes with autoscale enabled as using the default extent so the raster auto-extent path remains stable across upstream Cartopy changes. Closes #1495.