### PR TITLE
Fix gradient returning all NaN on SCRIP-derived grids

### DIFF
--- a/test/core/test_vector_calculus.py
+++ b/test/core/test_vector_calculus.py
@@ -23,13 +23,17 @@ class TestGradientQuadHex:
         assert uxds['t2m'].sizes == grad_ds.sizes
 
     def test_gradient_all_boundary_faces(self, gridpath, datasetpath):
-        """Quad hexagon grid has 4 faces, each of which are on the boundary, so the expected gradients are zero for both components"""
+        """Quad hexagon grid has 4 faces, all touching the boundary.
+
+        Each face still has some interior edges, so the gradient should
+        produce finite (small) values rather than NaN.
+        """
         uxds = ux.open_dataset(gridpath("ugrid", "quad-hexagon", "grid.nc"), datasetpath("ugrid", "quad-hexagon", "data.nc"))
 
         grad = uxds['t2m'].gradient()
 
-        assert np.isnan(grad['meridional_gradient']).all()
-        assert np.isnan(grad['zonal_gradient']).all()
+        assert not np.isnan(grad['meridional_gradient']).any()
+        assert not np.isnan(grad['zonal_gradient']).any()
 
 
 class TestGradientMPASOcean:

--- a/uxarray/core/gradient.py
+++ b/uxarray/core/gradient.py
@@ -295,59 +295,58 @@ def _compute_gradients_on_faces(
     # Parallel across faces
     for face_idx in prange(n_face):
         gradient = np.zeros(3)
+        has_contribution = False
 
-        if not _check_face_on_boundary(
-            face_idx,
-            face_node_connectivity,
-            node_edge_connectivity,
-            edge_face_connectivity,
-        ):  # check face is not on boundary
-            for node_idx in face_node_connectivity[
-                face_idx
-            ]:  # take each node on that face
-                if node_idx != INT_FILL_VALUE:
-                    for edge_idx in node_edge_connectivity[
-                        node_idx
-                    ]:  # grab each edge connected to that node
-                        if edge_idx != INT_FILL_VALUE:
-                            if (
-                                face_idx not in edge_face_connectivity[edge_idx]
-                            ):  # check if edge connected to original face
-                                face1_idx = edge_face_connectivity[edge_idx][0]
-                                face2_idx = edge_face_connectivity[edge_idx][1]
+        for node_idx in face_node_connectivity[face_idx]:  # take each node on that face
+            if node_idx != INT_FILL_VALUE:
+                for edge_idx in node_edge_connectivity[
+                    node_idx
+                ]:  # grab each edge connected to that node
+                    if edge_idx != INT_FILL_VALUE:
+                        # Skip edges that lack a second face neighbor
+                        # instead of NaN-ing the entire face.  Fixes
+                        # grids where edge_face_connectivity has
+                        # spurious INT_FILL_VALUE entries (e.g. SCRIP-
+                        # derived SE grids like ne120np4).  See #1452.
+                        if INT_FILL_VALUE in edge_face_connectivity[edge_idx]:
+                            continue
 
-                                face1_coords = face_coords[face1_idx]
-                                face2_coords = face_coords[face2_idx]
+                        if (
+                            face_idx not in edge_face_connectivity[edge_idx]
+                        ):  # check if edge connected to original face
+                            face1_idx = edge_face_connectivity[edge_idx][0]
+                            face2_idx = edge_face_connectivity[edge_idx][1]
 
-                                # compute normal pointing outwards from face
-                                cross = np.cross(face1_coords, face2_coords)
-                                norm = np.linalg.norm(cross)
-                                if (
-                                    np.dot(cross, face1_coords - face_coords[face_idx])
-                                    > 0
-                                ):
-                                    normal = cross / norm
-                                else:
-                                    normal = -cross / norm
+                            face1_coords = face_coords[face1_idx]
+                            face2_coords = face_coords[face2_idx]
 
-                                # compute arc length between the two faces
-                                arc_length = _compute_arc_length(
-                                    face_lat[face1_idx],
-                                    face_lat[face2_idx],
-                                    face_lon[face1_idx],
-                                    face_lon[face2_idx],
-                                )
+                            # compute normal pointing outwards from face
+                            cross = np.cross(face1_coords, face2_coords)
+                            norm = np.linalg.norm(cross)
+                            if np.dot(cross, face1_coords - face_coords[face_idx]) > 0:
+                                normal = cross / norm
+                            else:
+                                normal = -cross / norm
 
-                                # compute trapezoidal rule
-                                trapz = (data[face1_idx] + data[face2_idx]) / 2
+                            # compute arc length between the two faces
+                            arc_length = _compute_arc_length(
+                                face_lat[face1_idx],
+                                face_lat[face2_idx],
+                                face_lon[face1_idx],
+                                face_lon[face2_idx],
+                            )
 
-                                # add to the gradient (subtract correction term)
-                                gradient = (
-                                    gradient
-                                    + (trapz - data[face_idx]) * arc_length * normal
-                                )
+                            # compute trapezoidal rule
+                            trapz = (data[face1_idx] + data[face2_idx]) / 2
 
-        else:
+                            # add to the gradient (subtract correction term)
+                            gradient = (
+                                gradient
+                                + (trapz - data[face_idx]) * arc_length * normal
+                            )
+                            has_contribution = True
+
+        if not has_contribution:
             gradient = np.full(3, np.nan)
 
         node_neighbors = face_node_connectivity[face_idx]


### PR DESCRIPTION
Skip edges with incomplete `edge_face_connectivity` in the gradient stencil instead of NaN-ing the entire face. Fixes #1452.

The ne120np4 grid in #1452 is a spectral element cubed-sphere mesh read through SCRIP format. UXarray's SCRIP reader deduplicates corner coordinates with exact floating-point comparison, but SE grids compute shared boundary nodes independently per element, so coordinates at element junctions can differ by machine epsilon. This prevents node merging and produces edges that only one face claims, leaving `INT_FILL_VALUE` in `edge_face_connectivity` for most edges. The boundary check then falsely flags nearly every face and sets the gradient to NaN — exactly what @jpan84 observed (1 non-NaN value out of 777,602 faces).

This fix skips those incomplete edges per-edge rather than rejecting the whole face, which is sufficient for exploratory analysis of smooth fields. The proper long-term fix is tolerance-based node deduplication in the SCRIP reader or native SE grid support (#1402).