### PR TITLE
Fix: execute ux.open_dataset() in data-structures user guide

### DIFF
--- a/docs/user-guide/data-structures.ipynb
+++ b/docs/user-guide/data-structures.ipynb
@@ -486,9 +486,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "uxds"
-   ]
+   "source": "uxds = ux.open_dataset(grid_path, data_path)\nuxds"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Execute `ux.open_dataset(grid_path, data_path)` in the "Opening a Single Data File" section, which previously referenced the method in prose but only displayed an already-loaded dataset.

