### PR TITLE
Fix use_dual type hints

### DIFF
--- a/test/core/test_type_hints.py
+++ b/test/core/test_type_hints.py
@@ -1,0 +1,26 @@
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).parents[2]
+
+
+def _annotation(source: Path, function_name: str, parameter_name: str) -> str:
+    tree = ast.parse(source.read_text())
+    function = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == function_name
+    )
+    parameter = next(arg for arg in function.args.args if arg.arg == parameter_name)
+    return ast.unparse(parameter.annotation)
+
+
+def test_use_dual_type_hints_do_not_allow_none():
+    api = ROOT / "uxarray" / "core" / "api.py"
+    grid = ROOT / "uxarray" / "grid" / "grid.py"
+
+    assert _annotation(api, "open_grid", "use_dual") == "bool"
+    assert _annotation(api, "open_dataset", "use_dual") == "bool"
+    assert _annotation(api, "open_mfdataset", "use_dual") == "bool"
+    assert _annotation(grid, "from_dataset", "use_dual") == "bool"

--- a/uxarray/core/api.py
+++ b/uxarray/core/api.py
@@ -35,7 +35,7 @@ __all__ = [
 def open_grid(
     grid_filename_or_obj: str | os.PathLike[Any] | dict | xr.Dataset,
     chunks=None,
-    use_dual: bool | None = False,
+    use_dual: bool = False,
     **kwargs: dict[str, Any],
 ):
     """Constructs and returns a ``Grid`` from a grid file.
@@ -348,7 +348,7 @@ def open_dataset(
     filename_or_obj: str | os.PathLike[Any] | xr.Dataset | None = None,
     chunks=None,
     chunk_grid: bool = True,
-    use_dual: bool | None = False,
+    use_dual: bool = False,
     grid_kwargs: dict[str, Any] | None = None,
     **kwargs: dict[str, Any],
 ) -> UxDataset:
@@ -475,7 +475,7 @@ def open_mfdataset(
     paths: str | os.PathLike,
     chunks=None,
     chunk_grid: bool = True,
-    use_dual: bool | None = False,
+    use_dual: bool = False,
     grid_kwargs: dict[str, Any] | None = None,
     **kwargs: dict[str, Any],
 ) -> UxDataset:

--- a/uxarray/grid/grid.py
+++ b/uxarray/grid/grid.py
@@ -254,7 +254,7 @@ class Grid:
     cross_section = UncachedAccessor(GridCrossSectionAccessor)
 
     @classmethod
-    def from_dataset(cls, dataset, use_dual: bool | None = False, **kwargs):
+    def from_dataset(cls, dataset, use_dual: bool = False, **kwargs):
         """Constructs a ``Grid`` object from a dataset.
 
         Parameters


### PR DESCRIPTION
Fixes part of #1593 but does not fully close it.

## Overview
- Narrow `use_dual` to `bool` across the public grid-loading APIs and `Grid.from_dataset`, matching the documented and implemented contract.
- Add a focused type-hint regression test covering all four signatures.

<!-- Expected Usage is not applicable because this corrects existing type hints without changing runtime usage. -->

## PR Checklist

**General**
- [x] An issue is linked created and linked
- [x] Add appropriate labels
- [x] Filled out Overview and Expected Usage (if applicable) sections

**Testing**
- [x] Adequate tests are created if there is new functionality
- [x] Tests cover all possible logical paths in your function
- [x] Tests are not too basic (such as simply calling a function and nothing else)

**Documentation**
- [N/A] Docstrings have been added to all new functions
- [N/A] Docstrings have updated with any function changes
- [N/A] Internal functions have a preceding underscore (`_`) and have been added to `docs/internal_api/index.rst`
- [N/A] User functions have been added to `docs/user_api/index.rst`

**Examples**
- [N/A] Any new notebook examples added to `docs/examples/` folder
- [N/A] Clear the output of all cells before committing
- [N/A] New notebook files added to `docs/examples.rst` toctree
- [N/A] New notebook files added to new entry in `docs/gallery.yml` with appropriate thumbnail photo in `docs/_static/thumbnails/`
