### PR TITLE
Add test: if subset empty, dont crash

### DIFF
--- a/test/test_subset.py
+++ b/test/test_subset.py
@@ -190,3 +190,20 @@ def test_da_subset(gridpath, datasetpath):
     res3 = uxds['t2m'].subset.nearest_neighbor(center_coord=(0, 0), k=4)
 
     assert len(res1) == len(res2) == len(res3) == 4
+
+
+def test_empty_subset(gridpath, datasetpath):
+    """ensure that subsetting methods still return a valid UXarray object even if subset is empty.
+    (The resulting object should have size=0.)
+    This test ensures issue #1285 has been fixed.
+    """
+    uxds = ux.open_dataset(gridpath("ugrid", "quad-hexagon", "grid.nc"), datasetpath("ugrid", "quad-hexagon", "data.nc"))
+    arr = uxds['t2m']
+    min_lon = arr.uxgrid.face_lon.min().item()
+    definitely_out_of_bounds = (min_lon - 10, min_lon - 5)
+    # mostly just want to ensure this doesn't crash:
+    res = arr.subset.bounding_box(lon_bounds=definitely_out_of_bounds, lat_bounds=(-10, 10))
+    assert isinstance(res, ux.UxDataArray)
+    assert res.size == 0
+    # should still have all the same dim names even if resulting subset is empty:
+    assert set(res.dims) == set(arr.dims)


### PR DESCRIPTION
Closes #1285 


## Overview
If subset is empty, uxarray should return empty array, not crash. This seems to already be the case. But, it also seems to be the primary issue of #1285. This PR adds a test to ensure that is the case.


## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->

**General**
- [X] An issue is linked created and linked
- [X] Add appropriate labels
- [X] Filled out Overview and Expected Usage (if applicable) sections

**Testing**
- [N/A] Adequate tests are created if there is new functionality
- [N/A] Tests cover all possible logical paths in your function
- [X] Tests are not too basic (such as simply calling a function and nothing else)