### PR TITLE
Add custom error types in uxarray

### DIFF
--- a/test/core/test_dataarray.py
+++ b/test/core/test_dataarray.py
@@ -1,5 +1,6 @@
 import numpy as np
 import uxarray as ux
+from uxarray.errors import DimensionError
 from uxarray.grid.geometry import _build_polygon_shells, _build_corrected_polygon_shells
 from uxarray.core.dataset import UxDataset, UxDataArray
 import pytest
@@ -124,7 +125,7 @@ def test_isel_invalid_dim(gridpath, datasetpath):
     uxda = UxDataArray(data, dims=["time", "n_face"], uxgrid=uxds.uxgrid)
 
     with pytest.raises(
-        ValueError,
+        DimensionError,
         match=r"Dimensions \{'invalid_dim'\} do not exist\..*Available dimensions: \('time', 'n_face'\)",
     ):
         uxda.isel(invalid_dim=0)

--- a/test/grid/integrate/test_zonal.py
+++ b/test/grid/integrate/test_zonal.py
@@ -8,6 +8,7 @@ import numpy.testing as nt
 
 import uxarray as ux
 from uxarray.constants import ERROR_TOLERANCE
+from uxarray.errors import DataCenteringError
 
 class TestZonalCSne30:
 
@@ -380,7 +381,7 @@ class TestZonalAnomaly:
         uxda = ux.UxDataArray(
             np.zeros(uxgrid.n_node), dims=["n_node"], uxgrid=uxgrid
         )
-        with pytest.raises(ValueError, match="face-centered"):
+        with pytest.raises(DataCenteringError, match="face-centered"):
             uxda.zonal_anomaly()
 
     def test_invalid_lat_input_raises(self):

--- a/test/test_remap_yac.py
+++ b/test/test_remap_yac.py
@@ -2,7 +2,8 @@ import numpy as np
 import pytest
 
 import uxarray as ux
-from uxarray.remap.yac import YacNotAvailableError, _import_yac
+from uxarray.errors import YacNotAvailableError
+from uxarray.remap.yac import _import_yac
 
 
 try:

--- a/uxarray/core/aggregation.py
+++ b/uxarray/core/aggregation.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 import uxarray.core.dataarray
+from uxarray.errors import DataCenteringError
 from uxarray.grid.connectivity import get_face_node_partitions
 
 NUMPY_AGGREGATIONS = {
@@ -32,7 +33,7 @@ def _uxda_grid_aggregate(uxda, destination, aggregation, **kwargs):
         elif destination == "edge":
             return _node_to_edge_aggregation(uxda, aggregation, kwargs)
         else:
-            raise ValueError(
+            raise DataCenteringError(
                 f"Invalid destination for a node-centered data variable. Expected"
                 f"one of ['face', 'edge' but received {destination}"
             )
@@ -62,7 +63,7 @@ def _uxda_grid_aggregate(uxda, destination, aggregation, **kwargs):
         #     raise ValueError("TODO: ")
 
     else:
-        raise ValueError(
+        raise DataCenteringError(
             "Invalid data mapping. Data variable is expected to be mapped to either the "
             "nodes, faces, or edges of the source grid."
         )
@@ -73,7 +74,7 @@ def _node_to_face_aggregation(uxda, aggregation, aggregation_func_kwargs):
     import dask.array as da
 
     if not uxda._node_centered():
-        raise ValueError(
+        raise DataCenteringError(
             f"Data Variable must be mapped to the corner nodes of each face, with dimension "
             f"{uxda.uxgrid.n_face}."
         )
@@ -141,7 +142,7 @@ def _node_to_edge_aggregation(uxda, aggregation, aggregation_func_kwargs):
     import dask.array as da
 
     if not uxda._node_centered():
-        raise ValueError(
+        raise DataCenteringError(
             f"Data Variable must be mapped to the corner nodes of each face, with dimension "
             f"{uxda.uxgrid.n_face}."
         )

--- a/uxarray/core/api.py
+++ b/uxarray/core/api.py
@@ -14,6 +14,7 @@ from uxarray.core.utils import (
     _open_dataset_with_fallback,
     match_chunks_to_ugrid,
 )
+from uxarray.errors import GridInvalidError
 from uxarray.grid import Grid
 from uxarray.io._scrip import (
     _detect_multigrid,
@@ -248,7 +249,7 @@ def open_multigrid(
             }
 
         if not grids_dict:
-            raise ValueError(f"No grids detected in file: {grid_filename_or_obj}")
+            raise GridInvalidError(f"No grids detected in file: {grid_filename_or_obj}")
 
         available_grids = list(grids_dict.keys())
 

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -620,10 +620,14 @@ class UxDataArray(xr.DataArray):
             integral = np.einsum("i,...i", face_areas, self.values)
 
         elif self.values.shape[-1] == self.uxgrid.n_node:
-            raise DataCenteringError("Integrating data mapped to each node not yet supported.")
+            raise DataCenteringError(
+                "Integrating data mapped to each node not yet supported."
+            )
 
         elif self.values.shape[-1] == self.uxgrid.n_edge:
-            raise DataCenteringError("Integrating data mapped to each edge not yet supported.")
+            raise DataCenteringError(
+                "Integrating data mapped to each edge not yet supported."
+            )
 
         else:
             raise DimensionError(

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -25,6 +25,7 @@ from uxarray.core.zonal import (
     _compute_zonal_anomaly,
 )
 from uxarray.cross_sections import UxDataArrayCrossSectionAccessor
+from uxarray.errors import DataCenteringError, DimensionError, GridsMismatchError
 from uxarray.formatting_html import array_repr
 from uxarray.grid import Grid
 from uxarray.grid.dual import construct_dual
@@ -248,7 +249,7 @@ class UxDataArray(xr.DataArray):
 
         if self.values.ndim > 1:
             # data is multidimensional, must be a 1D slice
-            raise ValueError(
+            raise DimensionError(
                 f"Data Variable must be 1-dimensional, with shape {self.uxgrid.n_face} "
                 f"for face-centered data."
             )
@@ -291,19 +292,19 @@ class UxDataArray(xr.DataArray):
             gdf[var_name] = _data
 
         elif self.values.size == self.uxgrid.n_node:
-            raise ValueError(
+            raise DataCenteringError(
                 f"Data Variable with size {self.values.size} does not match the number of faces "
                 f"({self.uxgrid.n_face}. Current size matches the number of nodes. Consider running "
                 f"``UxDataArray.topological_mean(destination='face') to aggregate the data onto the faces."
             )
         elif self.values.size == self.uxgrid.n_edge:
-            raise ValueError(
+            raise DataCenteringError(
                 f"Data Variable with size {self.values.size} does not match the number of faces "
                 f"({self.uxgrid.n_face}. Current size matches the number of edges."
             )
         else:
             # data is not mapped to
-            raise ValueError(
+            raise DimensionError(
                 f"Data Variable with size {self.values.size} does not match the number of faces "
                 f"({self.uxgrid.n_face}."
             )
@@ -341,7 +342,7 @@ class UxDataArray(xr.DataArray):
         """
         # data is multidimensional, must be a 1D slice
         if self.values.ndim > 1:
-            raise ValueError(
+            raise DimensionError(
                 f"Data Variable must be 1-dimensional, with shape {self.uxgrid.n_face} "
                 f"for face-centered data."
             )
@@ -392,7 +393,7 @@ class UxDataArray(xr.DataArray):
             else:
                 return poly_collection
         else:
-            raise ValueError("Data variable must be face centered.")
+            raise DataCenteringError("Data variable must be face centered.")
 
     def to_raster(
         self,
@@ -619,13 +620,13 @@ class UxDataArray(xr.DataArray):
             integral = np.einsum("i,...i", face_areas, self.values)
 
         elif self.values.shape[-1] == self.uxgrid.n_node:
-            raise ValueError("Integrating data mapped to each node not yet supported.")
+            raise DataCenteringError("Integrating data mapped to each node not yet supported.")
 
         elif self.values.shape[-1] == self.uxgrid.n_edge:
-            raise ValueError("Integrating data mapped to each edge not yet supported.")
+            raise DataCenteringError("Integrating data mapped to each edge not yet supported.")
 
         else:
-            raise ValueError(
+            raise DimensionError(
                 f"The final dimension of the data variable does not match the number of nodes, edges, "
                 f"or faces. Expected one of "
                 f"{self.uxgrid.n_node}, {self.uxgrid.n_edge}, or {self.uxgrid.n_face}, "
@@ -687,7 +688,7 @@ class UxDataArray(xr.DataArray):
         physical analysis. Non-conservative averaging samples at latitude lines.
         """
         if not self._face_centered():
-            raise ValueError(
+            raise DataCenteringError(
                 "Zonal mean computations are currently only supported for face-centered data variables."
             )
 
@@ -768,7 +769,7 @@ class UxDataArray(xr.DataArray):
                 )
 
             if edges.ndim != 1 or edges.size < 2:
-                raise ValueError("Band edges must be 1D with at least two values")
+                raise DimensionError("Band edges must be 1D with at least two values")
 
             res = _compute_conservative_zonal_mean_bands(self, edges)
 
@@ -835,7 +836,7 @@ class UxDataArray(xr.DataArray):
         >>> uxds["var"].zonal_anomaly(lat=(-60, 60, 5), conservative=True)
         """
         if not self._face_centered():
-            raise ValueError(
+            raise DataCenteringError(
                 "Zonal anomaly is only supported for face-centered data variables."
             )
 
@@ -854,7 +855,7 @@ class UxDataArray(xr.DataArray):
             )
 
         if edges.ndim != 1 or edges.size < 2:
-            raise ValueError("Band edges must be 1D with at least two values.")
+            raise DimensionError("Band edges must be 1D with at least two values.")
 
         res = _compute_zonal_anomaly(self, edges, conservative=conservative)
 
@@ -914,7 +915,7 @@ class UxDataArray(xr.DataArray):
         from uxarray.grid.coordinates import _lonlat_rad_to_xyz
 
         if not self._face_centered():
-            raise ValueError(
+            raise DataCenteringError(
                 "Azimuthal mean computations are currently only supported for face-centered data variables."
             )
 
@@ -1633,13 +1634,13 @@ class UxDataArray(xr.DataArray):
             raise TypeError("other must be a UxDataArray")
 
         if self.uxgrid != other.uxgrid:
-            raise ValueError("Both vector components must be on the same grid")
+            raise GridsMismatchError("Both vector components must be on the same grid")
 
         if self.dims != other.dims:
-            raise ValueError("Both vector components must have the same dimensions")
+            raise DimensionError("Both vector components must have the same dimensions")
 
         if len(self.dims) != 1:
-            raise ValueError(
+            raise DimensionError(
                 "Curl computation currently only supports 1-dimensional data. "
                 "Use .isel() to select a single time slice or level."
             )
@@ -1724,20 +1725,20 @@ class UxDataArray(xr.DataArray):
             raise TypeError("other must be a UxDataArray")
 
         if self.uxgrid != other.uxgrid:
-            raise ValueError("Both UxDataArrays must have the same grid")
+            raise GridsMismatchError("Both UxDataArrays must have the same grid")
 
         if self.dims != other.dims:
-            raise ValueError("Both UxDataArrays must have the same dimensions")
+            raise DimensionError("Both UxDataArrays must have the same dimensions")
 
         if self.ndim > 1:
-            raise ValueError(
+            raise DimensionError(
                 "Divergence currently requires 1D face-centered data. Consider "
                 "reducing the dimension by selecting data across leading dimensions (e.g., `.isel(time=0)`, "
                 "`.sel(lev=500)`, or `.mean('time')`)."
             )
 
         if not (self._face_centered() and other._face_centered()):
-            raise ValueError(
+            raise DataCenteringError(
                 "Computing the divergence is only supported for face-centered data variables."
             )
 
@@ -1804,19 +1805,19 @@ class UxDataArray(xr.DataArray):
             raise TypeError("q must be a UxDataArray")
 
         if self.uxgrid != v.uxgrid or self.uxgrid != q.uxgrid:
-            raise ValueError("All UxDataArrays must have the same grid")
+            raise GridsMismatchError("All UxDataArrays must have the same grid")
 
         if self.dims != v.dims or self.dims != q.dims:
-            raise ValueError("All UxDataArrays must have the same dimensions")
+            raise DimensionError("All UxDataArrays must have the same dimensions")
 
         if self.ndim > 1:
-            raise ValueError(
+            raise DimensionError(
                 "Scalar dot gradient currently requires 1D face-centered data. "
                 "Consider selecting a single slice before computing."
             )
 
         if not (self._face_centered() and v._face_centered() and q._face_centered()):
-            raise ValueError(
+            raise DataCenteringError(
                 "Computing the scalar dot gradient is only supported for face-centered data variables."
             )
 
@@ -1879,12 +1880,12 @@ class UxDataArray(xr.DataArray):
                 dims[-1] = "n_edge"
                 name = f"{var_name}edge_face_difference"
             elif destination == "face":
-                raise ValueError(
+                raise DataCenteringError(
                     "Invalid destination 'face' for a face-centered data variable, computing"
                     "the difference and storing it on each face is not possible"
                 )
             elif destination == "node":
-                raise ValueError(
+                raise DataCenteringError(
                     "Support for computing the difference of a face-centered data variable and storing"
                     "the result on each node not yet supported."
                 )
@@ -1897,13 +1898,13 @@ class UxDataArray(xr.DataArray):
                 dims[-1] = "n_edge"
                 name = f"{var_name}edge_node_difference"
             elif destination == "node":
-                raise ValueError(
+                raise DataCenteringError(
                     "Invalid destination 'node' for a node-centered data variable, computing"
                     "the difference and storing it on each node is not possible"
                 )
 
             elif destination == "face":
-                raise ValueError(
+                raise DataCenteringError(
                     "Support for computing the difference of a node-centered data variable and storing"
                     "the result on each face not yet supported."
                 )
@@ -1914,7 +1915,7 @@ class UxDataArray(xr.DataArray):
             )
 
         else:
-            raise ValueError("TODO: ")
+            raise DataCenteringError("TODO: ")
 
         uxda = UxDataArray(
             _difference,
@@ -1986,7 +1987,7 @@ class UxDataArray(xr.DataArray):
 
         Raises
         ------
-        ValueError
+        DimensionError (subclass of ValueError)
             If more than one grid dimension is selected and `ignore_grid=False`.
         """
         from uxarray.core.utils import _validate_indexers
@@ -2040,7 +2041,7 @@ class UxDataArray(xr.DataArray):
                 # e.g. "Dimensions {'level'} do not exist. Expected one of ('n_face', 'time', 'lev')"
                 # Let's just append the available dimensions.
                 original_error_msg = str(e)
-                raise ValueError(
+                raise DimensionError(
                     f"{original_error_msg}. Available dimensions: {self.dims}"
                 ) from e
             else:
@@ -2105,7 +2106,7 @@ class UxDataArray(xr.DataArray):
             raise ValueError("`da` must be a xr.DataArray")
 
         if face_dim not in da.dims:
-            raise ValueError(
+            raise DimensionError(
                 f"The provided face dimension '{face_dim}' is present in the provided healpix data array."
                 f"Please set 'face_dim' to the dimension corresponding to the healpix face dimension."
             )
@@ -2139,7 +2140,7 @@ class UxDataArray(xr.DataArray):
             )
 
         else:
-            raise ValueError(
+            raise DataCenteringError(
                 "Data variable must be either node, edge, or face centered."
             )
 

--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -15,6 +15,7 @@ from xarray.core.utils import UncachedAccessor
 import uxarray
 from uxarray.core.dataarray import UxDataArray
 from uxarray.core.utils import _map_dims_to_ugrid, _open_dataset_with_fallback
+from uxarray.errors import DimensionError
 from uxarray.formatting_html import dataset_repr
 from uxarray.grid import Grid
 from uxarray.grid.dual import construct_dual
@@ -347,7 +348,7 @@ class UxDataset(xr.Dataset):
             ds = _open_dataset_with_fallback(ds, **kwargs)
 
         if face_dim not in ds.dims:
-            raise ValueError(
+            raise DimensionError(
                 f"The provided face dimension '{face_dim}' is not present in the provided healpix dataset."
                 f"Please set 'face_dim' to the dimension corresponding to the healpix face dimension."
             )

--- a/uxarray/core/gradient.py
+++ b/uxarray/core/gradient.py
@@ -4,6 +4,7 @@ import numpy as np
 from numba import njit, prange
 
 from uxarray.constants import INT_FILL_VALUE
+from uxarray.errors import DataCenteringError, DimensionError
 from uxarray.grid.area import calculate_face_area
 
 
@@ -96,7 +97,7 @@ def _compute_gradient(data, scale_by_radius=True):
     uxgrid = data.uxgrid
 
     if data.ndim > 1:
-        raise ValueError(
+        raise DimensionError(
             "Gradient currently requires 1D face-centered data. Consider "
             "reducing the dimension by selecting data across leading dimensions (e.g., `.isel(time=0)`, "
             "`.sel(lev=500)`, or `.mean('time')`). "
@@ -184,7 +185,7 @@ def _compute_gradient(data, scale_by_radius=True):
     #         normal_lon,
     #     )
     else:
-        raise ValueError(
+        raise DataCenteringError(
             "Computing the gradient is only supported for face-centered data variables."
         )
 

--- a/uxarray/core/utils.py
+++ b/uxarray/core/utils.py
@@ -1,5 +1,6 @@
 import xarray as xr
 
+from uxarray.errors import DimensionError
 from uxarray.io.utils import _get_source_dims_dict, _parse_grid_type
 
 
@@ -141,7 +142,7 @@ def _validate_indexers(indexers, indexers_kwargs, func_name, ignore_grid):
     }
 
     if not ignore_grid and len(grid_dims) > 1:
-        raise ValueError(
+        raise DimensionError(
             f"Only one grid dimension can be sliced at a time; got {sorted(grid_dims)}."
         )
 

--- a/uxarray/core/zonal.py
+++ b/uxarray/core/zonal.py
@@ -1,8 +1,8 @@
 import numpy as np
 from numba import njit
 
-from uxarray.grid.area import calculate_face_area
 from uxarray.errors import DimensionError
+from uxarray.grid.area import calculate_face_area
 from uxarray.grid.geometry import _unique_points
 from uxarray.grid.integrate import _zonal_face_weights, _zonal_face_weights_robust
 from uxarray.grid.intersections import (

--- a/uxarray/core/zonal.py
+++ b/uxarray/core/zonal.py
@@ -2,6 +2,7 @@ import numpy as np
 from numba import njit
 
 from uxarray.grid.area import calculate_face_area
+from uxarray.errors import DimensionError
 from uxarray.grid.geometry import _unique_points
 from uxarray.grid.integrate import _zonal_face_weights, _zonal_face_weights_robust
 from uxarray.grid.intersections import (
@@ -252,7 +253,7 @@ def _compute_face_band_weights(uxgrid, bands):
     """
     bands = np.asarray(bands, dtype=float)
     if bands.ndim != 1 or bands.size < 2:
-        raise ValueError("bands must be 1D with at least two edges")
+        raise DimensionError("bands must be 1D with at least two edges")
     if np.any(np.diff(bands) < 0):
         raise ValueError(
             f"bands must be monotonic non-decreasing; got diff(bands)={np.diff(bands)}"
@@ -393,7 +394,7 @@ def _compute_zonal_anomaly(uxda, bands, conservative=False):
 
     bands = np.asarray(bands, dtype=float)
     if bands.ndim != 1 or bands.size < 2:
-        raise ValueError("Band edges must be 1D with at least two values.")
+        raise DimensionError("Band edges must be 1D with at least two values.")
     if np.any(np.diff(bands) < 0):
         raise ValueError(
             "Band edges must be monotonic non-decreasing; got "

--- a/uxarray/cross_sections/dataarray_accessor.py
+++ b/uxarray/cross_sections/dataarray_accessor.py
@@ -6,6 +6,7 @@ import numpy as np
 import xarray as xr
 
 from uxarray.constants import INT_DTYPE
+from uxarray.errors import DataCenteringError
 
 from .sample import (
     _fill_numba,
@@ -81,7 +82,7 @@ class UxDataArrayCrossSectionAccessor:
         """
 
         if not self.uxda._face_centered():
-            raise ValueError("Data variable must be face-centered")
+            raise DataCenteringError("Data variable must be face-centered")
 
         if steps < 2:
             raise ValueError("steps must be at least 2")

--- a/uxarray/errors.py
+++ b/uxarray/errors.py
@@ -1,0 +1,28 @@
+"""
+File Purpose: custom error types in uxarray
+
+Defining custom error types helps with:
+    - quickly presenting relevant info
+    - cleaner error handling within uxarray
+    - cleaner error handling for packages using uxarray
+
+For more details, see: https://github.com/UXARRAY/uxarray/issues/1556
+"""
+
+
+class DataCenteringError(ValueError):
+    """data centering issue, such as expecting node-centered data but got edge-centered."""
+
+
+class DimensionError(ValueError):
+    """issue with dimension(s), such as wrong size(s), name(s), or number of dimensions."""
+
+
+class GridInvalidError(ValueError):
+    """data does not correspond to a valid uxarray.Grid.
+    E.g., unrecognized format, duplicate nodes, or some faces with area < 0.
+    """
+
+
+class GridsMismatchError(ValueError):
+    """attempted to perform an operation involving two incompatible uxarray.Grid objects"""

--- a/uxarray/errors.py
+++ b/uxarray/errors.py
@@ -1,10 +1,15 @@
 """
-File Purpose: custom error types in uxarray
+File Purpose: all custom error types in uxarray
 
 Defining custom error types helps with:
     - quickly presenting relevant info
     - cleaner error handling within uxarray
     - cleaner error handling for packages using uxarray
+
+Defining all such custom error types in this file, instead of throughout the codebase,
+    helps with maintainability, discoverability, and convenience,
+    as the import syntax will always be "import uxarray.errors.CustomError",
+    and help(uxarray.errors) will list all custom error types in one place.
 
 For more details, see: https://github.com/UXARRAY/uxarray/issues/1556
 """
@@ -26,3 +31,10 @@ class GridInvalidError(ValueError):
 
 class GridsMismatchError(ValueError):
     """attempted to perform an operation involving two incompatible uxarray.Grid objects"""
+
+
+# # # ----- Io-type-specific Errors ----- # # #
+
+
+class YacNotAvailableError(RuntimeError):
+    """Raised when the YAC backend is requested but unavailable."""

--- a/uxarray/grid/coordinates.py
+++ b/uxarray/grid/coordinates.py
@@ -7,6 +7,7 @@ from numba import njit, prange
 
 from uxarray.constants import ERROR_TOLERANCE
 from uxarray.conventions import ugrid
+from uxarray.errors import DimensionError
 from uxarray.grid.utils import _small_angle_of_2_vectors
 
 
@@ -790,7 +791,7 @@ def prepare_points(points, normalize):
         if normalize:
             x, y, z = _normalize_xyz(x, y, z)
     else:
-        raise ValueError(
+        raise DimensionError(
             "Points must be a sequence of length 2 (longitude, latitude) or 3 (x, y, z coordinates)."
         )
 
@@ -828,7 +829,7 @@ def points_atleast_2d_xyz(points):
     elif points.shape[1] == 3:
         points_xyz = points
     else:
-        raise ValueError(
+        raise DimensionError(
             "Points are neither Cartesian (shape N x 3) nor Spherical (shape N x 2)."
         )
 

--- a/uxarray/grid/grid.py
+++ b/uxarray/grid/grid.py
@@ -17,6 +17,7 @@ from uxarray.conventions import ugrid
 # Import the utility function for opening datasets with fallback
 from uxarray.core.utils import _open_dataset_with_fallback
 from uxarray.cross_sections import GridCrossSectionAccessor
+from uxarray.errors import DataCenteringError, GridInvalidError
 from uxarray.formatting_html import grid_repr
 from uxarray.grid.area import get_all_face_area_from_coords
 from uxarray.grid.bounds import _populate_face_bounds
@@ -165,7 +166,7 @@ class Grid:
         # check if inputted dataset is a minimum representable 2D UGRID unstructured grid
         if source_grid_spec != "HEALPix":
             if not _validate_minimum_ugrid(grid_ds):
-                raise ValueError(
+                raise GridInvalidError(
                     "Grid unable to be represented in the UGRID conventions. Representing an unstructured grid requires "
                     "at least the following variables: ['node_lon',"
                     "'node_lat', and 'face_node_connectivity']"
@@ -301,7 +302,7 @@ class Grid:
                         "Use ux.Grid.from_geodataframe(<shapefile_name) instead"
                     )
                 else:
-                    raise ValueError("Unsupported Grid Format")
+                    raise GridInvalidError("Unsupported Grid Format")
             else:
                 # custom source grid spec is provided
                 source_grid_spec = kwargs.get("source_grid_spec", None)
@@ -315,7 +316,7 @@ class Grid:
                     source_grid_spec = "FESOM2"
                     return cls(grid_ds, source_grid_spec, source_dims_dict)
             except TypeError:
-                raise ValueError("Unsupported Grid Format")
+                raise GridInvalidError("Unsupported Grid Format")
 
         return cls(
             grid_ds,
@@ -2526,14 +2527,14 @@ class Grid:
 
         if "n_node" in dim_kwargs:
             if inverse_indices:
-                raise Exception(
+                raise DataCenteringError(
                     "Inverse indices are not yet supported for node selection, please use face centers"
                 )
             return _slice_node_indices(self, dim_kwargs["n_node"])
 
         elif "n_edge" in dim_kwargs:
             if inverse_indices:
-                raise Exception(
+                raise DataCenteringError(
                     "Inverse indices are not yet supported for edge selection, please use face centers"
                 )
             return _slice_edge_indices(self, dim_kwargs["n_edge"])
@@ -2544,7 +2545,7 @@ class Grid:
             )
 
         else:
-            raise ValueError(
+            raise ValueError(  # intentionally not DataCenteringError; issue is with kwargs, not data.
                 "Indexing must be along a grid dimension: ('n_node', 'n_edge', 'n_face')"
             )
 

--- a/uxarray/grid/intersections.py
+++ b/uxarray/grid/intersections.py
@@ -4,6 +4,7 @@ import numpy as np
 from numba import njit, prange
 
 from uxarray.constants import ERROR_TOLERANCE, INT_DTYPE
+from uxarray.errors import DimensionError
 from uxarray.grid.arcs import _on_minor_arc_xyz, on_minor_arc
 from uxarray.utils.computing import (
     _cdp2,
@@ -433,7 +434,7 @@ def gca_gca_intersection(gca_a_xyz, gca_b_xyz):
         (0, 1, or 2 valid rows).
     """
     if gca_a_xyz.shape[1] != 3 or gca_b_xyz.shape[1] != 3:
-        raise ValueError("The two GCAs must be in the cartesian [x, y, z] format")
+        raise DimensionError("The two GCAs must be in the cartesian [x, y, z] format")
 
     w0 = gca_a_xyz[0]
     w1 = gca_a_xyz[1]

--- a/uxarray/io/_delaunay.py
+++ b/uxarray/io/_delaunay.py
@@ -2,6 +2,7 @@ import numpy as np
 import xarray as xr
 
 from uxarray.conventions import ugrid
+from uxarray.errors import DimensionError
 from uxarray.grid.geometry import stereographic_projection
 
 
@@ -16,7 +17,7 @@ def _spherical_delaunay_from_points(points, boundary_points=None):
     if boundary_points is not None:
         boundary_points = np.asarray(boundary_points)
         if boundary_points.ndim != 1:
-            raise ValueError(
+            raise DimensionError(
                 "boundary_points must be a 1D array-like of point indices."
             )
         if np.any(boundary_points < 0) or np.any(boundary_points >= len(points)):
@@ -77,7 +78,7 @@ def _regional_delaunay_from_points(points, boundary_points=None):
     if boundary_points is not None:
         boundary_points = np.asarray(boundary_points)
         if boundary_points.ndim != 1:
-            raise ValueError(
+            raise DimensionError(
                 "boundary_points must be a 1D array-like of point indices."
             )
         if np.any(boundary_points < 0) or np.any(boundary_points >= len(points)):

--- a/uxarray/io/_esmf.py
+++ b/uxarray/io/_esmf.py
@@ -5,6 +5,7 @@ import xarray as xr
 
 from uxarray.constants import INT_DTYPE, INT_FILL_VALUE
 from uxarray.conventions import ugrid
+from uxarray.errors import GridInvalidError
 
 
 def _esmf_to_ugrid_dims(in_ds):
@@ -138,7 +139,7 @@ def _encode_esmf(ds: xr.Dataset) -> xr.Dataset:
             if attr in out_ds["nodeCoords"].attrs:
                 del out_ds["nodeCoords"].attrs[attr]
     else:
-        raise ValueError("Input dataset must contain 'node_lon' and 'node_lat'.")
+        raise GridInvalidError("Input dataset must contain 'node_lon' and 'node_lat'.")
 
     # Face Node Connectivity (elementConn)
     if "face_node_connectivity" in ds:
@@ -153,7 +154,7 @@ def _encode_esmf(ds: xr.Dataset) -> xr.Dataset:
         )
         out_ds["elementConn"].encoding = {"dtype": np.int32}
     else:
-        raise ValueError("Input dataset must contain 'face_node_connectivity'.")
+        raise GridInvalidError("Input dataset must contain 'face_node_connectivity'.")
 
     # Number of nodes per face (numElementConn)
     if "n_nodes_per_face" in ds:

--- a/uxarray/io/_scrip.py
+++ b/uxarray/io/_scrip.py
@@ -483,7 +483,9 @@ def _extract_single_grid(
 
     dims = list(corner_lat.dims)
     if len(dims) < 2:
-        raise DimensionError(f"Corner variable for grid '{grid_name}' must be at least 2D.")
+        raise DimensionError(
+            f"Corner variable for grid '{grid_name}' must be at least 2D."
+        )
 
     corner_dim = metadata.get("corner_dim", dims[-1])
     cell_dims = _resolve_cell_dims(metadata, dims, corner_dim)

--- a/uxarray/io/_scrip.py
+++ b/uxarray/io/_scrip.py
@@ -6,6 +6,7 @@ import xarray as xr
 
 from uxarray.constants import INT_DTYPE, INT_FILL_VALUE
 from uxarray.conventions import ugrid
+from uxarray.errors import DimensionError, GridInvalidError
 from uxarray.grid.connectivity import _replace_fill_values
 
 
@@ -422,7 +423,7 @@ def _resolve_cell_dims(
         cell_dims = [dim for dim in data_dims if dim != corner_dim]
 
     if not cell_dims:
-        raise ValueError("Unable to determine cell dimensions for grid variable.")
+        raise DimensionError("Unable to determine cell dimensions for grid variable.")
 
     return cell_dims
 
@@ -436,7 +437,7 @@ def _stack_cell_dims(
     if not dims_in_array:
         if new_dim in data_array.dims:
             return data_array
-        raise ValueError(
+        raise DimensionError(
             f"Unable to stack dimensions {cell_dims}; none are present in {data_array.dims}"
         )
 
@@ -475,14 +476,14 @@ def _extract_single_grid(
     """
 
     if "corner_lat" not in metadata or "corner_lon" not in metadata:
-        raise ValueError(f"Grid '{grid_name}' is missing corner variables.")
+        raise GridInvalidError(f"Grid '{grid_name}' is missing corner variables.")
 
     corner_lat = ds[metadata["corner_lat"]]
     corner_lon = ds[metadata["corner_lon"]]
 
     dims = list(corner_lat.dims)
     if len(dims) < 2:
-        raise ValueError(f"Corner variable for grid '{grid_name}' must be at least 2D.")
+        raise DimensionError(f"Corner variable for grid '{grid_name}' must be at least 2D.")
 
     corner_dim = metadata.get("corner_dim", dims[-1])
     cell_dims = _resolve_cell_dims(metadata, dims, corner_dim)

--- a/uxarray/plot/accessor.py
+++ b/uxarray/plot/accessor.py
@@ -5,8 +5,8 @@ from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 
-from uxarray.errors import DataCenteringError
 import uxarray.plot.utils
+from uxarray.errors import DataCenteringError
 
 if TYPE_CHECKING:
     from uxarray.core.dataarray import UxDataArray

--- a/uxarray/plot/accessor.py
+++ b/uxarray/plot/accessor.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 
+from uxarray.errors import DataCenteringError
 import uxarray.plot.utils
 
 if TYPE_CHECKING:
@@ -505,7 +506,7 @@ class UxDataArrayPlotAccessor:
 
         Raises
         ------
-        ValueError
+        DataCenteringError (subclass of ValueError)
             If the data is not mapped to the nodes, edges, or faces.
         """
 
@@ -521,7 +522,7 @@ class UxDataArrayPlotAccessor:
         elif data_mapping == "edges":
             lon, lat = uxgrid.edge_lon.values, uxgrid.edge_lat.values
         else:
-            raise ValueError(
+            raise DataCenteringError(
                 "Data is not mapped to the nodes, edges, or faces of the grid."
             )
 

--- a/uxarray/plot/matplotlib.py
+++ b/uxarray/plot/matplotlib.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 
 import numpy as np
 
+from uxarray.errors import DimensionError
+
 if TYPE_CHECKING:
     from cartopy.mpl.geoaxes import GeoAxes
 
@@ -17,23 +19,23 @@ def _ensure_dimensions(data: UxDataArray) -> UxDataArray:
 
     Raises
     ------
-    ValueError
+    DimensionError (subclass of ValueError)
         If the DataArray has more or fewer than one dimension.
-    ValueError
+    DimensionError (subclass of ValueError)
         If the sole dimension is not named "n_face".
     """
     # Allow extra singleton dimensions as long as there's exactly one non-singleton dim
     non_trivial_dims = [dim for dim, size in zip(data.dims, data.shape) if size != 1]
 
     if len(non_trivial_dims) != 1:
-        raise ValueError(
+        raise DimensionError(
             "Expected data with a single dimension (other axes may be length 1), "
             f"but got dims {data.dims} with shape {data.shape}"
         )
 
     sole_dim = non_trivial_dims[0]
     if sole_dim != "n_face":
-        raise ValueError(f"Expected dimension 'n_face', but got '{sole_dim}'")
+        raise DimensionError(f"Expected dimension 'n_face', but got '{sole_dim}'")
 
     # Squeeze any singleton axes to ensure we return a true 1D array over n_face
     return data.squeeze()

--- a/uxarray/remap/apply_weights.py
+++ b/uxarray/remap/apply_weights.py
@@ -6,6 +6,7 @@ import numpy as np
 import xarray as xr
 
 import uxarray.core.dataarray
+from uxarray.errors import DimensionError
 
 from .utils import (
     LABEL_TO_COORD,
@@ -25,21 +26,21 @@ def _get_source_dim(
     spatial_dims = [dim for dim in da.dims if dim in SPATIAL_DIMS]
 
     if len(spatial_dims) > 1:
-        raise ValueError(
+        raise DimensionError(
             f"Weight application does not support variables with multiple "
             f"spatial dimensions. Got {spatial_dims!r} for variable {da.name!r}."
         )
 
     if source_dim is not None:
         if source_dim not in SPATIAL_DIMS:
-            raise ValueError(
+            raise DimensionError(
                 f"source_dim {source_dim!r} is not a spatial dimension. "
                 f"Expected one of {sorted(SPATIAL_DIMS)}."
             )
         if source_dim not in da.dims:
             return None
         if da.sizes[source_dim] != weights.source_size:
-            raise ValueError(
+            raise DimensionError(
                 f"Variable {da.name!r} dimension {source_dim!r} has size "
                 f"{da.sizes[source_dim]}, expected {weights.source_size}."
             )
@@ -69,7 +70,7 @@ def _apply_weights(
     destination_size = destination_grid.sizes[destination_dim]
 
     if destination_size != weights_obj.destination_size:
-        raise ValueError(
+        raise DimensionError(
             f"Destination grid size for {destination_dim!r} is {destination_size}, "
             f"but weights target size is {weights_obj.destination_size}."
         )
@@ -107,10 +108,10 @@ def _apply_weights(
 
     if not remapped_any:
         if is_da:
-            raise ValueError(
+            raise DimensionError(
                 f"No spatial dimension matched the weight source size {weights_obj.source_size}."
             )
-        raise ValueError(
+        raise DimensionError(
             "No dataset variables matched the supplied weight source size."
         )
 

--- a/uxarray/remap/bilinear.py
+++ b/uxarray/remap/bilinear.py
@@ -6,6 +6,8 @@ import numpy as np
 import xarray as xr
 from numba import njit, prange
 
+from uxarray.errors import DataCenteringError
+
 if TYPE_CHECKING:
     from uxarray.core.dataarray import UxDataArray
     from uxarray.core.dataset import UxDataset
@@ -62,7 +64,7 @@ def _bilinear(
 
     for src_dim in dims_to_remap:
         if src_dim != "n_face":
-            raise ValueError(
+            raise DataCenteringError(
                 "Bilinear remapping is not supported for non-face centered variables"
             )
 

--- a/uxarray/remap/spatial_coords_remap.py
+++ b/uxarray/remap/spatial_coords_remap.py
@@ -4,6 +4,7 @@ from typing import Dict, Literal, Optional, Tuple
 import xarray as xr
 
 from uxarray.core.dataarray import UxDataArray
+from uxarray.errors import DimensionError
 from uxarray.grid.grid import Grid
 
 COORD_TYPES = {
@@ -278,7 +279,7 @@ class SpatialCoordsRemapper:
         # Get the dimension that `source` is defined on
         source_dims = list(self.source.dims)
         if len(source_dims) == 0:
-            raise ValueError("Source data has no dimensions")
+            raise DimensionError("Source data has no dimensions")
 
         # Find the primary spatial dimension (should be n_face, n_node, or n_edge)
         source_spatial_dim = None
@@ -288,7 +289,7 @@ class SpatialCoordsRemapper:
                 break
 
         if source_spatial_dim is None:
-            raise ValueError(
+            raise DimensionError(
                 f"Could not identify spatial dimension in `source` dims: {source_dims}"
             )
 

--- a/uxarray/remap/structured.py
+++ b/uxarray/remap/structured.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 import numpy as np
 import xarray as xr
 
+from uxarray.errors import DimensionError
+
 
 @dataclass(frozen=True)
 class RectilinearGridSpec:
@@ -65,7 +67,7 @@ def _as_1d_coord(coord, default_name: str) -> xr.DataArray:
     if isinstance(coord, xr.DataArray):
         values = np.asarray(coord.values, dtype=np.float64)
         if coord.ndim != 1:
-            raise ValueError(
+            raise DimensionError(
                 f"Rectilinear {default_name!r} coordinate must be 1-D, "
                 f"got {coord.ndim}-D."
             )
@@ -75,7 +77,7 @@ def _as_1d_coord(coord, default_name: str) -> xr.DataArray:
     else:
         values = np.asarray(coord, dtype=np.float64)
         if values.ndim != 1:
-            raise ValueError(
+            raise DimensionError(
                 f"Rectilinear {default_name!r} coordinate must be 1-D, "
                 f"got {values.ndim}-D."
             )
@@ -84,7 +86,7 @@ def _as_1d_coord(coord, default_name: str) -> xr.DataArray:
         attrs = {}
 
     if values.size < 2:
-        raise ValueError(
+        raise DimensionError(
             f"Rectilinear {default_name!r} coordinate must contain at least two values."
         )
     return xr.DataArray(values, dims=(dim,), name=name, attrs=attrs)
@@ -148,7 +150,7 @@ def _reshape_array_to_rectilinear(
 
     axis = da.get_axis_num("n_face")
     if da.sizes["n_face"] != spec.size:
-        raise ValueError(
+        raise DimensionError(
             "Cannot reshape remapped data to the requested rectilinear grid. "
             f"Expected {spec.size} face values, got {da.sizes['n_face']}."
         )

--- a/uxarray/remap/utils.py
+++ b/uxarray/remap/utils.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 import uxarray.core.dataset
+from uxarray.errors import DimensionError
 
 # To preserve old names for remapping
 KDTREE_DIM_MAP: dict[str, str] = {
@@ -48,11 +49,11 @@ def _assert_dimension(dim):
 
     Raises
     ------
-    ValueError
+    DimensionError (subclass of ValueError)
         If `dim` is not a key in `LABEL_TO_COORD`.
     """
     if dim not in LABEL_TO_COORD:
-        raise ValueError(f"Invalid spatial dimension: {dim!r}")
+        raise DimensionError(f"Invalid spatial dimension: {dim!r}")
 
 
 def _construct_remapped_ds(source, remapped_vars, destination_grid, remap_to):
@@ -143,7 +144,7 @@ def _get_remap_dims(ds):
 
     Raises
     ------
-    ValueError
+    DimensionError (subclass of ValueError)
         If no spatial dimensions are detected in the dataset.
     """
     dims_to_remap: set[str] = set()
@@ -151,7 +152,7 @@ def _get_remap_dims(ds):
         dims_to_remap |= set(da.dims) & SPATIAL_DIMS
 
     if not dims_to_remap:
-        raise ValueError(
+        raise DimensionError(
             "No spatial dimensions (n_node, n_edge, or n_face) found in source to remap."
         )
 

--- a/uxarray/remap/weights.py
+++ b/uxarray/remap/weights.py
@@ -10,6 +10,7 @@ import numpy as np
 import xarray as xr
 
 from uxarray.core.utils import _open_dataset_with_fallback
+from uxarray.errors import DimensionError
 
 if TYPE_CHECKING:
     from scipy import sparse
@@ -123,7 +124,7 @@ class RemapWeights:
             ).ravel()
 
             if not (row.size == col.size == values.size):
-                raise ValueError(
+                raise DimensionError(
                     "Remap weights require row, col, and weight arrays of equal length."
                 )
 
@@ -152,10 +153,10 @@ class RemapWeights:
         values = np.asarray(values)
 
         if values.ndim == 0:
-            raise ValueError("Remap weights require at least a 1-D input array.")
+            raise DimensionError("Remap weights require at least a 1-D input array.")
 
         if values.shape[-1] != self.source_size:
-            raise ValueError(
+            raise DimensionError(
                 f"Expected trailing dimension of size {self.source_size}, "
                 f"got {values.shape[-1]}."
             )

--- a/uxarray/remap/yac.py
+++ b/uxarray/remap/yac.py
@@ -13,7 +13,7 @@ import numpy as np
 import xarray as xr
 
 import uxarray.core.dataarray
-from uxarray.errors import DataCenteringError, DimensionError
+from uxarray.errors import DataCenteringError, DimensionError, YacNotAvailableError
 from uxarray.remap.structured import (
     RectilinearGridSpec,
     _normalize_rectilinear_target,
@@ -27,10 +27,6 @@ from uxarray.remap.utils import (
     _get_remap_dims,
     _to_dataset,
 )
-
-
-class YacNotAvailableError(RuntimeError):
-    """Raised when the YAC backend is requested but unavailable."""
 
 
 @dataclass

--- a/uxarray/remap/yac.py
+++ b/uxarray/remap/yac.py
@@ -13,6 +13,7 @@ import numpy as np
 import xarray as xr
 
 import uxarray.core.dataarray
+from uxarray.errors import DataCenteringError, DimensionError
 from uxarray.remap.structured import (
     RectilinearGridSpec,
     _normalize_rectilinear_target,
@@ -327,11 +328,11 @@ class _YacRemapper:
         if values.ndim == 1:
             values = values.reshape(1, -1)
         elif values.ndim != 2:
-            raise ValueError(
+            raise DimensionError(
                 f"YAC remap expects a 1-D or 2-D array, got {values.ndim}-D input."
             )
         if values.shape[1] != self._src_size:
-            raise ValueError(
+            raise DimensionError(
                 f"YAC remap expects {self._src_size} values, got {values.shape[1]}."
             )
 
@@ -340,12 +341,12 @@ class _YacRemapper:
             if frac_mask.ndim == 1:
                 frac_mask = frac_mask.reshape(1, -1)
             elif frac_mask.ndim != 2:
-                raise ValueError(
+                raise DimensionError(
                     "YAC fractional mask expects a 1-D or 2-D array, "
                     f"got {frac_mask.ndim}-D input."
                 )
             if frac_mask.shape != values.shape:
-                raise ValueError(
+                raise DimensionError(
                     "YAC fractional mask must match remap input shape. "
                     f"Got mask shape {frac_mask.shape} and value shape {values.shape}."
                 )
@@ -376,7 +377,7 @@ def _prepare_frac_mask(frac_mask, da_t, src_values, src_dim: str) -> np.ndarray:
         frac_mask_values = np.asarray(frac_mask)
 
     if frac_mask_values.shape != src_values.shape:
-        raise ValueError(
+        raise DimensionError(
             "YAC fractional mask must match the remapped source variable shape. "
             f"Got mask shape {frac_mask_values.shape} and source shape {src_values.shape}."
         )
@@ -401,14 +402,14 @@ def _yac_remap(source, destination_grid, remap_to: str, yac_method: str, yac_kwa
 
     if options.method == "conservative":
         if destination_dim != "n_face":
-            raise ValueError(
+            raise ValueError(  # not DataCenteringError; the issue here is the remap_to kwarg.
                 "YAC conservative remapping requires the destination to be "
                 "face-centered (remap_to='faces'). "
                 f"Got remap_to={remap_to!r} which maps to dimension {destination_dim!r}."
             )
         non_face_src = dims_to_remap - {"n_face"}
         if non_face_src:
-            raise ValueError(
+            raise DataCenteringError(
                 "YAC conservative remapping requires all source data to be "
                 f"face-centered (dimension 'n_face'). "
                 f"Found non-face source dimension(s): {non_face_src}. "
@@ -481,7 +482,7 @@ def _yac_remap_to_rectilinear(source, lon, lat, yac_method: str, yac_kwargs):
     if options.method == "conservative":
         non_face_src = dims_to_remap - {"n_face"}
         if non_face_src:
-            raise ValueError(
+            raise DataCenteringError(
                 "YAC conservative remapping to a rectilinear grid requires all "
                 "source data to be face-centered (dimension 'n_face'). "
                 f"Found non-face source dimension(s): {non_face_src}. "

--- a/uxarray/subset/dataarray_accessor.py
+++ b/uxarray/subset/dataarray_accessor.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import numpy as np
 
+from uxarray.errors import DataCenteringError
+
 
 class DataArraySubsetAccessor:
     """Accessor for performing unstructured grid subsetting with a data
@@ -147,8 +149,10 @@ class DataArraySubsetAccessor:
 
         Raises
         ------
+        DataCenteringError (subclass of ValueError)
+            If the data variable is not face-centered.
         ValueError
-            If no intersections are found at the specified longitude or the data variable is not face-centered.
+            If no intersections are found at the specified longitude.
 
         Examples
         --------
@@ -157,7 +161,7 @@ class DataArraySubsetAccessor:
 
         """
         if not self.uxda._face_centered():
-            raise ValueError(
+            raise DataCenteringError(
                 "Cross sections are only supported for face-centered data variables."
             )
 
@@ -201,8 +205,10 @@ class DataArraySubsetAccessor:
 
         Raises
         ------
+        DataCenteringError (subclass of ValueError)
+            If the data variable is not face-centered.
         ValueError
-            If no intersections are found at the specified longitude or the data variable is not face-centered.
+            If no intersections are found at the specified longitude.
 
         Examples
         --------
@@ -210,7 +216,7 @@ class DataArraySubsetAccessor:
         >>> cross_section = uxda.cross_section.constant_longitude(lon=0.0)
         """
         if not self.uxda._face_centered():
-            raise ValueError(
+            raise DataCenteringError(
                 "Cross sections are only supported for face-centered data variables."
             )
 

--- a/uxarray/subset/grid_accessor.py
+++ b/uxarray/subset/grid_accessor.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from uxarray.errors import DimensionError
+
 if TYPE_CHECKING:
     from uxarray.grid import Grid
 
@@ -394,7 +396,7 @@ class GridSubsetAccessor:
     def _get_tree(self, coords, tree_type):
         """Internal helper for obtaining the desired KDTree or BallTree."""
         if coords.ndim > 1:
-            raise ValueError("Coordinates must be one-dimensional")
+            raise DimensionError("Coordinates must be one-dimensional")
 
         if len(coords) == 2:
             # Spherical coordinates
@@ -403,7 +405,7 @@ class GridSubsetAccessor:
             # Cartesian coordinates
             tree = self.uxgrid.get_kd_tree(tree_type)
         else:
-            raise ValueError("Unsupported coordinates provided.")
+            raise DimensionError("Unsupported coordinates provided.")
 
         return tree
 


### PR DESCRIPTION
Closes #1556 

## Overview
Adds custom error types in uxarray. Defining custom error types can help with:
- Quickly presenting relevant info (e.g. "DataCenteringError" name quickly clarifies this is about data being centered incorrectly, e.g. centered on nodes but expected it to be on faces). This could speed up debugging for developers and users alike.
- Cleaner error handling within/outside of uxarray (e.g., catch "uxarray.errors.DimensionError" without catching other ValueErrors by accident).

In particular, this PR adds the following error types:
```python
class DataCenteringError(ValueError):
    """data centering issue, such as expecting node-centered data but got edge-centered."""


class DimensionError(ValueError):
    """issue with dimension(s), such as wrong size(s), name(s), or number of dimensions."""


class GridInvalidError(ValueError):
    """data does not correspond to a valid uxarray.Grid.
    E.g., unrecognized format, duplicate nodes, or some faces with area < 0.
    """


class GridsMismatchError(ValueError):
    """attempted to perform an operation involving two incompatible uxarray.Grid objects"""
```


## Small expansion of scope
This PR expands scope slightly beyond that of the original issue as follows:
- move `YacNotAvailableError` from uxarray/remap/yac.py to uxarray/errors.py.

The following justification for this move is provided in the docstring at the top of errors.py:
> Defining all such custom error types in this file, instead of throughout the codebase, helps with maintainability, discoverability, and convenience, as the import syntax will always be "import uxarray.errors.CustomError", and help(uxarray.errors) will list all custom error types in one place.

Though, this could be reverted if PR reviewers disagree or feel that this should be scoped as a separate issue instead.


## Compatibility notes:
This PR should be fully backwards compatible, or nearly fully backwards compatible. Compatibility is maintained via subclassing. For example, any code catching ValueError will still catch any of the newly-defined custom error types, because they inherit from ValueError.

This PR adjusts two tests to check that custom error types are indeed being raised (e.g. `with pytest.raises(DataCenteringError)` instead of `with pytest.raises(ValueError)`). It does not adjust all tests to the new error types because it is desirable to see that the existing tests still pass, to confirm there are no breaking changes here.

Thinking about it a bit further, there are three technically-possible breakage points for existing code, but only for hopefully-very-unlikely code design patterns:
1. Any string-based error processing which checks for string match to error class name, e.g. `repr(err).startswith("ValueError")`
2. Any processing which checks for type equality, e.g. `type(err) == ValueError`
3. Any processing which specifically excludes subclasses, e.g. `isinstance(err, Exception) and not isinstance(err, ValueError)`, could fail in some cases. This PR replaces Exception with a custom error type in some cases, such as using DataCenteringError instead of Exception in a few places in grid.py.


## Other Recommended Changes (Not Implemented Here)

Should custom errors become part of the public API? I would be interested in at least adding `import uxarray.errors` in `uxarray.__init__.py`, so that users who have imported uxarray already can do things like: `ux.errors.DimensionError` without needing to remember to add another import statement like `from uxarray.errors import DimensionError`.

There are a few locations where the new error types would better describe the actual error, but which are not included in this PR because they could break backwards compatibility. These could be added here if PR reviewers want, or split into a separate issue and PR afterwards. Including these here is not necessary to close issue #1556.

- RuntimeError → GridInvalidError, in UxDataArray.get_dual, UxDataset.get_dual, and Grid.get_dual: "Duplicate nodes found, cannot construct dual"
- RuntimeError → DimensionError, in Grid.from_face_vertices: f"Invalid Input Dimension: {face_vertices.ndim}. Expected dimension should be 3: [n_face, n_node, two/three] or 2 when only one face is passed in."
- RuntimeError → GridInvalidError, in Grid.validate: "Mesh validation failed."
- AssertionError → DimensionError, in grid.neighbors._prepare_xy_for_query: "The dimension of each coordinate pair must be two (lon, lat). Did you attempt to query using Cartesian (x, y, z) coordinates?", **and** "The dimension of each coordinate pair must be two (lon, lat).)"
- AssertionError → DimensionError, in grid.neighbors._prepare_xyz_for_query: (similar messages as above)
- RuntimeError → GridInvalidError, in io.utils._parse_grid_type: "Failed to parse uxgrid information from xarray.Dataset."

I also put together a variety of error-type changes I would recommend but which are unrelated to this PR, because they do not use the new error types. _(Example: ValueError → TypeError in grid.utils.make_setter: f"{key} must be an xr.DataArray", which gets raised if not isinstance(value, xr.DataArray).)_ I have opened a separate issue to track those, see #1622.


## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->

**General**
- [X] An issue is linked created and linked
- [X] Add appropriate labels
- [X] Filled out Overview and Expected Usage (if applicable) sections

**Testing**
- [X] Adequate tests are created if there is new functionality
- [ ] Tests cover all possible logical paths in your function
- [X] Tests are not too basic (such as simply calling a function and nothing else)

**Documentation**
- [X] Docstrings have been added to all new functions
- [X] Docstrings have updated with any function changes
- [N/A] Internal functions have a preceding underscore (`_`) and have been added to `docs/internal_api/index.rst`
- [N/A] User functions have been added to `docs/user_api/index.rst`
