### PR TITLE
Update Read the Docs Python installer

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-lts-latest
   tools:
-    python: mambaforge-latest
+    python: miniforge3-latest
   jobs:
     post_checkout:
       - git fetch --unshallow || true


### PR DESCRIPTION
Changes the Read the Docs Python installer to miniforge ([the mambaforge option was recently deprecated](https://docs.readthedocs.com/platform/stable/config-file/v2.html#build-tools-python)).  This should get the docs builds working again for you all.
