### PR TITLE
Honor quadrature kwargs in calculate_total_face_area

### DIFF
--- a/test/grid/grid/test_areas.py
+++ b/test/grid/grid/test_areas.py
@@ -30,6 +30,29 @@ def test_face_areas_calculate_total_face_area_triangle(mesh_constants):
     nt.assert_almost_equal(area_gaussian, mesh_constants['CORRECTED_TRI_AREA'], decimal=3)
 
 
+def test_calculate_total_face_area_respects_quadrature_kwargs(mesh_constants):
+    """calculate_total_face_area must honor its quadrature_rule/order/
+    latitude_adjusted_area kwargs instead of always returning the cached
+    default-parameter face areas."""
+    verts = [
+    [[0.02974582, -0.74469018, 0.66674712],
+    [0.1534193, -0.88744577, 0.43462917],
+    [0.18363692, -0.72230586, 0.66674712]]
+    ]
+
+    grid_verts = ux.open_grid(verts, latlon=False)
+
+    area_default = grid_verts.calculate_total_face_area(
+        quadrature_rule="triangular", order=4)
+    area_corrected = grid_verts.calculate_total_face_area(
+        quadrature_rule="gaussian", order=5, latitude_adjusted_area=True)
+
+    # the corrected result must actually differ from the uncorrected one
+    assert not np.isclose(area_default, area_corrected)
+    nt.assert_almost_equal(area_default, mesh_constants['TRI_AREA'], decimal=6)
+    nt.assert_almost_equal(area_corrected, mesh_constants['CORRECTED_TRI_AREA'], decimal=6)
+
+
 def test_face_areas_compute_face_areas_geoflow_small(gridpath):
     """Checks if the GeoFlow Small can generate a face areas output."""
     grid_geoflow = ux.open_grid(gridpath("ugrid", "geoflow-small", "grid.nc"))

--- a/uxarray/grid/grid.py
+++ b/uxarray/grid/grid.py
@@ -1951,8 +1951,21 @@ class Grid:
         -------
         Sum of area of all the faces in the mesh : float
         """
+        # Default parameters match the cached ``face_areas`` property, which also
+        # preserves the equal-area values used for HEALPix grids; reuse it to avoid
+        # recomputation. Any non-default quadrature settings require a fresh
+        # geometric computation so the requested rule/order actually take effect.
+        if (
+            quadrature_rule == "triangular"
+            and order == 4
+            and not latitude_adjusted_area
+        ):
+            return np.sum(self.face_areas.values)
 
-        return np.sum(self.face_areas.values)
+        face_areas, _ = self._compute_face_areas(
+            quadrature_rule, order, latitude_adjusted_area
+        )
+        return np.sum(face_areas)
 
     def compute_face_areas(
         self,


### PR DESCRIPTION
Closes #1567.

`Grid.calculate_total_face_area()` documents `quadrature_rule`, `order` and `latitude_adjusted_area` parameters, but the body ignored them and always returned `np.sum(self.face_areas.values)` — the cached face areas computed with the default parameters. So calling it with, for example, `quadrature_rule="gaussian", order=5, latitude_adjusted_area=True` gave exactly the same total as the default triangular call.

### Fix
- Keep the fast path: when the parameters are the defaults (`triangular`, `order=4`, no latitude adjustment) it still returns the cached `face_areas`, which also preserves the theoretical equal-area values used for HEALPix grids.
- Otherwise it routes through `_compute_face_areas(quadrature_rule, order, latitude_adjusted_area)` so the requested quadrature rule, order and latitude adjustment actually take effect.

The default behavior (and the HEALPix path) is unchanged.

### Tests
Added `test_calculate_total_face_area_respects_quadrature_kwargs`, which asserts the corrected result differs from the uncorrected one and matches the expected `TRI_AREA` / `CORRECTED_TRI_AREA` constants to 6 decimals. The existing `test_face_areas_calculate_total_face_area_triangle` used a `decimal=3` tolerance too loose to catch this (the correction for that triangle is ~2.8e-4). The new test fails on the previous code and passes with the fix; the full `test/grid/grid/test_areas.py` suite passes.

Note: the "Face Area Calculations" docs page (section 2) also states the second calculation gives a slightly different area than the first — with this fix that statement becomes true when non-default quadrature settings are used.