### PR TITLE
Fix line color with Bokeh Orthographic plots

### DIFF
--- a/docs/user-guide/healpix.ipynb
+++ b/docs/user-guide/healpix.ipynb
@@ -149,20 +149,17 @@
     "    ux.Grid.from_healpix(zoom=2).plot(\n",
     "        periodic_elements=\"split\",\n",
     "        projection=ccrs.Orthographic(),\n",
-    "        title=\"zoom=2\",\n",
-    "        backend=\"matplotlib\",\n",
+    "        title=\"zoom=2\"\n",
     "    )\n",
     "    + ux.Grid.from_healpix(zoom=3).plot(\n",
     "        periodic_elements=\"split\",\n",
     "        projection=ccrs.Orthographic(),\n",
-    "        title=\"zoom=3\",\n",
-    "        backend=\"matplotlib\",\n",
+    "        title=\"zoom=3\"\n",
     "    )\n",
     "    + ux.Grid.from_healpix(zoom=4).plot(\n",
     "        periodic_elements=\"split\",\n",
     "        projection=ccrs.Orthographic(),\n",
-    "        title=\"zoom=4\",\n",
-    "        backend=\"matplotlib\",\n",
+    "        title=\"zoom=4\"\n",
     "    )\n",
     ").cols(1)"
    ]
@@ -448,22 +445,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.14.4"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/docs/user-guide/healpix.ipynb
+++ b/docs/user-guide/healpix.ipynb
@@ -147,19 +147,13 @@
    "source": [
     "(\n",
     "    ux.Grid.from_healpix(zoom=2).plot(\n",
-    "        periodic_elements=\"split\",\n",
-    "        projection=ccrs.Orthographic(),\n",
-    "        title=\"zoom=2\"\n",
+    "        periodic_elements=\"split\", projection=ccrs.Orthographic(), title=\"zoom=2\"\n",
     "    )\n",
     "    + ux.Grid.from_healpix(zoom=3).plot(\n",
-    "        periodic_elements=\"split\",\n",
-    "        projection=ccrs.Orthographic(),\n",
-    "        title=\"zoom=3\"\n",
+    "        periodic_elements=\"split\", projection=ccrs.Orthographic(), title=\"zoom=3\"\n",
     "    )\n",
     "    + ux.Grid.from_healpix(zoom=4).plot(\n",
-    "        periodic_elements=\"split\",\n",
-    "        projection=ccrs.Orthographic(),\n",
-    "        title=\"zoom=4\"\n",
+    "        periodic_elements=\"split\", projection=ccrs.Orthographic(), title=\"zoom=4\"\n",
     "    )\n",
     ").cols(1)"
    ]

--- a/uxarray/plot/accessor.py
+++ b/uxarray/plot/accessor.py
@@ -222,6 +222,8 @@ class GridPlotAccessor:
             kwargs["projection"] = ccrs.PlateCarree()
         if "clabel" not in kwargs:
             kwargs["clabel"] = "edges"
+        if "color" not in kwargs and "line_color" not in kwargs:
+            kwargs["color"] = "black"
         if "crs" not in kwargs:
             if "projection" in kwargs:
                 central_longitude = kwargs["projection"].proj4_params["lon_0"]


### PR DESCRIPTION
<!--  The PR title should summarize the changes, for example "Add `Grid._build_face_dimension` function".
      Avoid non-descriptive titles such as "Addresses issue #229". -->

<!--  Replace XXX with the number of the issue that this PR will resolve. If this PR closed more than one,
      you may add a comma separated sequence-->
Closes #1512

## Overview
<!--  Please provide a few bullet points summarizing the changes in this PR. This should include
      points on any bug fixes, new functions, or other changes that have been made. -->

This fixes the grid plots rendering as empty circles with Bokeh backend. I checked the healpix and dual-mesh notebooks, and both now render correctly with the Bokeh backend.
healpix paths were reaching bokeh as a MultiLine renderer, but the actual mesh renderer had `line_color=None`

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->

**General**
- [X] An issue is linked created and linked

**Examples**
- [X] Clear the output of all cells before committing

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

**PR Etiquette Reminders**
- This PR should be listed as a draft PR until you are ready to request reviewers

- After making changes in accordance with the reviews, re-request your reviewers

- Do *not* mark conversations as resolved if you didn't start them

- Do mark conversations as resolved *if you opened them* and are satisfied with the changes/discussion.
-->
