### PR TITLE
Connectivity benchmarks: gate larger files

### DIFF
--- a/benchmarks/bench_connectivity.py
+++ b/benchmarks/bench_connectivity.py
@@ -30,14 +30,21 @@ all_paths_exist = True
 for file_path in dyamond_path_dict.values():
     all_paths_exist = all_paths_exist and os.path.exists(file_path)
 
-file_path_dict = oQU_path_dict | dyamond_path_dict
+file_path_dict = oQU_path_dict
+if all_paths_exist:
+    file_path_dict = file_path_dict | dyamond_path_dict
 
 
 class GridBenchmark:
     """Class used as a template for benchmarks requiring a ``Grid`` in this
     module across both resolutions."""
     param_names = ['resolution', ]
-    params = [['480km', '120km', '30km', '15km', '7.5km', '3.75km'], ]
+
+    # Conditionally available; could get annoying if there are downstream tools relying on it.
+    if all_paths_exist:
+        params = [['480km', '120km', '30km', '15km', '7.5km', '3.75km'], ]
+    else:
+        params = [['480km', '120km'], ]
 
     def setup(self, resolution, *args, **kwargs):
         self.uxgrid = ux.open_grid(file_path_dict[resolution])

--- a/benchmarks/bench_connectivity.py
+++ b/benchmarks/bench_connectivity.py
@@ -25,6 +25,11 @@ dyamond_path_dict = {"30km": "/glade/campaign/cisl/vast/uxarray/data/dyamond/30k
                   "7.5km": "/glade/campaign/cisl/vast/uxarray/data/dyamond/7.5km/grid.nc",
                   "3.75km": "/glade/campaign/cisl/vast/uxarray/data/dyamond/3.75km/grid.nc"}
 
+# Determines if all file paths exist and are accesible
+all_paths_exist = True
+for file_path in dyamond_path_dict.values():
+    all_paths_exist = all_paths_exist and os.path.exists(file_path)
+
 file_path_dict = oQU_path_dict | dyamond_path_dict
 
 


### PR DESCRIPTION
<!--  The PR title should summarize the changes, for example "Add `Grid._build_face_dimension` function".
      Avoid non-descriptive titles such as "Addresses issue #229". -->
      
This PR is to fix an issue with the connectivity benchmarks. The current github runner doesn't seem to have access to the larger dyamond files, so those benchmarks fail and spam up the benchmark logs.

<!--  Replace XXX with the number of the issue that this PR will resolve. If this PR closed more than one,
      you may add a comma separated sequence-->

Continuation of #1549.

## Overview
<!--  Please provide a few bullet points summarizing the changes in this PR. This should include
      points on any bug fixes, new functions, or other changes that have been made. -->
      
I naively copied the file paths from the dyamond benchmarks without the gate, not realizing that the github runner wouldn't have access to them. The gate there basically pings for file access, which will fail for github's runner, but would succeed for someone running somewhere with transparent access to the data on Glade. 


## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->

**General**
- [x] An issue is linked created and linked
- [x] Add appropriate labels
- [x] Filled out Overview and Expected Usage (if applicable) sections

**Testing**
- [N/A] Adequate tests are created if there is new functionality
- [N/A] Tests cover all possible logical paths in your function
- [N/A] Tests are not too basic (such as simply calling a function and nothing else)

**Documentation**
- [ ] Docstrings have been added to all new functions
- [ ] Docstrings have updated with any function changes
- [ ] Internal functions have a preceding underscore (`_`) and have been added to `docs/internal_api/index.rst`
- [ ] User functions have been added to `docs/user_api/index.rst`

**Examples**
- [ ] Any new notebook examples added to `docs/examples/` folder
- [ ] Clear the output of all cells before committing
- [ ] New notebook files added to `docs/examples.rst` toctree
- [ ] New notebook files added to new entry in `docs/gallery.yml` with appropriate thumbnail photo in `docs/_static/thumbnails/`

