### PR TITLE
Fix face_areas type hints and add compute_face_areas return type

### DIFF
--- a/uxarray/grid/grid.py
+++ b/uxarray/grid/grid.py
@@ -1940,9 +1940,9 @@ class Grid:
 
     def calculate_total_face_area(
         self,
-        quadrature_rule: str | None = "triangular",
-        order: int | None = 4,
-        latitude_adjusted_area: bool | None = False,
+        quadrature_rule: str = "triangular",
+        order: int = 4,
+        latitude_adjusted_area: bool = False,
     ) -> float:
         """Function to calculate the total surface area of all the faces in a
         mesh.
@@ -1978,10 +1978,10 @@ class Grid:
 
     def compute_face_areas(
         self,
-        quadrature_rule: str | None = "triangular",
-        order: int | None = 4,
-        latitude_adjusted_area: bool | None = False,
-    ):
+        quadrature_rule: str = "triangular",
+        order: int = 4,
+        latitude_adjusted_area: bool = False,
+    ) -> tuple[np.ndarray, np.ndarray]:
         """Face areas calculation function for grid class, calculates area of
         all faces in the grid.
 
@@ -2022,10 +2022,10 @@ class Grid:
 
     def _compute_face_areas(
         self,
-        quadrature_rule: str | None = "triangular",
-        order: int | None = 4,
-        latitude_adjusted_area: bool | None = False,
-    ):
+        quadrature_rule: str = "triangular",
+        order: int = 4,
+        latitude_adjusted_area: bool = False,
+    ) -> tuple[np.ndarray, np.ndarray]:
         """Internal face areas calculation function for grid class, calculates area of
         all faces in the grid.
 


### PR DESCRIPTION
Closes #1590

## Overview
- `calculate_total_face_area`, `compute_face_areas`, and `_compute_face_areas` annotated `quadrature_rule`, `order`, and `latitude_adjusted_area` with `| None`, but `None` is never a valid value and the code does not handle it. Dropped the `| None` so the annotations match the actual accepted types (`str`, `int`, `bool`).
- Added the missing return type annotation `tuple[np.ndarray, np.ndarray]` to `compute_face_areas` (and `_compute_face_areas`), matching what they return and the existing docstrings.

Kept narrowly scoped to the face_areas signatures per @Sevans711's note; the broader codebase-wide sweep is tracked separately.

## Expected Usage
<!-- N/A: no new functionality, only corrected type annotations on existing methods. -->

## PR Checklist

**General**
- [x] An issue is linked created and linked
- [N/A] Add appropriate labels
- [x] Filled out Overview and Expected Usage (if applicable) sections

**Testing**
- [N/A] Adequate tests are created if there is new functionality
- [N/A] Tests cover all possible logical paths in your function
- [N/A] Tests are not too basic (such as simply calling a function and nothing else)

**Documentation**
- [N/A] Docstrings have been added to all new functions
- [x] Docstrings have updated with any function changes
- [N/A] Internal functions have a preceding underscore (`_`) and have been added to `docs/internal_api/index.rst`
- [N/A] User functions have been added to `docs/user_api/index.rst`

**Examples**
- [N/A] Any new notebook examples added to `docs/examples/` folder
- [N/A] Clear the output of all cells before committing
- [N/A] New notebook files added to `docs/examples.rst` toctree
- [N/A] New notebook files added to new entry in `docs/gallery.yml` with appropriate thumbnail photo in `docs/_static/thumbnails/`
