### PR TITLE
Fix and improve bot "🤖 Upstream testing failure" posts

### DIFF
--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -98,7 +98,7 @@ jobs:
           if [ -n "$existing_issue" ]; then
             echo "Found existing open issue #$existing_issue, updating it..."
             echo "$issue_body" | gh issue edit "$existing_issue" \
-              --title "$issue_title"
+              --title "$issue_title" \
               --body-file -
             echo "Updated existing issue #$existing_issue"
           else

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -88,12 +88,10 @@ jobs:
           title_prefix="🤖 Upstream testing failure"
           issue_title="${title_prefix} ($(date -u +%Y-%m-%d))"
 
-          # Find existing open issue whose title starts with the fixed prefix.
-          # Uses --label to narrow the API call, then a rigorous client-side
-          # startswith check (not GitHub's fuzzy --search) for the actual match.
+          # Find existing open issue whose title starts with the fixed prefix
           existing_issue=$(gh issue list --state open --label "CI" --json number,title \
-            --jq --arg prefix "$title_prefix" \
-            '[.[] | select(.title | startswith($prefix))] | .[0].number // empty')
+            --jq '.[] | select(.title | startswith("'"$title_prefix"'")) | .number' \
+            | head -n1)
 
           if [ -n "$existing_issue" ]; then
             echo "Found existing open issue #$existing_issue, updating it..."

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -84,13 +84,22 @@ jobs:
           issue_body="${issue_body//\{\{RUN_URL\}\}/${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}}"
           issue_body="${issue_body//\{\{DATE\}\}/$(date -u)}"
 
-          # Check for existing open issue with same title
-          issue_title="🤖 Upstream testing failure"
-          existing_issue=$(gh issue list --state open --label "CI" --search "\"$issue_title\" in:title" --json number --jq '.[0].number // empty')
+          # Prefix used for identity/matching; date suffix is for display only
+          title_prefix="🤖 Upstream testing failure"
+          issue_title="${title_prefix} ($(date -u +%Y-%m-%d))"
+
+          # Find existing open issue whose title starts with the fixed prefix.
+          # Uses --label to narrow the API call, then a rigorous client-side
+          # startswith check (not GitHub's fuzzy --search) for the actual match.
+          existing_issue=$(gh issue list --state open --label "CI" --json number,title \
+            --jq --arg prefix "$title_prefix" \
+            '[.[] | select(.title | startswith($prefix))] | .[0].number // empty')
 
           if [ -n "$existing_issue" ]; then
             echo "Found existing open issue #$existing_issue, updating it..."
-            echo "$issue_body" | gh issue edit "$existing_issue" --body-file -
+            echo "$issue_body" | gh issue edit "$existing_issue" \
+              --title "$issue_title"
+              --body-file -
             echo "Updated existing issue #$existing_issue"
           else
             echo "No existing open issue found, creating new one..."

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -61,7 +61,7 @@ jobs:
     name: failure-issue
     needs: [upstream-dev]
     if: |
-      needs.upstream-dev.testresults != 'success'
+      needs.upstream-dev.outputs.testresults != 'success'
       && github.repository == 'UXARRAY/uxarray'
       && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #1619
Closes #1591 

## Overview
Fixes typo in upstream-dev-ci.yml which led to always running the "make or update bot issue post reporting failed upstream-ci" commands, regardless of whether the upstream-ci actually succeeded. (See #1619.) The old version was checking if `needs.upstream-dev.testresults != 'success'`; the corrected version is checking if `needs.upstream-dev.outputs.testresults != 'success'` instead.

Updates title for bot issue reporting failed upstream-ci; now the post's title should include date of failure. When the bot updates the post, the title will update accordingly as well. (See #1591.)

~Keeping as draft PR until I figure out how to properly test these changes before merging….~ EDIT: see tests below.

## Testing these changes

I ran tests on my fork to see how this behaves, with some small changes to the workflow file to allow me to run it on my fork, repeatedly, while forcing failure / success each time as desired.

**To know that issue #1619 is properly fixed**, we should observe:
- (A) No issue posted on initial upstream-ci pipeline success.
- (B) Issue gets posted on failure.
- (C) No update to issue on subsequent success.
- (D) Issue gets updated on subsequent failure.
- (E) No issue posted on subsequent success after older issue gets closed.

Indeed, that is what happened. I did the following steps, in this order:
1. [Successful CI Upstream run](https://github.com/Sevans711/uxarray/actions/runs/30475039436). No corresponding issue was posted; this confirms (A).
2. [Failed CI Upstream run](https://github.com/Sevans711/uxarray/actions/runs/30478327844). A corresponding issue was posted (see https://github.com/Sevans711/uxarray/issues/2). This confirms (B). (The issue has since been edited and marked as closed, as per steps (4) and (5) below.)
3. [Another successful CI Upstream run](https://github.com/Sevans711/uxarray/actions/runs/30478756463). The corresponding issue was NOT updated; this confirms (C).
4. [Another failed CI Upstream run](https://github.com/Sevans711/uxarray/actions/runs/30479162317). The corresponding issue WAS updated; this confirms (D).
5. Closed the issue.
6. [One last successful CI Upstream run](https://github.com/Sevans711/uxarray/actions/runs/30479428319). Indeed, no issue was posted; this confirms (E).


**To know that issue #1591 is properly addressed**, we should observe:
- (A) title includes date.
- (B) title updates upon subsequent failure.

Steps from above demonstrate (A) properly already; The issue (https://github.com/Sevans711/uxarray/issues/2) includes a date in the title.

To demonstrate (B) without needing to wait a whole day, I made another branch (`testing_upstream-ci_bot_post_title`) on my fork and updated the .yml file; the only update was adding `-%H:%M` into line 105: `issue_title="${title_prefix} ($(date -u +%Y-%m-%d-%H:%M))"` for testing purposes.

Then, I ran two failed CI Upstream jobs. The first job created the issue https://github.com/Sevans711/uxarray/issues/3, and the second job updated the issue's title appropriately, as demonstrated by the edit history on that issue.

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->

**General**
- [X] An issue is linked created and linked
- [X] Add appropriate labels
- [X] Filled out Overview and Expected Usage (if applicable) sections

Claude helped with finding these bugs and suggesting code edits. I reviewed, made additional changes, and take responsibility for all revisions.