### PR TITLE
Downgrade to matplotlib<3.11 to fix RTD plots

### DIFF
--- a/ci/asv.yml
+++ b/ci/asv.yml
@@ -8,7 +8,7 @@ dependencies:
   - datashader
   - geoviews
   - holoviews
-  - matplotlib-base
+  - matplotlib-base<3.11   # 3.11.0 breaks some plots but <3.11 is fine; see issue #1542.
   - matplotlib-inline
   - healpix
   - netcdf4

--- a/ci/docs.yml
+++ b/ci/docs.yml
@@ -28,7 +28,7 @@ dependencies:
     - myst-nb
     - sphinx-design
     - nbsphinx
-    - matplotlib-base
+    - matplotlib-base<3.11   # 3.11.0 breaks some plots but <3.11 is fine; see issue #1542.
     - matplotlib-inline
     - shapely
     - hvplot

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - holoviews
   - hvplot
   - hypothesis
-  - matplotlib-base
+  - matplotlib-base<3.11   # 3.11.0 breaks some plots but <3.11 is fine; see issue #1542.
   - matplotlib-inline
   - netcdf4
   - numba

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "datashader",
   "geoviews",
   "holoviews",
-  "matplotlib",
+  "matplotlib<3.11",  # matplotlib 3.11.0 breaks some plots but <3.11 is fine; see issue #1542.
   "matplotlib-inline",
   "netcdf4",
   "numba",

--- a/test/test_plot.py
+++ b/test/test_plot.py
@@ -243,5 +243,5 @@ def test_plot_with_features(gridpath, datasetpath):
     plot2 = uxds2["v2"].plot(features=['coastline'])
     plot = plot1 + plot2
     # the crash associated with issue #1542 only occurs when actually trying to render:
-    renderer = hv.renderer("matplotlib")   # or "matplotlib"
+    renderer = hv.renderer("matplotlib")
     renderer.get_plot(plot)

--- a/test/test_plot.py
+++ b/test/test_plot.py
@@ -229,3 +229,19 @@ def test_to_raster_pixel_ratio(gridpath, r1, r2):
     f = r2 / r1
     d = np.array(raster2.shape) - f * np.array(raster1.shape)
     assert (d >= 0).all() and (d <= f - 1).all()
+
+def test_plot_with_features(gridpath, datasetpath):
+    """ensure can render a multiplot layout with geoviews features.
+    Regression test for issue #1542.
+    """
+    gridpath = gridpath("ugrid", "geoflow-small", "grid.nc")
+    uxds1 = ux.open_dataset(gridpath, datasetpath("ugrid", "geoflow-small", "v1.nc"))
+    uxds2 = ux.open_dataset(gridpath, datasetpath("ugrid", "geoflow-small", "v2.nc"))
+    uxds1 = uxds1.isel(time=0, meshLayers=0)  # plot currently expects 1D along n_node
+    uxds2 = uxds2.isel(time=0, meshLayers=0)
+    plot1 = uxds1["v1"].plot(features=['coastline'])
+    plot2 = uxds2["v2"].plot(features=['coastline'])
+    plot = plot1 + plot2
+    # the crash associated with issue #1542 only occurs when actually trying to render:
+    renderer = hv.renderer("matplotlib")   # or "matplotlib"
+    renderer.get_plot(plot)


### PR DESCRIPTION
readthedocs plots are breaking on matplotlib 3.11 but not matplotlib<3.11; see issue #1542. Workaround for now: restrict to matplotlib<3.11 in the pyproject.toml.

This restriction should be removed once things get fixed upstream, either by matplotlib or by geoviews.

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->

**General**
- [X] An issue is linked created and linked
- [X] Add appropriate labels

**Testing**
- [x] Adequate tests are created if there is new functionality
- [x] Tests cover all possible logical paths in your function
- [x] Tests are not too basic (such as simply calling a function and nothing else)
