### PR TITLE
Scale gradient and curl by sphere radius

### DIFF
--- a/docs/user-guide/vector_calculus.ipynb
+++ b/docs/user-guide/vector_calculus.ipynb
@@ -121,6 +121,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "66caacb5",
+   "metadata": {},
+   "source": "> **Units.** By default, `gradient()` and `curl()` divide by `uxgrid.sphere_radius` so derivatives carry physical units (e.g. `[data units]/m`, `1/s` for velocity curl). Pass `scale_by_radius=False` to keep results on the unit sphere (per radian). If the grid has no `sphere_radius` attribute, the call falls back to unit-sphere output and emits a `UserWarning`."
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "7",
@@ -438,6 +444,70 @@
     ")\n",
     "\n",
     "(vortex_vectors + curl_magnitude).opts(shared_axes=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e67a135",
+   "metadata": {},
+   "source": "### Example 3: Relative Vorticity from Solid-Body Rotation\n\nThe 2D curl on the sphere is **relative vorticity** $\\zeta = \\partial v/\\partial x - \\partial u/\\partial y$, a quantity meteorologists and oceanographers care about every day. With the default `scale_by_radius=True`, `u.curl(v)` returns $\\zeta$ in physical units of $s^{-1}$.\n\nA clean analytical check is **solid-body rotation about the polar axis** with angular speed $\\Omega$:\n\n$$\nu(\\varphi) = \\Omega R \\cos\\varphi, \\qquad v = 0\n$$\n\nFor this flow the relative vorticity on a sphere of radius $R$ is\n\n$$\n\\zeta = -\\frac{1}{R\\cos\\varphi}\\frac{\\partial(u\\cos\\varphi)}{\\partial \\varphi} = -2\\Omega \\sin\\varphi.\n$$\n\nWe construct the field on the existing MPAS subset and compare `u.curl(v)` against this closed form."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b5f3090",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "OMEGA = 7.292115e-5  # Earth's angular speed (rad/s)\n",
+    "R = uxds.uxgrid.sphere_radius\n",
+    "lat_rad = np.deg2rad(uxds.uxgrid.face_lat.values)\n",
+    "\n",
+    "u_sbr_data = OMEGA * R * np.cos(lat_rad)\n",
+    "v_sbr_data = np.zeros_like(u_sbr_data)\n",
+    "\n",
+    "u_sbr = ux.UxDataArray(\n",
+    "    u_sbr_data,\n",
+    "    dims=[\"n_face\"],\n",
+    "    uxgrid=uxds.uxgrid,\n",
+    "    name=\"u_sbr\",\n",
+    "    attrs={\"units\": \"m/s\"},\n",
+    ")\n",
+    "v_sbr = ux.UxDataArray(\n",
+    "    v_sbr_data,\n",
+    "    dims=[\"n_face\"],\n",
+    "    uxgrid=uxds.uxgrid,\n",
+    "    name=\"v_sbr\",\n",
+    "    attrs={\"units\": \"m/s\"},\n",
+    ")\n",
+    "\n",
+    "zeta = u_sbr.curl(v_sbr)\n",
+    "zeta_analytic = -2.0 * OMEGA * np.sin(lat_rad)\n",
+    "\n",
+    "finite = np.isfinite(zeta.values)\n",
+    "err = np.abs(zeta.values[finite] - zeta_analytic[finite])\n",
+    "\n",
+    "print(f\"curl units: {zeta.attrs['units']}\")\n",
+    "print(f\"sphere_radius (m): {R:.3e}\")\n",
+    "print(\n",
+    "    f\"computed   zeta range: [{zeta.values[finite].min():.3e}, {zeta.values[finite].max():.3e}]  1/s\"\n",
+    ")\n",
+    "print(\n",
+    "    f\"analytic   zeta range: [{zeta_analytic.min():.3e}, {zeta_analytic.max():.3e}]  1/s\"\n",
+    ")\n",
+    "print(f\"max |error|: {err.max():.3e}  1/s  (≈ {err.max() / (2 * OMEGA):.1%} of 2Omega)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "434634a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zeta.plot(cmap=\"RdBu_r\", aspect=1).opts(\n",
+    "    title=\"Relative Vorticity (1/s) — Solid-Body Rotation\", colorbar=True\n",
+    ")"
    ]
   },
   {

--- a/test/core/test_vector_calculus.py
+++ b/test/core/test_vector_calculus.py
@@ -87,7 +87,7 @@ class TestGradientDyamondSubset:
             gridpath("mpas", "dyamond-30km", "gradient_grid_subset.nc"),
             datasetpath("mpas", "dyamond-30km", "gradient_data_subset.nc")
         )
-        grad = uxds['gaussian'].gradient()
+        grad = uxds['gaussian'].gradient(scale_by_radius=False)
         zg, mg = grad.zonal_gradient, grad.meridional_gradient
         mag = np.hypot(zg, mg)
         angle = np.arctan2(mg, zg)
@@ -118,7 +118,7 @@ class TestGradientDyamondSubset:
             gridpath("mpas", "dyamond-30km", "gradient_grid_subset.nc"),
             datasetpath("mpas", "dyamond-30km", "gradient_data_subset.nc")
         )
-        grad = uxds['inverse_gaussian'].gradient()
+        grad = uxds['inverse_gaussian'].gradient(scale_by_radius=False)
         zg, mg = grad.zonal_gradient, grad.meridional_gradient
         mag = np.hypot(zg, mg)
         angle = np.arctan2(mg, zg)
@@ -140,6 +140,24 @@ class TestGradientDyamondSubset:
         assert angle[self.right_fidx] < 0
         assert angle[self.top_fidx] > 0
         assert angle[self.bottom_fidx] < 0
+
+    def test_gradient_scales_by_radius(self, gridpath, datasetpath):
+        uxds = ux.open_dataset(
+            gridpath("mpas", "dyamond-30km", "gradient_grid_subset.nc"),
+            datasetpath("mpas", "dyamond-30km", "gradient_data_subset.nc"),
+        )
+        radius = uxds.uxgrid.sphere_radius
+
+        grad_scaled = uxds["gaussian"].gradient()
+        grad_unit = uxds["gaussian"].gradient(scale_by_radius=False)
+
+        nt.assert_allclose(
+            grad_scaled["zonal_gradient"], grad_unit["zonal_gradient"] / radius
+        )
+        nt.assert_allclose(
+            grad_scaled["meridional_gradient"],
+            grad_unit["meridional_gradient"] / radius,
+        )
 
 
 class TestDivergenceQuadHex:
@@ -523,6 +541,20 @@ class TestCurlDyamondSubset:
             antisymmetry_error = np.abs(curl_uv_finite + curl_vu_finite).max()
             # Use a more relaxed tolerance for discrete computation
             assert antisymmetry_error < 200.0, f"Curl antisymmetry violated, max error: {antisymmetry_error}"
+
+    def test_curl_scales_by_radius(self, gridpath, datasetpath):
+        uxds = ux.open_dataset(
+            gridpath("mpas", "dyamond-30km", "gradient_grid_subset.nc"),
+            datasetpath("mpas", "dyamond-30km", "gradient_data_subset.nc"),
+        )
+        radius = uxds.uxgrid.sphere_radius
+        u_component = uxds["face_lon"]
+        v_component = uxds["face_lat"]
+
+        curl_scaled = u_component.curl(v_component)
+        curl_unit = u_component.curl(v_component, scale_by_radius=False)
+
+        nt.assert_allclose(curl_scaled, curl_unit / radius)
 
     def test_curl_units_and_attributes(self, gridpath, datasetpath):
         """Test that curl preserves appropriate units and attributes"""

--- a/test/core/test_vector_calculus.py
+++ b/test/core/test_vector_calculus.py
@@ -152,11 +152,14 @@ class TestGradientDyamondSubset:
         grad_unit = uxds["gaussian"].gradient(scale_by_radius=False)
 
         nt.assert_allclose(
-            grad_scaled["zonal_gradient"], grad_unit["zonal_gradient"] / radius
+            grad_scaled["zonal_gradient"],
+            grad_unit["zonal_gradient"] / radius,
+            equal_nan=True,
         )
         nt.assert_allclose(
             grad_scaled["meridional_gradient"],
             grad_unit["meridional_gradient"] / radius,
+            equal_nan=True,
         )
 
 
@@ -554,7 +557,7 @@ class TestCurlDyamondSubset:
         curl_scaled = u_component.curl(v_component)
         curl_unit = u_component.curl(v_component, scale_by_radius=False)
 
-        nt.assert_allclose(curl_scaled, curl_unit / radius)
+        nt.assert_allclose(curl_scaled, curl_unit / radius, equal_nan=True)
 
     def test_curl_units_and_attributes(self, gridpath, datasetpath):
         """Test that curl preserves appropriate units and attributes"""

--- a/test/core/test_vector_calculus.py
+++ b/test/core/test_vector_calculus.py
@@ -162,6 +162,9 @@ class TestGradientDyamondSubset:
             equal_nan=True,
         )
 
+        assert grad_scaled["zonal_gradient"].attrs["units"].endswith("/m")
+        assert grad_unit["zonal_gradient"].attrs["units"].endswith("/rad")
+
 
 class TestDivergenceQuadHex:
 
@@ -558,6 +561,9 @@ class TestCurlDyamondSubset:
         curl_unit = u_component.curl(v_component, scale_by_radius=False)
 
         nt.assert_allclose(curl_scaled, curl_unit / radius, equal_nan=True)
+
+        assert curl_scaled.attrs["units"]
+        assert curl_unit.attrs["units"].endswith("/rad")
 
     def test_curl_units_and_attributes(self, gridpath, datasetpath):
         """Test that curl preserves appropriate units and attributes"""

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -1411,9 +1411,14 @@ class UxDataArray(xr.DataArray):
         """
         return _uxda_grid_aggregate(self, destination, "any", **kwargs)
 
-    def gradient(self, **kwargs) -> UxDataset:
+    def gradient(self, scale_by_radius: bool = True, **kwargs) -> UxDataset:
         """
         Computes the gradient of a data variable.
+
+        Parameters
+        ----------
+        scale_by_radius : bool, default=True
+            Scale derivatives by ``uxgrid.sphere_radius``.
 
         Returns
         -------
@@ -1441,7 +1446,9 @@ class UxDataArray(xr.DataArray):
             )
 
         # Compute the zonal and meridional gradient components of the stored data variable
-        grad_zonal_da, grad_meridional_da = _compute_gradient(self)
+        grad_zonal_da, grad_meridional_da = _compute_gradient(
+            self, scale_by_radius=scale_by_radius
+        )
 
         # Create a dataset containing both gradient components
         return UxDataset(
@@ -1454,7 +1461,9 @@ class UxDataArray(xr.DataArray):
             coords=self.coords,
         )
 
-    def curl(self, other: "UxDataArray", **kwargs) -> "UxDataArray":
+    def curl(
+        self, other: "UxDataArray", scale_by_radius: bool = True, **kwargs
+    ) -> "UxDataArray":
         """
         Computes the curl of a vector field.
 
@@ -1464,6 +1473,8 @@ class UxDataArray(xr.DataArray):
             The second component of the vector field. This UxDataArray should
             represent the meridional (v) component, while self represents the
             zonal (u) component.
+        scale_by_radius : bool, default=True
+            Scale derivatives by ``uxgrid.sphere_radius``.
         **kwargs : dict
             Additional keyword arguments (currently unused, reserved for future extensions).
 
@@ -1514,8 +1525,12 @@ class UxDataArray(xr.DataArray):
             )
 
         # Compute gradients of both components
-        grad_u_zonal, grad_u_meridional = _compute_gradient(self)
-        grad_v_zonal, grad_v_meridional = _compute_gradient(other)
+        grad_u_zonal, grad_u_meridional = _compute_gradient(
+            self, scale_by_radius=scale_by_radius
+        )
+        grad_v_zonal, grad_v_meridional = _compute_gradient(
+            other, scale_by_radius=scale_by_radius
+        )
 
         # Compute curl = ∂v/∂x - ∂u/∂y
         curl_values = grad_v_zonal.values - grad_u_meridional.values

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -1418,7 +1418,7 @@ class UxDataArray(xr.DataArray):
         Parameters
         ----------
         scale_by_radius : bool, default=True
-            Scale derivatives by ``uxgrid.sphere_radius``.
+            Divide unit-sphere derivatives by ``uxgrid.sphere_radius``.
 
         Returns
         -------
@@ -1474,7 +1474,7 @@ class UxDataArray(xr.DataArray):
             represent the meridional (v) component, while self represents the
             zonal (u) component.
         scale_by_radius : bool, default=True
-            Scale derivatives by ``uxgrid.sphere_radius``.
+            Divide unit-sphere derivatives by ``uxgrid.sphere_radius``.
         **kwargs : dict
             Additional keyword arguments (currently unused, reserved for future extensions).
 

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -1535,15 +1535,20 @@ class UxDataArray(xr.DataArray):
         # Compute curl = ∂v/∂x - ∂u/∂y
         curl_values = grad_v_zonal.values - grad_u_meridional.values
 
+        u_units = self.attrs.get("units", "")
+        has_sphere_radius = "sphere_radius" in self.uxgrid._ds.attrs
+        if scale_by_radius and has_sphere_radius:
+            curl_units = f"({u_units})/m" if u_units else "1/s"
+        else:
+            curl_units = f"({u_units})/rad" if u_units else "1/rad"
+
         # Create the result UxDataArray
         curl_da = UxDataArray(
             curl_values,
             dims=self.dims,
             attrs={
                 "long_name": f"Curl of ({self.name}, {other.name})",
-                "units": "1/s"
-                if "units" not in self.attrs
-                else f"({self.attrs.get('units', '1')})/m",
+                "units": curl_units,
                 "description": "Curl of vector field computed as ∂v/∂x - ∂u/∂y",
             },
             uxgrid=self.uxgrid,

--- a/uxarray/core/gradient.py
+++ b/uxarray/core/gradient.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 from numba import njit, prange
 
@@ -186,20 +188,38 @@ def _compute_gradient(data, scale_by_radius=True):
             "Computing the gradient is only supported for face-centered data variables."
         )
 
+    has_sphere_radius = "sphere_radius" in uxgrid._ds.attrs
     if scale_by_radius:
-        radius = uxgrid.sphere_radius
-        grad_zonal = grad_zonal / radius
-        grad_meridional = grad_meridional / radius
+        if has_sphere_radius:
+            radius = uxgrid.sphere_radius
+            grad_zonal = grad_zonal / radius
+            grad_meridional = grad_meridional / radius
+        else:
+            warnings.warn(
+                "scale_by_radius=True but the grid has no 'sphere_radius' "
+                "attribute; result is left on the unit sphere. Set "
+                "uxgrid.sphere_radius or pass scale_by_radius=False.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+    base_units = data.attrs.get("units", "")
+    if scale_by_radius and has_sphere_radius:
+        grad_units = f"{base_units}/m" if base_units else "1/m"
+    else:
+        grad_units = f"{base_units}/rad" if base_units else "1/rad"
 
     # Zonal
     grad_zonal_da = UxDataArray(
         data=grad_zonal, name="zonal_gradient", dims=data.dims, uxgrid=uxgrid
     )
+    grad_zonal_da.attrs["units"] = grad_units
 
     # Meridional
     grad_meridional_da = UxDataArray(
         data=grad_meridional, name="meridional_gradient", dims=data.dims, uxgrid=uxgrid
     )
+    grad_meridional_da.attrs["units"] = grad_units
 
     return grad_zonal_da, grad_meridional_da
 

--- a/uxarray/core/gradient.py
+++ b/uxarray/core/gradient.py
@@ -88,7 +88,7 @@ def _check_node_on_boundary_and_gather_node_neighbors(
     return bool_bdy, node_neighbors[0:num_node_neighbors]
 
 
-def _compute_gradient(data):
+def _compute_gradient(data, scale_by_radius=True):
     from uxarray import UxDataArray
 
     uxgrid = data.uxgrid
@@ -185,6 +185,11 @@ def _compute_gradient(data):
         raise ValueError(
             "Computing the gradient is only supported for face-centered data variables."
         )
+
+    if scale_by_radius:
+        radius = uxgrid.sphere_radius
+        grad_zonal = grad_zonal / radius
+        grad_meridional = grad_meridional / radius
 
     # Zonal
     grad_zonal_da = UxDataArray(


### PR DESCRIPTION
## Summary
- scale `gradient()` and `curl()` by `uxgrid.sphere_radius` by default
- add `scale_by_radius=False` for unit-sphere derivatives
- emit `UserWarning` when `scale_by_radius=True` but the grid has no `sphere_radius` attribute
- set `units` on gradient and curl outputs (`[data units]/m`, `1/s` when scaled; `/rad` otherwise)
- user guide: units callout and a solid-body-rotation vorticity example validated against $\zeta = -2\Omega \sin\varphi$

## Note

The default flips behavior for callers that were previously computing on the unit sphere and dividing the result by `sphere_radius` themselves — they will now **double-divide**. Pass `scale_by_radius=False` to restore the prior behavior.

Closes #1516