### PR TITLE
Move imports for should-be-optional dependencies

### DIFF
--- a/test/io/test_structured.py
+++ b/test/io/test_structured.py
@@ -2,6 +2,9 @@ import uxarray as ux
 import xarray as xr
 import pytest
 
+# import pooch  # not necessary to actually import, but tests would likely fail if this fails.
+# (commented here for future reference, since pooch is included in uxarray[dev]
+#    dependencies, but not imported explicitly anywhere in uxarray.)
 
 @pytest.mark.parametrize("ds_name", ["air_temperature", "ersstv5"])
 def test_read_structured_grid_from_ds(ds_name):

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -5,10 +5,8 @@ from html import escape
 from typing import TYPE_CHECKING, Any, Hashable, Literal, Mapping, Optional
 from warnings import warn
 
-import cartopy.crs as ccrs
 import numpy as np
 import xarray as xr
-from cartopy.mpl.geoaxes import GeoAxes
 from xarray.core import dtypes
 from xarray.core.options import OPTIONS
 from xarray.core.utils import UncachedAccessor
@@ -37,6 +35,9 @@ from uxarray.remap.accessor import RemapAccessor
 from uxarray.subset import DataArraySubsetAccessor
 
 if TYPE_CHECKING:
+    import cartopy.crs as ccrs
+    from cartopy.mpl.geoaxes import GeoAxes
+
     from uxarray.core.dataset import UxDataset
 
 
@@ -462,6 +463,8 @@ class UxDataArray(xr.DataArray):
         >>> ax.imshow(raster, origin="lower", extent=ax.get_xlim() + ax.get_ylim())
 
         """
+        from cartopy.mpl.geoaxes import GeoAxes
+
         from uxarray.constants import INT_DTYPE
         from uxarray.plot.matplotlib import (
             _ensure_dimensions,

--- a/uxarray/cross_sections/sample.py
+++ b/uxarray/cross_sections/sample.py
@@ -1,6 +1,5 @@
 import numpy as np
 from numba import njit, prange
-from pyproj import Geod
 
 
 @njit(parallel=True)
@@ -17,6 +16,8 @@ def _fill_numba(flat_orig, face_idx, n_face, n_steps):
 def sample_geodesic(
     start: tuple[float, float], end: tuple[float, float], steps: int
 ) -> tuple[np.ndarray, np.ndarray]:
+    from pyproj import Geod
+
     lon0, lat0 = start
     lon1, lat1 = end
 

--- a/uxarray/grid/geometry.py
+++ b/uxarray/grid/geometry.py
@@ -397,8 +397,6 @@ def _build_corrected_polygon_shells(polygon_shells):
     _corrected_shells_to_original_faces : np.ndarray
         Original indices used to map the corrected polygon shells to their entries in face nodes
     """
-
-    # import optional dependencies
     import antimeridian
     from shapely import Polygon
 

--- a/uxarray/grid/grid.py
+++ b/uxarray/grid/grid.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 import copy
 import os
 from html import escape
-from typing import Optional, Sequence
+from typing import TYPE_CHECKING, Optional, Sequence
 from warnings import warn
 
-import cartopy.crs as ccrs
 import numpy as np
 import xarray as xr
 from xarray.core.options import OPTIONS
@@ -98,6 +99,9 @@ from uxarray.io._voronoi import _spherical_voronoi_from_points
 from uxarray.io.utils import _parse_grid_type
 from uxarray.plot.accessor import GridPlotAccessor
 from uxarray.subset import GridSubsetAccessor
+
+if TYPE_CHECKING:
+    import cartopy.crs as ccrs
 
 
 class Grid:

--- a/uxarray/io/_healpix.py
+++ b/uxarray/io/_healpix.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-import healpix as hp
 import numpy as np
 import polars as pl
 import xarray as xr
@@ -68,6 +67,8 @@ def pix2corner_ang(
     ----
     This will be updated when https://github.com/ntessore/healpix/issues/66 is implemented.
     """
+    import healpix as hp
+
     if nest:
         fu = hp._chp.nest2ang_uv
     else:
@@ -102,6 +103,8 @@ def _pixels_to_ugrid(zoom, nest):
         A dataset containing pixel longitude and latitude coordinates along with related attributes.
 
     """
+    import healpix as hp
+
     ds = xr.Dataset()
 
     nside = hp.order2nside(zoom)

--- a/uxarray/plot/utils.py
+++ b/uxarray/plot/utils.py
@@ -1,6 +1,3 @@
-import holoviews as hv
-
-
 class HoloviewsBackend:
     """Compare and set the HoloViews plotting backend."""
 
@@ -9,6 +6,8 @@ class HoloviewsBackend:
 
     def assign(self, backend: str):
         """Assign a HoloViews backend, one of 'matplotlib', 'bokeh'."""
+        import holoviews as hv
+
         if backend not in ["bokeh", "matplotlib", None]:
             raise ValueError(
                 f"Unsupported backend. Expected one of ['bokeh', 'matplotlib'], but received {backend}"

--- a/uxarray/remap/weights.py
+++ b/uxarray/remap/weights.py
@@ -4,12 +4,15 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from os import PathLike
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 import xarray as xr
-from scipy import sparse
 
 from uxarray.core.utils import _open_dataset_with_fallback
+
+if TYPE_CHECKING:
+    from scipy import sparse
 
 # LRU-bounded cache for loaded remap operators.
 _WEIGHTS_CACHE_MAXSIZE = 32
@@ -83,6 +86,8 @@ class RemapWeights:
     @classmethod
     def from_file(cls, filename_or_obj: str | PathLike[str] | xr.Dataset):
         """Load a standard sparse remap-weight file into memory once."""
+        from scipy import sparse
+
         if isinstance(filename_or_obj, xr.Dataset):
             ds = filename_or_obj
             close_ds = False


### PR DESCRIPTION
One step towards solving #1224, but not the full solution.

## Overview
Moves imports for "should-be-optional" dependencies to be inside functions instead of at tops of files. All of these changes were originally proposed in PR #1548, which also includes detailed discussion about which dependencies should be optional. However, the changes here do not include edits to pyproject.toml; the should-be-optional dependencies remain fully required, leaving installation processes fully untouched.

The narrower scope of this PR aims to provide simpler-to-accept changes. It was created in response to concerns about the size of PR 1548.

Recommended action plan:
1. Review this PR. Discuss as needed.
2. When approved, merge to main.
3. Merge main into the original PR (1548). This will reduce the number of changes in PR 1548 significantly.
4. PR 1548 will continue to be responsible for changes to pyproject.toml, optional dependencies testing, etc. Or, maybe some of those details will be split into other PRs, too; that can be discussed in thread on PR 1548 directly.

## PR Checklist

**General**
- [X] An issue is linked created and linked
- [X] Add appropriate labels
- [X] Filled out Overview and Expected Usage (if applicable) sections
