### PR TITLE
Add UxDataArray.data_location property

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -250,6 +250,8 @@ Grid Accessor
    :toctree: generated/
 
    UxDataArray.uxgrid
+   UxDataArray.data_mapping
+   UxDataArray.data_location
 
 
 UxDataset

--- a/test/core/test_dataarray.py
+++ b/test/core/test_dataarray.py
@@ -134,3 +134,32 @@ def test_isel_invalid_dim(gridpath, datasetpath):
         match=r"Dimensions \{'level'\} do not exist\..*Available dimensions: \('time', 'n_face'\)",
     ):
         uxda.isel(level=0)
+
+
+def test_data_location():
+    """Tests data_location for face/node/edge centered data and non-grid data."""
+    uxgrid = ux.Grid.from_healpix(zoom=1)
+
+    face_da = UxDataArray(
+        np.ones(uxgrid.n_face), dims=["n_face"], uxgrid=uxgrid
+    )
+    node_da = UxDataArray(
+        np.ones(uxgrid.n_node), dims=["n_node"], uxgrid=uxgrid
+    )
+    edge_da = UxDataArray(
+        np.ones(uxgrid.n_edge), dims=["n_edge"], uxgrid=uxgrid
+    )
+    other_da = UxDataArray(
+        np.ones(5), dims=["other_dim"], uxgrid=uxgrid
+    )
+
+    assert face_da.data_location == "face_centered"
+    assert node_da.data_location == "node_centered"
+    assert edge_da.data_location == "edge_centered"
+    assert other_da.data_location is None
+
+    # Works when an extra (non-grid) dimension is present
+    face_time = UxDataArray(
+        np.ones((3, uxgrid.n_face)), dims=["time", "n_face"], uxgrid=uxgrid
+    )
+    assert face_time.data_location == "face_centered"

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -164,6 +164,40 @@ class UxDataArray(xr.DataArray):
         else:
             return None
 
+    @property
+    def data_location(self):
+        """Returns where on the grid the data variable is stored.
+
+        The location is inferred from the grid dimension present in the data
+        variable, using UGRID-style names:
+
+        - ``"face_centered"`` if the data contains the ``n_face`` dimension
+        - ``"node_centered"`` if the data contains the ``n_node`` dimension
+        - ``"edge_centered"`` if the data contains the ``n_edge`` dimension
+        - ``None`` if the data is not mapped to the grid
+
+        Notes
+        -----
+        Additional locations described in the UGRID/spectral-element ecosystem
+        (e.g. ``"face_average"``, ``"edge_orthogonal"``, ``"edge_parallel"``,
+        ``"cgll"``, ``"dgll"``) cannot be inferred from a data variable's
+        dimensions alone and are not currently distinguished here.
+
+        Returns
+        -------
+        str or None
+            One of ``"face_centered"``, ``"node_centered"``,
+            ``"edge_centered"``, or ``None``.
+        """
+        if self._face_centered():
+            return "face_centered"
+        elif self._node_centered():
+            return "node_centered"
+        elif self._edge_centered():
+            return "edge_centered"
+        else:
+            return None
+
     def to_geodataframe(
         self,
         periodic_elements: str | None = "exclude",


### PR DESCRIPTION
## Overview

Adds a public `UxDataArray.data_location` property that reports where a data
variable is stored on the grid, addressing the long-open issue #547 (opened in
October 2023).

## What it does

`data_location` infers the storage location from the grid dimension present on
the data variable and returns one of:

- `"face_centered"` — data contains the `n_face` dimension
- `"node_centered"` — data contains the `n_node` dimension
- `"edge_centered"` — data contains the `n_edge` dimension
- `None` — data is not mapped to the grid

This builds on the existing internal `_face_centered()` / `_node_centered()` /
`_edge_centered()` helpers and complements the existing `data_mapping` property.

## Scope note

The original issue proposed a richer enumeration including `face_average`,
`edge_orthogonal`, `edge_parallel`, `cgll`, and `dgll` (with polynomial order
for the spectral-element cases). Those locations cannot be inferred from a data
variable's dimensions alone and are not currently representable in UXarray, so
this PR implements the three locations that are reliably determinable today and
documents the rest as not-yet-distinguished. Happy to extend the enum if/when
the underlying metadata becomes available.

## Changes

- Add `UxDataArray.data_location` property (`uxarray/core/dataarray.py`)
- Add it (and the existing `data_mapping`) to the API reference (`docs/api.rst`)
- Add unit tests covering all three locations plus the non-grid / extra-dim
  cases (`test/core/test_dataarray.py`)

Closes #547
