### PR TITLE
Show UXarray calendar on docs sidebar

### DIFF
--- a/docs/calendar.rst
+++ b/docs/calendar.rst
@@ -2,9 +2,9 @@
 
 .. _calendar:
 
-*************************
-UXarray's Public Calendar
-*************************
+***************
+Events Calendar
+***************
 
 Please find the public monthly community meetings and other events in the
 calendar below and join us once or regularly with whichever of them works

--- a/docs/calendar.rst
+++ b/docs/calendar.rst
@@ -11,4 +11,5 @@ calendar below and join us once or regularly with whichever of them works
 best for you:
 
 .. raw:: html
-    <iframe src="https://calendar.google.com/calendar/embed?src=c_aded7956c547d66408841073b714d36d98955376d40f43f32efb1d6bad3b9824%40group.calendar.google.com&ctz=America%2FDenver" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+
+   <iframe src="https://calendar.google.com/calendar/embed?src=c_aded7956c547d66408841073b714d36d98955376d40f43f32efb1d6bad3b9824%40group.calendar.google.com&ctz=America%2FDenver" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>

--- a/docs/calendar.rst
+++ b/docs/calendar.rst
@@ -1,0 +1,14 @@
+.. currentmodule:: uxarray
+
+.. _calendar:
+
+*************************
+UXarray's Public Calendar
+*************************
+
+Please find the public monthly community meetings and other events in the
+calendar below and join us once or regularly with whichever of them works
+best for you:
+
+.. raw:: html
+    <iframe src="https://calendar.google.com/calendar/embed?src=c_aded7956c547d66408841073b714d36d98955376d40f43f32efb1d6bad3b9824%40group.calendar.google.com&ctz=America%2FDenver" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -113,6 +113,7 @@ around the `UGRID <http://ugrid-conventions.github.io/ugrid-conventions/>`_ conv
     GitHub Issues <https://github.com/UXARRAY/uxarray/issues>
     UGRID Conventions <https://ugrid-conventions.github.io/ugrid-conventions/>
     contributing
+    calendar
 
 .. raw:: html
 


### PR DESCRIPTION
Closes #1505

## Overview

UXarray's public monthly community meetings (and maybe other events that might be scheduled over time) needed a place to be shown in the docs. 

It looks like this:

<img width="1180" height="806" alt="image" src="https://github.com/user-attachments/assets/60c134f8-e2eb-46a1-a23d-d91149bd686a" />


## PR Checklist

**General**
- [x] An issue is linked created and linked
- [x] Add appropriate labels
- [x] Filled out Overview
