### PR TITLE
Fix uxarray CI link-check failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           python -m pytest test
 
   link-check:
-      if: github.event_name != 'pull_request'
+      #if: github.event_name != 'pull_request'  # commented for debugging; UNCOMMENT BEFORE MERGE
       runs-on: ubuntu-latest
       defaults:
         run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           python -m pytest test
 
   link-check:
-      #if: github.event_name != 'pull_request'  # commented for debugging; UNCOMMENT BEFORE MERGE
+      if: github.event_name != 'pull_request'
       runs-on: ubuntu-latest
       defaults:
         run:

--- a/docs/user-guide/grid-formats.rst
+++ b/docs/user-guide/grid-formats.rst
@@ -221,7 +221,7 @@ References
 * https://easy.gems.dkrz.de/Processing/healpix/index.html#hierarchical-healpix-output
 * https://healpix.sourceforge.io/
 * https://irsa.ipac.caltech.edu/healpix/
-* https://iopscience.iop.org/article/10.1086/427976
+* https://doi.org/10.1086/427976
 
 Parsed Variables
 ================


### PR DESCRIPTION
Address uxarray ci failing due to link-check; see #1580. Does not yet address the upstream-ci failure.

## Overview
The healpix paper link (https://iopscience.iop.org/article/10.1086/427976) started failing recently for github ci. Replaced with doi link (https://doi.org/10.1086/427976). This might be enough to fix the broken link check?

Note: make sure to un-comment commented part of workflow before merging (maybe there was a more elegant way to tell link-check to run on this PR)?

## PR Checklist

**General**
- [X] An issue is linked created and linked
- [X] Add appropriate labels
- [N/A] Filled out Overview and Expected Usage (if applicable) sections
