### PR TITLE
Fix to_polycollection exclude path: always cache antimeridian_face_indices

### DIFF
--- a/uxarray/grid/geometry.py
+++ b/uxarray/grid/geometry.py
@@ -495,13 +495,6 @@ def _grid_to_matplotlib_polycollection(
         polygon_shells[:, :, 0]
     )
 
-    # Always cache antimeridian_face_indices; dataarray.to_polycollection reads it
-    # regardless of whether a projection is used. Without this, the cache entry
-    # stays None and np.delete raises IndexError on numpy >= 2.0.
-    grid._poly_collection_cached_parameters["antimeridian_face_indices"] = (
-        antimeridian_face_indices
-    )
-
     # Filter out NaN-containing polygons if projection is applied
     non_nan_polygon_indices = None
     if projected_polygon_shells is not None:
@@ -514,9 +507,12 @@ def _grid_to_matplotlib_polycollection(
         does_not_contain_nan = ~np.isnan(shells_d).any(axis=(1, 2))
         non_nan_polygon_indices = np.where(does_not_contain_nan)[0]
 
-        grid._poly_collection_cached_parameters["non_nan_polygon_indices"] = (
-            non_nan_polygon_indices
-        )
+    grid._poly_collection_cached_parameters["non_nan_polygon_indices"] = (
+        non_nan_polygon_indices
+    )
+    grid._poly_collection_cached_parameters["antimeridian_face_indices"] = (
+        antimeridian_face_indices
+    )
 
     # Select which shells to use: projected or original
     if projected_polygon_shells is not None:

--- a/uxarray/grid/geometry.py
+++ b/uxarray/grid/geometry.py
@@ -495,6 +495,13 @@ def _grid_to_matplotlib_polycollection(
         polygon_shells[:, :, 0]
     )
 
+    # Always cache antimeridian_face_indices; dataarray.to_polycollection reads it
+    # regardless of whether a projection is used. Without this, the cache entry
+    # stays None and np.delete raises IndexError on numpy >= 2.0.
+    grid._poly_collection_cached_parameters["antimeridian_face_indices"] = (
+        antimeridian_face_indices
+    )
+
     # Filter out NaN-containing polygons if projection is applied
     non_nan_polygon_indices = None
     if projected_polygon_shells is not None:
@@ -509,9 +516,6 @@ def _grid_to_matplotlib_polycollection(
 
         grid._poly_collection_cached_parameters["non_nan_polygon_indices"] = (
             non_nan_polygon_indices
-        )
-        grid._poly_collection_cached_parameters["antimeridian_face_indices"] = (
-            antimeridian_face_indices
         )
 
     # Select which shells to use: projected or original


### PR DESCRIPTION
Fixes #1507

`to_polycollection(periodic_elements='exclude')` (the default) raised an `IndexError` starting with numpy 2.0 when no cartopy projection was supplied.

**Root cause:** `antimeridian_face_indices` was computed in `_build_polygon_collection` but only written to `_poly_collection_cached_parameters` inside the `if projected_polygon_shells is not None` block. Without a projection that cache entry stayed `None`. `dataarray.to_polycollection` then called `np.delete(data, None, axis=0)` — a silent no-op in numpy < 2.0 but a hard `IndexError` since numpy 2.0 (June 2024).

**Fix:** Move the cache write to before the projection-only block so `antimeridian_face_indices` is always populated regardless of whether a projection is supplied.