### PR TITLE
Fix UxDataset.to_array() missing args/kwargs dim and name

### DIFF
--- a/test/core/test_dataset.py
+++ b/test/core/test_dataset.py
@@ -112,3 +112,28 @@ def test_uxdataset_init_from_xarray_dataset():
     assert "a" in uxds.data_vars
     assert "x" in uxds.coords
     assert uxds.attrs["source"] == "testing"
+
+def test_uxdataset_to_array():
+    """Tests UxDataset.to_array(), ensuring `dim` and `name` kwargs work too."""
+    uxds = UxDataset(
+        data_vars={
+            "a": ("x", [1, 2]),
+            "b": ("x", [3, 4]),
+            "c": ("y", [-1, -2, -3, -4]),
+        },
+        coords={"x": [10, 20], "y": [-10, -20, -30, -40]},
+        attrs={"source": "testing"},
+    )
+    # first check basic functionality without worrying about kwargs
+    arr = uxds.to_array()
+    assert isinstance(arr, ux.UxDataArray)
+    assert arr.sizes == {"variable": 3, "x": 2, "y": 4}
+    assert arr.attrs["source"] == "testing"
+    for k, c in arr.coords.items():
+        assert k in arr.coords and c.equals(arr.coords[k])
+    # next check that dim & name args/kwargs work as expected.
+    arr1 = uxds.to_array('custom_dim')
+    assert arr1.sizes == {"custom_dim": 3, "x": 2, "y": 4}
+    assert arr1.name is None
+    arr2 = uxds.to_array(dim='custom_dim', name='custom_name')
+    assert arr2.name == 'custom_name'

--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -621,10 +621,11 @@ class UxDataset(xr.Dataset):
 
         return integral
 
-    def to_array(self,
-            dim: Hashable = 'variable',
-            name: Hashable = None,
-        ) -> UxDataArray:
+    def to_array(
+        self,
+        dim: Hashable = "variable",
+        name: Hashable = None,
+    ) -> UxDataArray:
         """Convert this ``uxarray.UxDataset`` into a ``uxarray.UxDataArray``,
         attaching this UxDataset's uxgrid to the result.
 

--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import sys
 from html import escape
-from typing import IO, Any, Mapping
+from typing import IO, Any, Hashable, Mapping
 from warnings import warn
 
 import numpy as np
@@ -621,11 +621,31 @@ class UxDataset(xr.Dataset):
 
         return integral
 
-    def to_array(self) -> UxDataArray:
-        """Override to make the result an instance of
-        ``uxarray.UxDataArray``."""
+    def to_array(self,
+            dim: Hashable = 'variable',
+            name: Hashable = None,
+        ) -> UxDataArray:
+        """Convert this ``uxarray.UxDataset`` into a ``uxarray.UxDataArray``,
+        attaching this UxDataset's uxgrid to the result.
 
-        xarr = super().to_array()
+        Similarly to xarray.Dataset.to_array(), the data variables will be
+        broadcast against each other and stacked along the first axis of
+        the new array. All coordinates of this dataset will remain coordinates.
+
+        Parameters
+        ----------
+        dim : Hashable, optional
+            Name of the new dimension. Defaults to "variable"
+        name : Hashable or None, optional
+            Name of the new data array.
+
+        Returns
+        -------
+        UxDataArray
+            The ``uxarray.UxDataset`` represented as a ``uxarray.UxDataArray``
+        """
+
+        xarr = super().to_array(dim=dim, name=name)
         return UxDataArray(xarr, uxgrid=self.uxgrid)
 
     def to_xarray(self, grid_format: str = "UGRID") -> xr.Dataset:


### PR DESCRIPTION
Closes #1520

## Overview
UxDataset.to_array() did not allow args/kwargs, even though Dataset.to_array() allows to input `dim` and `name`. This commit allows UxDataset.to_array() to accept dim and name (they are simply passed through to super().to_array()), and also adds a corresponding test in test_dataset.py.

## Expected Usage
```Python
import uxarray as ux

grid_path = "/path/to/grid.nc"
data_path = "/path/to/data.nc"

uxds = ux.open_dataset(grid_path, data_path)

example1 = uxds.to_array(dim="custom_dim_name")  # instead of the default, dim="variable"
assert "custom_dim_name" in example1.dims

example2 = uxds.to_array(name="custom_arr_name")  # instead of the default, name = None
assert example2.name == "custom_arr_name"
```

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->

**General**
- [X] An issue is linked created and linked
- [X] Add appropriate labels
- [X] Filled out Overview and Expected Usage (if applicable) sections

**Testing**
- [X] Adequate tests are created if there is new functionality
- [X] Tests cover all possible logical paths in your function
- [X] Tests are not too basic (such as simply calling a function and nothing else)

**Documentation**
- [N/A] Docstrings have been added to all new functions
- [X] Docstrings have updated with any function changes
- [N/A] Internal functions have a preceding underscore (`_`) and have been added to `docs/internal_api/index.rst`
- [N/A] User functions have been added to `docs/user_api/index.rst`
