### PR TITLE
fix time_face_search benchmark

### DIFF
--- a/benchmarks/mpas_ocean.py
+++ b/benchmarks/mpas_ocean.py
@@ -208,16 +208,17 @@ class PointInPolygon:
         point = np.array([0.0, 0.0, 1.0])
         res = self.uxgrid.get_faces_containing_point(point)
 
+        self.point_xyz = np.array([self.uxgrid.face_x[0].values, self.uxgrid.face_y[0].values, self.uxgrid.face_z[0].values], dtype=np.float64)
+        self.point_lonlat = np.array([self.uxgrid.face_lon[0].values, self.uxgrid.face_lat.values[0]], dtype=np.float64)
+
     def teardown(self, resolution):
         del self.uxgrid
 
     def time_face_search_xyz(self, resolution):
-        point_xyz = np.array([self.uxgrid.face_x[0].values, self.uxgrid.face_y[0].values, self.uxgrid.face_z[0].values], dtype=np.float64)
-        self.uxgrid.get_faces_containing_point(point_xyz)
+        self.uxgrid.get_faces_containing_point(self.point_xyz)
 
     def time_face_search_lonlat(self, resolution):
-        point_lonlat = np.array([self.uxgrid.face_lon[0].values, self.uxgrid.face_lat.values[0]], dtype=np.float64)
-        self.uxgrid.get_faces_containing_point(point_lonlat)
+        self.uxgrid.get_faces_containing_point(self.point_lonlat)
 
 
 class ZonalAverage(DatasetBenchmark):

--- a/benchmarks/mpas_ocean.py
+++ b/benchmarks/mpas_ocean.py
@@ -211,10 +211,13 @@ class PointInPolygon:
     def teardown(self, resolution):
         del self.uxgrid
 
-    def time_face_search(self, resolution):
+    def time_face_search_xyz(self, resolution):
         point_xyz = np.array([self.uxgrid.face_x[0].values, self.uxgrid.face_y[0].values, self.uxgrid.face_z[0].values], dtype=np.float64)
+        self.uxgrid.get_faces_containing_point(point_xyz)
+
+    def time_face_search_lonlat(self, resolution):
         point_lonlat = np.array([self.uxgrid.face_lon[0].values, self.uxgrid.face_lat.values[0]], dtype=np.float64)
-        self.uxgrid.get_faces_containing_point(point_xyz=point_xyz, point_lonlat=point_lonlat)
+        self.uxgrid.get_faces_containing_point(point_lonlat)
 
 
 class ZonalAverage(DatasetBenchmark):


### PR DESCRIPTION
Closes #1545 

## Overview
Fixes benchmarks:
```
mpas_ocean.PointInPolygon.time_face_search('120km')
mpas_ocean.PointInPolygon.time_face_search('480km')
```
which were failing with: `TypeError: Grid.get_faces_containing_point() got an unexpected keyword argument 'point_xyz'`

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->

**General**
- [X] An issue is linked created and linked
- [X] Add appropriate labels
- [X] Filled out Overview and Expected Usage (if applicable) sections