### PR TITLE
Fix stale per-radian magnitude assumptions after sphere-radius scaling

### DIFF
--- a/docs/user-guide/vector_calculus.ipynb
+++ b/docs/user-guide/vector_calculus.ipynb
@@ -125,7 +125,9 @@
    "cell_type": "markdown",
    "id": "66caacb5",
    "metadata": {},
-   "source": "> **Units.** By default, `gradient()` and `curl()` divide by `uxgrid.sphere_radius` so derivatives carry physical units (e.g. `[data units]/m`, `1/s` for velocity curl). Pass `scale_by_radius=False` to keep results on the unit sphere (per radian). If the grid has no `sphere_radius` attribute, the call falls back to unit-sphere output and emits a `UserWarning`."
+   "source": [
+    "> **Units.** By default, `gradient()` and `curl()` divide by `uxgrid.sphere_radius` so derivatives carry physical units (e.g. `[data units]/m`, `1/s` for velocity curl). Pass `scale_by_radius=False` to keep results on the unit sphere (per radian). If the grid has no `sphere_radius` attribute, the call falls back to unit-sphere output and emits a `UserWarning`."
+   ]
   },
   {
    "cell_type": "code",
@@ -328,7 +330,9 @@
    "source": [
     "### Example 1: Curl of Gradient Field\n",
     "\n",
-    "In the continuous setting, curl(∇φ) = 0 exactly for any scalar field φ. On an unstructured mesh, however, gradient and curl are independent finite-volume stencils that do not form a discrete de Rham complex, so the identity holds only approximately. The residual is a **discretization error** — not a bug — and shrinks with grid refinement (O(Δx) for first-order stencils). For a Gaussian field on a coarse mesh the residual is typically O(1–10), consistent with the grid spacing.\n"
+    "In the continuous setting, curl(∇φ) = 0 exactly for any scalar field φ. On an unstructured mesh, however, gradient and curl are independent finite-volume stencils that do not form a discrete de Rham complex, so the identity holds only approximately. The residual is a **discretization error** — not a bug — and shrinks with grid refinement.\n",
+    "\n",
+    "The *magnitude* of the residual depends on the units. By default `gradient()`/`curl()` scale by `uxgrid.sphere_radius` (Earth ≈ 6.37×10⁶ m), so each derivative picks up a factor of 1/radius. `curl(∇φ)` applies the gradient stencil twice and therefore carries a factor of 1/radius² (≈ 4×10⁻¹⁴). For the Gaussian field here (φ ~ O(1)) the scaled residual is ~O(10⁻¹³); on the unit sphere (`scale_by_radius=False`) the same residual is ~O(1–10). Either way it shrinks with refinement.\n"
    ]
   },
   {
@@ -356,7 +360,9 @@
     ")\n",
     "print(f\"Mean absolute curl: {abs(curl_of_gradient).mean().values:.2e}\")\n",
     "\n",
-    "curl_plot = curl_of_gradient.plot(cmap=\"RdBu_r\", aspect=1, clim=(-1e-10, 1e-10)).opts(\n",
+    "# Note: values are ~O(1e-13) (per meter^2) with the default radius scaling,\n",
+    "# so we let the color limits autoscale rather than hardcoding them.\n",
+    "curl_plot = curl_of_gradient.plot(cmap=\"RdBu_r\", aspect=1).opts(\n",
     "    title=\"Curl of Gradient Field (Should ≈ 0)\", colorbar=True\n",
     ")\n",
     "curl_plot"
@@ -402,7 +408,7 @@
     "    v_vortex_data, dims=[\"n_face\"], uxgrid=uxds.uxgrid, name=\"v_vortex\"\n",
     ")\n",
     "\n",
-    "# Compute curl via gradients\n",
+    "# Compute curl via gradients (default: scaled by sphere_radius -> per meter)\n",
     "grad_u = u_vortex.gradient()\n",
     "grad_v = v_vortex.gradient()\n",
     "du_dy = grad_u[\"meridional_gradient\"]\n",
@@ -410,9 +416,11 @@
     "curl_vortex = dv_dx - du_dy\n",
     "\n",
     "print(\n",
-    "    f\"Vortex curl range: [{curl_vortex.min().values:.2f}, {curl_vortex.max().values:.2f}]\"\n",
+    "    f\"Vortex curl range: [{curl_vortex.min().values:.2e}, {curl_vortex.max().values:.2e}]\"\n",
     ")\n",
-    "print(\"Expected curl for pure rotation: ~2.0\")"
+    "# On the unit sphere this rotation has curl ~2; with the default radius scaling\n",
+    "# the result is that value divided by sphere_radius (positive and roughly uniform).\n",
+    "print(f\"Mean vortex curl: {curl_vortex.mean().values:.2e} (positive => rotational)\")"
    ]
   },
   {
@@ -451,7 +459,25 @@
    "cell_type": "markdown",
    "id": "6e67a135",
    "metadata": {},
-   "source": "### Example 3: Relative Vorticity from Solid-Body Rotation\n\nThe 2D curl on the sphere is **relative vorticity** $\\zeta = \\partial v/\\partial x - \\partial u/\\partial y$, a quantity meteorologists and oceanographers care about every day. With the default `scale_by_radius=True`, `u.curl(v)` returns $\\zeta$ in physical units of $s^{-1}$.\n\nA clean analytical check is **solid-body rotation about the polar axis** with angular speed $\\Omega$:\n\n$$\nu(\\varphi) = \\Omega R \\cos\\varphi, \\qquad v = 0\n$$\n\nFor this flow the relative vorticity on a sphere of radius $R$ is\n\n$$\n\\zeta = -\\frac{1}{R\\cos\\varphi}\\frac{\\partial(u\\cos\\varphi)}{\\partial \\varphi} = -2\\Omega \\sin\\varphi.\n$$\n\nWe construct the field on the existing MPAS subset and compare `u.curl(v)` against this closed form."
+   "source": [
+    "### Example 3: Relative Vorticity from Solid-Body Rotation\n",
+    "\n",
+    "The 2D curl on the sphere is **relative vorticity** $\\zeta = \\partial v/\\partial x - \\partial u/\\partial y$, a quantity meteorologists and oceanographers care about every day. With the default `scale_by_radius=True`, `u.curl(v)` returns $\\zeta$ in physical units of $s^{-1}$.\n",
+    "\n",
+    "A clean analytical check is **solid-body rotation about the polar axis** with angular speed $\\Omega$:\n",
+    "\n",
+    "$$\n",
+    "u(\\varphi) = \\Omega R \\cos\\varphi, \\qquad v = 0\n",
+    "$$\n",
+    "\n",
+    "For this flow the relative vorticity on a sphere of radius $R$ is\n",
+    "\n",
+    "$$\n",
+    "\\zeta = -\\frac{1}{R\\cos\\varphi}\\frac{\\partial(u\\cos\\varphi)}{\\partial \\varphi} = -2\\Omega \\sin\\varphi.\n",
+    "$$\n",
+    "\n",
+    "We construct the field on the existing MPAS subset and compare `u.curl(v)` against this closed form."
+   ]
   },
   {
    "cell_type": "code",
@@ -679,7 +705,8 @@
     "print(f\"Mean absolute divergence: {abs(div_vortex).mean().values:.2e}\")\n",
     "print(\"Pure rotation should have zero divergence\")\n",
     "\n",
-    "div_vortex_plot = div_vortex.plot(cmap=\"RdBu_r\", aspect=1, clim=(-1e-10, 1e-10)).opts(\n",
+    "# Residual is ~O(1e-13) with default radius scaling; let color limits autoscale.\n",
+    "div_vortex_plot = div_vortex.plot(cmap=\"RdBu_r\", aspect=1).opts(\n",
     "    title=\"Divergence of Vortex (Should ≈ 0)\", colorbar=True\n",
     ")\n",
     "div_vortex_plot"
@@ -713,7 +740,7 @@
     "    v_radial_data, dims=[\"n_face\"], uxgrid=uxds.uxgrid, name=\"v_radial\"\n",
     ")\n",
     "\n",
-    "# Compute curl and divergence via gradients\n",
+    "# Compute curl and divergence via gradients (default: scaled by sphere_radius)\n",
     "grad_u = u_radial.gradient()\n",
     "grad_v = v_radial.gradient()\n",
     "du_dy = grad_u[\"meridional_gradient\"]\n",
@@ -728,9 +755,13 @@
     "    f\"Radial field curl range: [{curl_radial.min().values:.2e}, {curl_radial.max().values:.2e}]\"\n",
     ")\n",
     "print(\n",
-    "    f\"Radial field divergence range: [{div_radial.min().values:.2f}, {div_radial.max().values:.2f}]\"\n",
+    "    f\"Radial field divergence range: [{div_radial.min().values:.2e}, {div_radial.max().values:.2e}]\"\n",
     ")\n",
-    "print(\"Expected: curl ≈ 0, divergence ≈ 2 (pure expansion)\")"
+    "# On the unit sphere this expansion has curl ~0 and divergence ~2; with the\n",
+    "# default radius scaling both are divided by sphere_radius.\n",
+    "print(\n",
+    "    \"Expected (unit sphere): curl ≈ 0, divergence ≈ 2; scaled values are /radius smaller\"\n",
+    ")"
    ]
   },
   {
@@ -754,6 +785,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "26b6a175",
    "metadata": {},
    "source": [
     "## 4. Scalar Dot Gradient (**v** · ∇q)\n",
@@ -774,6 +806,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "34cb8d60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -792,6 +825,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e9c38f86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -809,6 +843,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c717562e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -828,7 +863,7 @@
     "Let's verify some fundamental vector calculus identities using our computed fields:\n",
     "\n",
     "### Identity 1: Curl of Gradient (Discretization Residual)\n",
-    "In the continuous setting: ∇ × (∇φ) = 0. UXarray's finite-volume operators are not mimetic, so this holds only approximately. The residual below is discretization error, not a numerical bug.\n"
+    "In the continuous setting: ∇ × (∇φ) = 0. UXarray's finite-volume operators are not mimetic, so this holds only approximately. The residual below is discretization error, not a numerical bug. With the default radius scaling it is ~O(10⁻¹³) for this φ ~ O(1) field (the curl stencil applies a 1/radius² factor); on the unit sphere it is ~O(1–10). It shrinks with grid refinement.\n"
    ]
   },
   {
@@ -883,12 +918,12 @@
     ")\n",
     "print()\n",
     "print(\"Vortex field (pure rotation):\")\n",
-    "print(f\"  - Curl: {curl_vortex.mean().values:.2f} (≈ 2, rotational)\")\n",
+    "print(f\"  - Curl: {curl_vortex.mean().values:.2e} (> 0, rotational)\")\n",
     "print(f\"  - Divergence: {np.abs(div_vortex).max().values:.2e} (≈ 0, incompressible)\")\n",
     "print()\n",
     "print(\"Radial field (pure expansion):\")\n",
     "print(f\"  - Curl: {np.abs(curl_radial).max().values:.2e} (≈ 0, irrotational)\")\n",
-    "print(f\"  - Divergence: {div_radial.mean().values:.2f} (≈ 2, expanding)\")"
+    "print(f\"  - Divergence: {div_radial.mean().values:.2e} (> 0, expanding)\")"
    ]
   }
  ],
@@ -908,7 +943,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.14.4"
+   "version": "3.12.2"
   }
  },
  "nbformat": 4,

--- a/test/core/test_vector_calculus.py
+++ b/test/core/test_vector_calculus.py
@@ -663,9 +663,8 @@ class TestCurlDyamondSubset:
         # Default output is the unit-sphere result divided by sphere_radius.
         nt.assert_allclose(div_scaled, div_unit / radius, equal_nan=True)
 
-        # Units should reflect the scaling (per meter vs per radian) and must not
-        # be hardcoded to 1/s regardless of input.
-        assert div_scaled.attrs["units"]
+        # Units should reflect the scaling (per meter vs per radian).
+        assert div_scaled.attrs["units"].endswith("/m")
         assert div_unit.attrs["units"].endswith("/rad")
 
     def test_curl_units_and_attributes(self, gridpath, datasetpath):

--- a/test/core/test_vector_calculus.py
+++ b/test/core/test_vector_calculus.py
@@ -549,7 +549,8 @@ class TestCurlDyamondSubset:
         # Boundary faces may have NaN values (which is expected)
         assert not np.isnan(finite_values).any(), "Found NaN in finite values"
 
-        # For a rotational field, curl should be non-zero
+        # For a rotational field, curl should be non-zero. With default radius
+        # scaling the magnitude is ~1e-7, comfortably above this lower bound.
         assert np.abs(finite_values).max() > 1e-10, "Curl values too small for rotational field"
 
     def test_curl_conservative_field(self, gridpath, datasetpath):
@@ -573,10 +574,12 @@ class TestCurlDyamondSubset:
 
         assert len(finite_values) > 0, "No finite curl values found"
 
-        # Curl of gradient should be close to zero (vector calculus identity)
-        # Allow for some numerical error in discrete computation
+        # Curl of gradient should be close to zero (vector calculus identity).
+        # With the default scale_by_radius=True the curl stencil applies a
+        # 1/radius^2 factor, so for this phi ~ O(1) field the residual is ~1e-13.
+        # Use a tight bound so a real regression is actually caught.
         max_curl = np.abs(finite_values).max()
-        assert max_curl < 10.0, f"Curl of gradient too large: {max_curl}"
+        assert max_curl < 1e-9, f"Curl of gradient too large: {max_curl}"
 
     def test_curl_identity_properties(self, gridpath, datasetpath):
         """Test vector calculus identities involving curl"""
@@ -596,8 +599,11 @@ class TestCurlDyamondSubset:
         finite_values = curl_grad.values[finite_mask]
 
         assert len(finite_values) > 0, "No finite curl values found"
+        # With default radius scaling the residual is ~1e-13 (1/radius^2 factor).
         max_curl_grad = np.abs(finite_values).max()
-        assert max_curl_grad < 10.0, f"curl(grad(f)) should be zero, got max: {max_curl_grad}"
+        assert max_curl_grad < 1e-9, (
+            f"curl(grad(f)) should be zero, got max: {max_curl_grad}"
+        )
 
         # Test 2: curl is antisymmetric: curl(u,v) = -curl(v,u)
         u_component = uxds['face_lon']
@@ -618,8 +624,12 @@ class TestCurlDyamondSubset:
             # curl(u,v) should equal -curl(v,u)
             # Note: Due to discrete computation, perfect antisymmetry may not hold
             antisymmetry_error = np.abs(curl_uv_finite + curl_vu_finite).max()
-            # Use a more relaxed tolerance for discrete computation
-            assert antisymmetry_error < 200.0, f"Curl antisymmetry violated, max error: {antisymmetry_error}"
+            # With default radius scaling the curl magnitudes are ~1e-10, so the
+            # antisymmetry residual is ~1e-5; keep a tolerance that reflects this
+            # scale rather than the old unit-sphere (~hundreds) bound.
+            assert antisymmetry_error < 1e-3, (
+                f"Curl antisymmetry violated, max error: {antisymmetry_error}"
+            )
 
     def test_curl_scales_by_radius(self, gridpath, datasetpath):
         uxds = ux.open_dataset(
@@ -637,6 +647,26 @@ class TestCurlDyamondSubset:
 
         assert curl_scaled.attrs["units"]
         assert curl_unit.attrs["units"].endswith("/rad")
+
+    def test_divergence_scales_by_radius(self, gridpath, datasetpath):
+        uxds = ux.open_dataset(
+            gridpath("mpas", "dyamond-30km", "gradient_grid_subset.nc"),
+            datasetpath("mpas", "dyamond-30km", "gradient_data_subset.nc"),
+        )
+        radius = uxds.uxgrid.sphere_radius
+        u_component = uxds["face_lon"]
+        v_component = uxds["face_lat"]
+
+        div_scaled = u_component.divergence(v_component)
+        div_unit = u_component.divergence(v_component, scale_by_radius=False)
+
+        # Default output is the unit-sphere result divided by sphere_radius.
+        nt.assert_allclose(div_scaled, div_unit / radius, equal_nan=True)
+
+        # Units should reflect the scaling (per meter vs per radian) and must not
+        # be hardcoded to 1/s regardless of input.
+        assert div_scaled.attrs["units"]
+        assert div_unit.attrs["units"].endswith("/rad")
 
     def test_curl_units_and_attributes(self, gridpath, datasetpath):
         """Test that curl preserves appropriate units and attributes"""

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -1483,12 +1483,20 @@ class UxDataArray(xr.DataArray):
         Parameters
         ----------
         scale_by_radius : bool, default=True
-            Divide unit-sphere derivatives by ``uxgrid.sphere_radius``.
+            Divide unit-sphere derivatives by ``uxgrid.sphere_radius`` so the
+            result carries physical, per-meter units (``[data units]/m``). When
+            ``False`` the result is left on the unit sphere with per-radian units
+            (``[data units]/rad``). If ``True`` but the grid has no
+            ``sphere_radius`` attribute, the result falls back to unit-sphere
+            output and a ``UserWarning`` is emitted.
 
         Returns
         -------
         gradient: UxDataset
             Dataset containing the zonal and merdional components of the gradient.
+            With the default ``scale_by_radius=True`` the components are in
+            ``[data units]/m``; with ``scale_by_radius=False`` they are in
+            ``[data units]/rad``.
 
         Notes
         -----
@@ -1496,6 +1504,11 @@ class UxDataArray(xr.DataArray):
         is formed connecting centroids of the neighboring cells. The surface integral is
         approximated using the trapezoidal rule. The sum of the contributions is then
         normalized by the cell volume.
+
+        By default the raw unit-sphere (per-radian) gradient is divided by
+        ``uxgrid.sphere_radius`` to yield physical per-meter values. For Earth
+        (radius ~6.37e6 m) this scales magnitudes down by ~1/6.37e6 relative to
+        the unit-sphere result.
 
         Example
         -------
@@ -1539,7 +1552,10 @@ class UxDataArray(xr.DataArray):
             represent the meridional (v) component, while self represents the
             zonal (u) component.
         scale_by_radius : bool, default=True
-            Divide unit-sphere derivatives by ``uxgrid.sphere_radius``.
+            Divide unit-sphere derivatives by ``uxgrid.sphere_radius`` so the
+            result carries physical, per-meter units (e.g. ``1/s`` for a velocity
+            field). When ``False`` the result is left on the unit sphere
+            (per radian).
         **kwargs : dict
             Additional keyword arguments (currently unused, reserved for future extensions).
 
@@ -1547,7 +1563,9 @@ class UxDataArray(xr.DataArray):
         -------
         curl : UxDataArray
             The curl of the vector field (u, v), computed as:
-            curl = ∂v/∂x - ∂u/∂y
+            curl = ∂v/∂x - ∂u/∂y. With the default ``scale_by_radius=True`` the
+            result is in ``([u units])/m`` (``1/s`` for velocity); with
+            ``scale_by_radius=False`` it is in ``([u units])/rad``.
 
         Notes
         -----
@@ -1622,7 +1640,9 @@ class UxDataArray(xr.DataArray):
 
         return curl_da
 
-    def divergence(self, other: "UxDataArray", **kwargs) -> "UxDataArray":
+    def divergence(
+        self, other: "UxDataArray", scale_by_radius: bool = True, **kwargs
+    ) -> "UxDataArray":
         """
         Computes the divergence of the vector field defined by this UxDataArray and other.
 
@@ -1630,8 +1650,15 @@ class UxDataArray(xr.DataArray):
         ----------
         other : UxDataArray
             The second component of the vector field. This UxDataArray represents the first component.
+        scale_by_radius : bool, default=True
+            Divide unit-sphere derivatives by ``uxgrid.sphere_radius``. When
+            ``True`` (and the grid has a ``sphere_radius`` attribute) the result
+            carries physical, per-meter units (e.g. ``1/s`` for a velocity
+            field); when ``False`` the result is left on the unit sphere
+            (per radian).
         **kwargs
-            Additional keyword arguments (reserved for future use).
+            Additional keyword arguments. ``units`` may be passed to override the
+            automatically inferred units.
 
         Returns
         -------
@@ -1645,7 +1672,9 @@ class UxDataArray(xr.DataArray):
         the divergence is calculated as div(V) = ∂u/∂x + ∂v/∂y.
 
         The implementation uses edge-centered gradients and face-centered divergence calculation
-        following the discrete divergence theorem.
+        following the discrete divergence theorem. By default the underlying
+        gradients are divided by ``uxgrid.sphere_radius``; pass
+        ``scale_by_radius=False`` for per-radian (unit-sphere) output.
 
         Example
         -------
@@ -1675,8 +1704,8 @@ class UxDataArray(xr.DataArray):
             )
 
         # Compute gradients of both components
-        u_gradient = self.gradient()
-        v_gradient = other.gradient()
+        u_gradient = self.gradient(scale_by_radius=scale_by_radius)
+        v_gradient = other.gradient(scale_by_radius=scale_by_radius)
 
         # For divergence: div(V) = ∂u/∂x + ∂v/∂y
         # We use the zonal gradient (∂/∂lon) of u and meridional gradient (∂/∂lat) of v
@@ -1687,10 +1716,24 @@ class UxDataArray(xr.DataArray):
         u, v = xr.align(u, v)
         divergence = u + v
         divergence.name = "divergence"
+
+        # Infer units consistently with gradient()/curl(): a divergence is a
+        # spatial derivative of the input field, so it carries an extra 1/length
+        # factor (per meter when scaled by radius, otherwise per radian).
+        if "units" in kwargs:
+            div_units = kwargs["units"]
+        else:
+            u_units = self.attrs.get("units", "")
+            has_sphere_radius = "sphere_radius" in self.uxgrid._ds.attrs
+            if scale_by_radius and has_sphere_radius:
+                div_units = f"({u_units})/m" if u_units else "1/s"
+            else:
+                div_units = f"({u_units})/rad" if u_units else "1/rad"
+
         divergence.attrs.update(
             {
                 "divergence": True,
-                "units": "1/s" if "units" not in kwargs else kwargs["units"],
+                "units": div_units,
             }
         )
 

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -1493,14 +1493,14 @@ class UxDataArray(xr.DataArray):
         Returns
         -------
         gradient: UxDataset
-            Dataset containing the zonal and merdional components of the gradient.
+            Dataset containing the zonal and meridional components of the gradient.
             With the default ``scale_by_radius=True`` the components are in
             ``[data units]/m``; with ``scale_by_radius=False`` they are in
             ``[data units]/rad``.
 
         Notes
         -----
-        The Green-Gauss theorm is utilized, where a closed control volume around each cell
+        The Green-Gauss theorem is utilized, where a closed control volume around each cell
         is formed connecting centroids of the neighboring cells. The surface integral is
         approximated using the trapezoidal rule. The sum of the contributions is then
         normalized by the cell volume.
@@ -1621,7 +1621,7 @@ class UxDataArray(xr.DataArray):
         u_units = self.attrs.get("units", "")
         has_sphere_radius = "sphere_radius" in self.uxgrid._ds.attrs
         if scale_by_radius and has_sphere_radius:
-            curl_units = f"({u_units})/m" if u_units else "1/s"
+            curl_units = f"({u_units})/m" if u_units else "1/m"
         else:
             curl_units = f"({u_units})/rad" if u_units else "1/rad"
 
@@ -1649,7 +1649,8 @@ class UxDataArray(xr.DataArray):
         Parameters
         ----------
         other : UxDataArray
-            The second component of the vector field. This UxDataArray represents the first component.
+            The second (meridional, v) component of the vector field; ``self`` is
+            the first (zonal, u) component.
         scale_by_radius : bool, default=True
             Divide unit-sphere derivatives by ``uxgrid.sphere_radius``. When
             ``True`` (and the grid has a ``sphere_radius`` attribute) the result
@@ -1726,7 +1727,7 @@ class UxDataArray(xr.DataArray):
             u_units = self.attrs.get("units", "")
             has_sphere_radius = "sphere_radius" in self.uxgrid._ds.attrs
             if scale_by_radius and has_sphere_radius:
-                div_units = f"({u_units})/m" if u_units else "1/s"
+                div_units = f"({u_units})/m" if u_units else "1/m"
             else:
                 div_units = f"({u_units})/rad" if u_units else "1/rad"
 


### PR DESCRIPTION
## Overview

After #1517 made `scale_by_radius=True` the default for `gradient()` and `curl()`, several places still assumed unit-sphere (per-radian) magnitudes. This surfaced in the docs as a confusing `curl(grad(f))` example (see #1522, where the documented O(1–10) residual is now ~1e-13).

Closes #1534. Refs #1522, #1516, #1517.

## Changes

**Code (`uxarray/core/dataarray.py`)**
- `divergence()`: add a `scale_by_radius` parameter (previously missing, unlike `gradient`/`curl`) and forward it to the underlying `gradient()` calls. Infer units from the input field and scaling instead of hardcoding `"1/s"`.
- Document output units and the default radius scaling in the `gradient()`, `curl()`, and `divergence()` docstrings.

**Docs (`docs/user-guide/vector_calculus.ipynb`)**
- Correct the `curl(grad(f))` residual wording: ~O(1e-13) with the default radius scaling (the curl stencil applies a 1/radius² factor) vs ~O(1–10) on the unit sphere.
- Update the vortex/radial examples to scientific notation (the old `:.2f` printed `0.00`) and reword the "≈ 2" annotations.
- Drop hardcoded `clim=(-1e-10, 1e-10)` on the curl/divergence plots, which rendered flat at the new ~1e-13 scale.

**Tests (`test/core/test_vector_calculus.py`)**
- Tighten the now-vacuous `curl(grad)` (`< 10.0`) and antisymmetry (`< 200.0`) thresholds to the actual scaled magnitudes (`< 1e-9` and `< 1e-3`).
- Add `test_divergence_scales_by_radius` covering the new parameter and units.

## Verification
- Re-executed the full notebook end-to-end with no errored cells; `curl(grad)` ~1.1e-13, vortex curl/radial divergence ~5.4e-5 (positive). Outputs stripped per repo convention.
- `pytest test/core/test_vector_calculus.py` → 28 passed.
- `pre-commit run --all-files` → all hooks pass.