### PR TITLE
Reduce imports inside functions

### DIFF
--- a/uxarray/core/api.py
+++ b/uxarray/core/api.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Mapping, Sequence, TypeAlias
+from typing import Any, Mapping, Sequence, TypeAlias
 from warnings import warn
 
 import numpy as np

--- a/uxarray/core/api.py
+++ b/uxarray/core/api.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Mapping, Sequence, TypeAlias
 from warnings import warn
 
 import numpy as np
+import xarray as xr
 
 from uxarray.core.dataset import UxDataset
 from uxarray.core.utils import (
@@ -22,9 +23,6 @@ from uxarray.io._scrip import (
     _stack_cell_dims,
 )
 
-if TYPE_CHECKING:
-    from xarray import Dataset
-
 __all__ = [
     "open_grid",
     "open_multigrid",
@@ -35,7 +33,7 @@ __all__ = [
 
 
 def open_grid(
-    grid_filename_or_obj: str | os.PathLike[Any] | dict | Dataset,
+    grid_filename_or_obj: str | os.PathLike[Any] | dict | xr.Dataset,
     chunks=None,
     use_dual: bool | None = False,
     **kwargs: dict[str, Any],
@@ -85,8 +83,6 @@ def open_grid(
 
     >>> uxgrid = ux.open_grid("grid_filename.nc", chunks=-1)
     """
-    import xarray as xr
-
     # Handle chunk-related kwargs first.
     data_chunks = kwargs.pop("data_chunks", None)
     if data_chunks is not None:
@@ -144,9 +140,9 @@ MaskActiveValue: TypeAlias = MaskValue | Mapping[str, MaskValue] | None
 
 
 def open_multigrid(
-    grid_filename_or_obj: str | Path | "Dataset",
+    grid_filename_or_obj: str | Path | xr.Dataset,
     gridnames: list[str] | None = None,
-    mask_filename: str | Path | "Dataset" | None = None,
+    mask_filename: str | Path | xr.Dataset | None = None,
     mask_active_value: MaskActiveValue = 1,
     **kwargs: dict[str, Any],
 ) -> dict[str, Grid]:
@@ -175,8 +171,6 @@ def open_multigrid(
     dict[str, Grid]
         Dictionary mapping grid names to ``Grid`` objects.
     """
-    import xarray as xr
-
     grid_ds_opened = False
     if isinstance(grid_filename_or_obj, xr.Dataset):
         grid_ds = grid_filename_or_obj
@@ -314,7 +308,7 @@ def open_multigrid(
 
 
 def list_grid_names(
-    grid_filename_or_obj: str | Path | "Dataset", **kwargs: dict[str, Any]
+    grid_filename_or_obj: str | Path | xr.Dataset, **kwargs: dict[str, Any]
 ) -> list[str]:
     """List all grid names available within a grid file.
 
@@ -331,8 +325,6 @@ def list_grid_names(
         ``['grid']`` for single-grid files or the detected grid names for
         multi-grid files.
     """
-    import xarray as xr
-
     grid_ds_opened = False
     if isinstance(grid_filename_or_obj, xr.Dataset):
         grid_ds = grid_filename_or_obj
@@ -352,8 +344,8 @@ def list_grid_names(
 
 
 def open_dataset(
-    grid_filename_or_obj: str | os.PathLike[Any] | dict | Dataset,
-    filename_or_obj: str | os.PathLike[Any] | Dataset | None = None,
+    grid_filename_or_obj: str | os.PathLike[Any] | dict | xr.Dataset,
+    filename_or_obj: str | os.PathLike[Any] | xr.Dataset | None = None,
     chunks=None,
     chunk_grid: bool = True,
     use_dual: bool | None = False,
@@ -426,8 +418,6 @@ def open_dataset(
 
     >>> ux_ds = ux.open_dataset("combined_file.nc")
     """
-    import xarray as xr
-
     if grid_kwargs is None:
         grid_kwargs = {}
 
@@ -481,7 +471,7 @@ def open_dataset(
 
 
 def open_mfdataset(
-    grid_filename_or_obj: str | os.PathLike[Any] | dict | Dataset,
+    grid_filename_or_obj: str | os.PathLike[Any] | dict | xr.Dataset,
     paths: str | os.PathLike,
     chunks=None,
     chunk_grid: bool = True,
@@ -546,8 +536,6 @@ def open_mfdataset(
 
     >>> ux_ds = ux.open_mfdataset("grid_filename.g", "grid_filename_vortex_*.nc")
     """
-    import xarray as xr
-
     if grid_kwargs is None:
         grid_kwargs = {}
 
@@ -588,8 +576,6 @@ def _get_grid(
 
 def concat(objs, *args, **kwargs):
     # Ensure there is at least one object to concat.
-    import xarray as xr
-
     if not objs:
         raise ValueError("No objects provided for concatenation.")
 

--- a/uxarray/grid/coordinates.py
+++ b/uxarray/grid/coordinates.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 
 import numpy as np
 import xarray as xr
@@ -750,8 +751,6 @@ def _set_desired_longitude_range(uxgrid):
     """
     if _is_projected_grid(uxgrid):
         if not getattr(uxgrid, "_projected_warning_issued", False):
-            import warnings
-
             warnings.warn(
                 "Projected (non-spherical) coordinates detected on this grid "
                 "(standard_name='projection_x_coordinate' or length units). "

--- a/uxarray/grid/grid.py
+++ b/uxarray/grid/grid.py
@@ -1,8 +1,8 @@
 import copy
 import os
+import warnings
 from html import escape
 from typing import Optional, Sequence
-import warnings
 
 import cartopy.crs as ccrs
 import numpy as np

--- a/uxarray/grid/grid.py
+++ b/uxarray/grid/grid.py
@@ -2,7 +2,7 @@ import copy
 import os
 from html import escape
 from typing import Optional, Sequence
-from warnings import warn
+import warnings
 
 import cartopy.crs as ccrs
 import numpy as np
@@ -169,7 +169,7 @@ class Grid:
 
         # grid spec not provided, check if grid_ds is a minimum representable UGRID dataset
         if source_grid_spec is None:
-            warn(
+            warnings.warn(
                 "Attempting to construct a Grid without passing in source_grid_spec. Direct use of Grid constructor"
                 "is only advised if grid_ds is following the internal unstructured grid definition, including"
                 "variable and dimension names. Using ux.open_grid() or ux.from_dataset() is suggested.",
@@ -817,7 +817,7 @@ class Grid:
     @property
     def parsed_attrs(self) -> dict:
         """Dictionary of parsed attributes from the source grid."""
-        warn(
+        warnings.warn(
             "Grid.parsed_attrs will be deprecated in a future release. Please use Grid.attrs instead.",
             DeprecationWarning,
         )
@@ -2011,8 +2011,6 @@ class Grid:
         ``face_areas`` property instead, which ensures mathematical correctness by using
         theoretical equal areas.
         """
-        import warnings
-
         warnings.warn(
             "compute_face_areas() is deprecated. Use the face_areas property instead for better performance and caching.",
             DeprecationWarning,
@@ -2264,7 +2262,7 @@ class Grid:
                 )
 
         if exclude_antimeridian is not None:
-            warn(
+            warnings.warn(
                 DeprecationWarning(
                     "The parameter ``exclude_antimeridian`` will be deprecated in a future release. Please "
                     "use ``periodic_elements='exclude'`` or ``periodic_elements='split'`` instead."

--- a/uxarray/io/_esmf.py
+++ b/uxarray/io/_esmf.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+
+import numpy as np
 import xarray as xr
 
 from uxarray.constants import INT_DTYPE, INT_FILL_VALUE
@@ -119,10 +122,6 @@ def _encode_esmf(ds: xr.Dataset) -> xr.Dataset:
     xr.Dataset
         An xarray.Dataset formatted according to ESMF Unstructured Grid conventions.
     """
-    from datetime import datetime
-
-    import numpy as np
-
     out_ds = xr.Dataset()
 
     # Node Coordinates (nodeCoords)


### PR DESCRIPTION
Closes #1575

## Overview

There are some places throughout the uxarray codebase where import is being used inside functions. This PR targets imports which are not "heavy" or which are already being imported non-lazily (i.e., at they are imported at "top-level" / top of file), changing them to be consistently imported non-lazily everywhere in uxarray.

Notes about all packages being imported internally in at least one location (e.g. imported inside a function; not just at top of file):
- `antimeridian`: not currently at top-level anywhere. Tiny required dependency, seems trivially-lightweight to import. But, might become optional some day...? → **keep internal**.
- `dask`: not currently at top-level anywhere, and not trivially-lightweight to import → **keep internal**
- `datetime`: trivially lightweight and builtin, no need to import lazily → **move to top**.
- `IPython`: not currently at top-level anywhere; optional (but forgot to list in pyproject.toml at all), and will probably be removed eventually, whenever upstream fix is released (see discussion in #1538 and upstream issue at holoviz/holoviews#6955) → **do not touch in this PR**.
- `numpy`: essential for core functionality and definitions, already at top level in many places → **move to top level**.
- `pyfma`: only appears in an otherwise-unused module? (See #1602) → **do not touch in this PR**.
- `scipy`: non-trivial import size, ~but does exist as top-level import in `weights.py`, which makes this a bit ambiguous. → **did not touch here, but _open for further discussion (should the scipy import in weights.py be moved to be internal instead?)_**.~ EDIT: this would be fully addressed by #1606, which moves that scipy import to be internal instead → **do not touch in this PR**.
- `sklearn`: not currently at top-level anywhere; non-trivial import size → **keep internal**.
- `shapely`: same story as with `antimeridian`: not currently at top-level anywhere. Tiny required dependency, seems trivially-lightweight to import. But, might become optional some day...? → **keep internal**.
- `warnings`: trivially lightweight and builtin, no need to import lazily → **move to top**.
- `xarray`: essential for core functionality and definitions, already at top level in many places → **move to top level**.
- Many packages should be an optional dependency eventually/soon (see #1548) → **do not touch in this PR**; these are already handled by that PR (or maybe will be moved to a separate issue/PR). This applies to:
  - `cartopy`
  - `geopandas`
  - `holoviews`
  - `hvplot`
  - `matplotlib`
  - `spatialpandas`


Notes about importing from uxarray internally to functions:

- In some cases, such as in uxarray.core.accessors, code like `from uxarray.core.dataarray import UxDataArray` must be kept inside functions, to avoid circular imports.
- There are many cases, such as `UxDataArray.isel` containing `from uxarray.core.utils import _validate_indexers`, where uxarray methods are imported internally without a clear compelling reason to do so. These should probably be moved to top-level. However, the original scope of issue #1575 did not clarify this possibility, and uxarray's explicit non-relative imports make me think it could be an intentional design choice, to reduce "cascading" imports. _**I think it makes more sense to open a separate issue to discuss internal imports like "from uxarray... import ...", instead of trying to also consider that here. If PR reviewers agree, let's open that issue before this PR gets merged**_


Misc notes:

- In some cases, imports were gated by "if TYPE_CHECKING" unnecessarily, such as "if TYPE_CHECKING: from xarray import Dataset". There is no reason to do this when xarray is already imported in the file → **cleaned up cases like this**.



## PR Checklist

**General**
- [X] An issue is linked created and linked
- [X] Add appropriate labels
- [X] Filled out Overview and Expected Usage (if applicable) sections
