### PR TITLE
Restore matplotlib backend after HoloViews matplotlib plot

### DIFF
--- a/test/test_plot.py
+++ b/test/test_plot.py
@@ -259,32 +259,59 @@ def test_matplotlib_backend_restored_after_switch(monkeypatch):
         matplotlib.use(original)
 
 
-def test_inline_backend_support_reconfigured(monkeypatch):
-    """Restoring the inline backend must also re-register IPython's display hook."""
+def test_inline_backend_reactivated_via_shell(monkeypatch):
+    """Inside IPython, restoring an inline backend must re-run the shell's own
+    backend activation (the public equivalent of ``%matplotlib inline``), which
+    rebuilds the full display integration that ``hv.extension`` tore down.
+
+    Simply calling ``mpl.use`` is not enough: it restores the backend name but
+    leaves last-line figure auto-display broken (see #1537 / #1538).
+    """
     import sys
     import types
 
     from uxarray.plot.utils import HoloviewsBackend
 
     inline_backend = "module://matplotlib_inline.backend_inline"
-    shell = object()
     calls = []
 
+    class FakeShell:
+        def enable_matplotlib(self, gui):
+            calls.append(("enable_matplotlib", gui))
+
     ipython = types.ModuleType("IPython")
-    ipython.get_ipython = lambda: shell
-    matplotlib_inline = types.ModuleType("matplotlib_inline")
-    backend_inline = types.ModuleType("matplotlib_inline.backend_inline")
-    backend_inline.configure_inline_support = lambda sh, backend: calls.append(
-        (sh, backend)
-    )
+    ipython.get_ipython = lambda: FakeShell()
 
     monkeypatch.setitem(sys.modules, "IPython", ipython)
-    monkeypatch.setitem(sys.modules, "matplotlib_inline", matplotlib_inline)
-    monkeypatch.setitem(sys.modules, "matplotlib_inline.backend_inline", backend_inline)
-    monkeypatch.setattr(matplotlib, "use", lambda backend: calls.append(("use", backend)))
+    monkeypatch.setattr(
+        matplotlib, "use", lambda backend: calls.append(("use", backend))
+    )
 
     be = HoloviewsBackend()
     be.matplotlib_backend = inline_backend
     be.reset_mpl_backend()
 
-    assert calls == [("use", inline_backend), (shell, inline_backend)]
+    # The module:// inline backend must be mapped to the "inline" gui name and
+    # restored through the shell, without falling back to mpl.use.
+    assert calls == [("enable_matplotlib", "inline")]
+
+
+def test_reset_backend_falls_back_to_mpl_use_outside_ipython(monkeypatch):
+    """Outside IPython (get_ipython() is None), restoration falls back to
+    ``mpl.use`` with the stored backend."""
+    import sys
+    import types
+
+    from uxarray.plot.utils import HoloviewsBackend
+
+    calls = []
+    ipython = types.ModuleType("IPython")
+    ipython.get_ipython = lambda: None
+    monkeypatch.setitem(sys.modules, "IPython", ipython)
+    monkeypatch.setattr(matplotlib, "use", lambda backend: calls.append(("use", backend)))
+
+    be = HoloviewsBackend()
+    be.matplotlib_backend = "svg"
+    be.reset_mpl_backend()
+
+    assert calls == [("use", "svg")]

--- a/test/test_plot.py
+++ b/test/test_plot.py
@@ -229,3 +229,29 @@ def test_to_raster_pixel_ratio(gridpath, r1, r2):
     f = r2 / r1
     d = np.array(raster2.shape) - f * np.array(raster1.shape)
     assert (d >= 0).all() and (d <= f - 1).all()
+
+
+def test_matplotlib_backend_does_not_clobber_mpl_state(gridpath):
+    """Regression test for #1537.
+
+    ``plot(backend="matplotlib")`` calls ``hv.extension("matplotlib")`` which
+    switches the active Matplotlib backend and breaks subsequent native
+    Matplotlib/xarray ``.plot()`` calls. UXarray should restore the original
+    Matplotlib backend so plain Matplotlib plotting still works afterwards.
+    """
+    mesh_path = gridpath("mpas", "QU", "oQU480.231010.nc")
+    uxds = ux.open_dataset(mesh_path, mesh_path)
+
+    backend_before = matplotlib.get_backend()
+
+    # UXarray plot using the matplotlib backend (the trigger in #1537)
+    uxds["bottomDepth"].plot(backend="matplotlib")
+
+    # The active matplotlib backend must be restored.
+    assert matplotlib.get_backend() == backend_before
+
+    # A subsequent plain xarray/matplotlib plot must still work without error.
+    fig, ax = plt.subplots()
+    xr.DataArray(np.random.rand(5, 5), dims=["y", "x"], name="plain").plot(ax=ax)
+    assert len(ax.collections) + len(ax.images) > 0
+    plt.close(fig)

--- a/test/test_plot.py
+++ b/test/test_plot.py
@@ -231,27 +231,29 @@ def test_to_raster_pixel_ratio(gridpath, r1, r2):
     assert (d >= 0).all() and (d <= f - 1).all()
 
 
-def test_matplotlib_backend_does_not_clobber_mpl_state(gridpath):
-    """Regression test for #1537.
+def test_matplotlib_backend_restored_after_switch(monkeypatch):
+    """Regression test for #1537: switching HoloViews to matplotlib must restore
+    the Matplotlib backend captured beforehand.
 
-    ``plot(backend="matplotlib")`` calls ``hv.extension("matplotlib")`` which
-    switches the active Matplotlib backend and breaks subsequent native
-    Matplotlib/xarray ``.plot()`` calls. UXarray should restore the original
-    Matplotlib backend so plain Matplotlib plotting still works afterwards.
+    A bare pytest can't reproduce the Jupyter inline-hook flip, so we simulate
+    hv.extension flipping the backend and assert assign() restores it.
     """
-    mesh_path = gridpath("mpas", "QU", "oQU480.231010.nc")
-    uxds = ux.open_dataset(mesh_path, mesh_path)
+    import holoviews as hv
 
-    backend_before = matplotlib.get_backend()
+    from uxarray.plot.utils import HoloviewsBackend
 
-    # UXarray plot using the matplotlib backend (the trigger in #1537)
-    uxds["bottomDepth"].plot(backend="matplotlib")
+    original = matplotlib.get_backend()
+    try:
+        matplotlib.use("svg")  # the "user's" backend before plotting
 
-    # The active matplotlib backend must be restored.
-    assert matplotlib.get_backend() == backend_before
+        # Simulate hv.extension("matplotlib") flipping the active backend to agg.
+        monkeypatch.setattr(hv.Store, "current_backend", "bokeh", raising=False)
+        monkeypatch.setattr(hv, "extension", lambda *a, **k: matplotlib.use("agg"))
 
-    # A subsequent plain xarray/matplotlib plot must still work without error.
-    fig, ax = plt.subplots()
-    xr.DataArray(np.random.rand(5, 5), dims=["y", "x"], name="plain").plot(ax=ax)
-    assert len(ax.collections) + len(ax.images) > 0
-    plt.close(fig)
+        be = HoloviewsBackend()
+        be.assign("matplotlib")
+
+        # assign() must restore the backend that was active before the switch.
+        assert matplotlib.get_backend() == "svg"
+    finally:
+        matplotlib.use(original)

--- a/test/test_plot.py
+++ b/test/test_plot.py
@@ -257,3 +257,34 @@ def test_matplotlib_backend_restored_after_switch(monkeypatch):
         assert matplotlib.get_backend() == "svg"
     finally:
         matplotlib.use(original)
+
+
+def test_inline_backend_support_reconfigured(monkeypatch):
+    """Restoring the inline backend must also re-register IPython's display hook."""
+    import sys
+    import types
+
+    from uxarray.plot.utils import HoloviewsBackend
+
+    inline_backend = "module://matplotlib_inline.backend_inline"
+    shell = object()
+    calls = []
+
+    ipython = types.ModuleType("IPython")
+    ipython.get_ipython = lambda: shell
+    matplotlib_inline = types.ModuleType("matplotlib_inline")
+    backend_inline = types.ModuleType("matplotlib_inline.backend_inline")
+    backend_inline.configure_inline_support = lambda sh, backend: calls.append(
+        (sh, backend)
+    )
+
+    monkeypatch.setitem(sys.modules, "IPython", ipython)
+    monkeypatch.setitem(sys.modules, "matplotlib_inline", matplotlib_inline)
+    monkeypatch.setitem(sys.modules, "matplotlib_inline.backend_inline", backend_inline)
+    monkeypatch.setattr(matplotlib, "use", lambda backend: calls.append(("use", backend)))
+
+    be = HoloviewsBackend()
+    be.matplotlib_backend = inline_backend
+    be.reset_mpl_backend()
+
+    assert calls == [("use", inline_backend), (shell, inline_backend)]

--- a/uxarray/plot/utils.py
+++ b/uxarray/plot/utils.py
@@ -30,8 +30,24 @@ class HoloviewsBackend:
             # only call hv.extension if it needs to be changed
             hv.extension(backend)
 
+            if backend == "matplotlib":
+                # ``hv.extension("matplotlib")`` switches the active Matplotlib
+                # backend (e.g. to ``agg`` in Jupyter), which clobbers the
+                # IPython inline display hook. This silently breaks any
+                # subsequent native ``matplotlib``/``xarray`` ``.plot()`` calls,
+                # which render nothing. HoloViews objects still display because
+                # they render through ``hv.Store.current_backend`` rather than
+                # the active Matplotlib backend, so restoring the original
+                # backend here is safe and fixes downstream plotting. See
+                # https://github.com/UXARRAY/uxarray/issues/1537
+                self.reset_mpl_backend()
+
     def reset_mpl_backend(self):
-        """Resets the default backend for the ``matplotlib`` module."""
+        """Restores the original ``matplotlib`` backend (and its IPython inline
+        display hook) that was active before a HoloViews backend switch."""
+        if self.matplotlib_backend is None:
+            return
+
         import matplotlib as mpl
 
         mpl.use(self.matplotlib_backend)

--- a/uxarray/plot/utils.py
+++ b/uxarray/plot/utils.py
@@ -37,5 +37,19 @@ class HoloviewsBackend:
 
         mpl.use(self.matplotlib_backend)
 
+        if self.matplotlib_backend in (
+            "inline",
+            "module://matplotlib_inline.backend_inline",
+        ):
+            try:
+                from IPython import get_ipython
+                from matplotlib_inline.backend_inline import configure_inline_support
+            except ImportError:
+                return
+
+            shell = get_ipython()
+            if shell is not None:
+                configure_inline_support(shell, self.matplotlib_backend)
+
 
 backend = HoloviewsBackend()

--- a/uxarray/plot/utils.py
+++ b/uxarray/plot/utils.py
@@ -29,27 +29,44 @@ class HoloviewsBackend:
                 self.reset_mpl_backend()
 
     def reset_mpl_backend(self):
-        """Switch Matplotlib back to the backend captured before the last switch."""
+        """Restore the Matplotlib backend captured before the last switch.
+
+        ``hv.extension("matplotlib")`` does not just change the active backend;
+        in an IPython/Jupyter kernel it also tears down the display integration
+        that auto-renders figures at the end of a cell. Simply calling
+        ``mpl.use`` puts the backend name back but leaves that integration
+        broken, so subsequent native ``matplotlib``/``xarray`` ``.plot()`` calls
+        silently produce no output unless ``plt.show()`` is called explicitly.
+
+        Inside IPython we therefore re-run the shell's own backend activation
+        (the public equivalent of the ``%matplotlib`` magic), which rebuilds the
+        full integration in one step. Outside IPython we fall back to
+        ``mpl.use``.
+        """
         if self.matplotlib_backend is None:
             return
+
+        try:
+            from IPython import get_ipython
+
+            shell = get_ipython()
+        except ImportError:
+            shell = None
+
+        if shell is not None:
+            # Map the stored backend to the gui name enable_matplotlib expects.
+            gui = self.matplotlib_backend
+            if gui.startswith("module://") and "inline" in gui:
+                gui = "inline"
+            try:
+                shell.enable_matplotlib(gui)
+                return
+            except Exception:
+                pass
 
         import matplotlib as mpl
 
         mpl.use(self.matplotlib_backend)
-
-        if self.matplotlib_backend in (
-            "inline",
-            "module://matplotlib_inline.backend_inline",
-        ):
-            try:
-                from IPython import get_ipython
-                from matplotlib_inline.backend_inline import configure_inline_support
-            except ImportError:
-                return
-
-            shell = get_ipython()
-            if shell is not None:
-                configure_inline_support(shell, self.matplotlib_backend)
 
 
 backend = HoloviewsBackend()

--- a/uxarray/plot/utils.py
+++ b/uxarray/plot/utils.py
@@ -2,49 +2,34 @@ import holoviews as hv
 
 
 class HoloviewsBackend:
-    """Utility class to compare and set a HoloViews plotting backend for
-    visualization."""
+    """Compare and set the HoloViews plotting backend."""
 
     def __init__(self):
         self.matplotlib_backend = None
 
     def assign(self, backend: str):
-        """Assigns a backend for use with HoloViews visualization.
-
-        Parameters
-        ----------
-        backend : str
-            Plotting backend to use, one of 'matplotlib', 'bokeh'
-        """
-
-        if self.matplotlib_backend is None:
-            import matplotlib as mpl
-
-            self.matplotlib_backend = mpl.get_backend()
-
+        """Assign a HoloViews backend, one of 'matplotlib', 'bokeh'."""
         if backend not in ["bokeh", "matplotlib", None]:
             raise ValueError(
                 f"Unsupported backend. Expected one of ['bokeh', 'matplotlib'], but received {backend}"
             )
         if backend is not None and backend != hv.Store.current_backend:
-            # only call hv.extension if it needs to be changed
+            import matplotlib as mpl
+
+            # Capture the live backend now (not once at init) so a backend the
+            # user set later is what we restore.
+            self.matplotlib_backend = mpl.get_backend()
             hv.extension(backend)
 
             if backend == "matplotlib":
-                # ``hv.extension("matplotlib")`` switches the active Matplotlib
-                # backend (e.g. to ``agg`` in Jupyter), which clobbers the
-                # IPython inline display hook. This silently breaks any
-                # subsequent native ``matplotlib``/``xarray`` ``.plot()`` calls,
-                # which render nothing. HoloViews objects still display because
-                # they render through ``hv.Store.current_backend`` rather than
-                # the active Matplotlib backend, so restoring the original
-                # backend here is safe and fixes downstream plotting. See
-                # https://github.com/UXARRAY/uxarray/issues/1537
+                # hv.extension("matplotlib") switches the active Matplotlib
+                # backend (e.g. to agg in Jupyter), breaking subsequent native
+                # matplotlib/xarray .plot() calls. HoloViews renders through
+                # hv.Store.current_backend, so restoring is safe. See #1537.
                 self.reset_mpl_backend()
 
     def reset_mpl_backend(self):
-        """Restores the original ``matplotlib`` backend (and its IPython inline
-        display hook) that was active before a HoloViews backend switch."""
+        """Switch Matplotlib back to the backend captured before the last switch."""
         if self.matplotlib_backend is None:
             return
 


### PR DESCRIPTION
Calling `plot(backend="matplotlib")` runs `hv.extension("matplotlib")`, which switches the active matplotlib backend and clobbers the IPython inline display hook, silently breaking any subsequent native matplotlib/xarray `.plot()` calls. This restores the original matplotlib backend right after the HoloViews extension switch, which is safe because HoloViews objects display through `Store.current_backend` rather than the active matplotlib backend. Verified in real Jupyter kernels that the reported sequence now works, with a new regression test and all plotting tests/relevant docs notebooks passing; closes #1537.