### PR TITLE
warn if calculate_total_face_area() too large; add FESOM areas regression test

### DIFF
--- a/test/grid/grid/test_areas.py
+++ b/test/grid/grid/test_areas.py
@@ -115,3 +115,10 @@ def test_latlon_bounds_populate_bounds_MPAS(gridpath):
     """Test bounds population with MPAS grid."""
     uxgrid = ux.open_grid(gridpath("mpas", "QU", "oQU480.231010.nc"))
     bounds_xarray = uxgrid.bounds
+
+
+def test_face_areas_fesom(gridpath):
+    """Ensure correct total area for FESOM grid (~8.3780 sr). Regression test for #425."""
+    uxgrid = ux.open_grid(gridpath("ugrid", "fesom", "fesom.mesh.diag.nc"))
+    total_area = uxgrid.calculate_total_face_area()
+    nt.assert_almost_equal(total_area, 8.3780, decimal=4)

--- a/uxarray/grid/grid.py
+++ b/uxarray/grid/grid.py
@@ -1958,7 +1958,12 @@ class Grid:
         """Calculate the total surface area of all the faces in a mesh.
 
         Equivalent to ``self.compute_face_areas(...).sum()``; provided as a
-        convenience.
+        convenience. (Note: for HEALPix grids, when called with default arguments,
+        this method actually returns ``self.face_areas.sum()`` instead,
+        which respects HEALPix equal-area property.)
+
+        Additionally, raises a warning if the result is larger than
+        the total area of a sphere (4 * pi * self.sphere_radius**2).
 
         Parameters
         ----------
@@ -1986,15 +1991,24 @@ class Grid:
             and order == 4
             and not latitude_adjusted_area
         ):
-            return np.sum(self.face_areas.values)
+            result = np.sum(self.face_areas.values)
 
-        return np.sum(
+        result = np.sum(
             self.compute_face_areas(
                 quadrature_rule=quadrature_rule,
                 order=order,
                 latitude_adjusted_area=latitude_adjusted_area,
             )
         )
+
+        RTOL = 1e-6  # 1e-7 had warnings in existing CI tests (as of 2026-08-05), 1e-6 did not.
+        if result > 4 * np.pi * self.sphere_radius**2 * (1 + RTOL):
+            warnings.warn(
+                f"Total face area (={result}) exceeds the surface area of the whole sphere "
+                f"(={4 * np.pi * self.sphere_radius**2}) (with sphere_radius={self.sphere_radius}).",
+            )
+
+        return result
 
     def compute_face_areas(
         self,


### PR DESCRIPTION
Closes #425 

## Overview
As discussed in thread in #425, the issue initially reported there has since been fixed by other changes. This PR adds a regression test (ensuring the total area for this FESOM grid is close to ~8.38 sr).

It also adds a warning to `calculate_total_face_areas()` if the result is larger than the total area of the sphere, to avoid silently returning wrong answers on malformed grids. It also updates the docstring for that function to clarify the warning might be raised.

Finally, a slight addition beyond just solving 425: updates the `calculate_total_face_areas()` docstring to clarify the actual behavior: it is not actually always equivalent to `compute_face_areas().sum()`. Specifically, for HEALPix grids, when using default values for all arguments, it is equivalent to `face_areas.sum()` (which respects HEALPix equal areas) instead.

Did not add any CI tests for this warning… please let me know if you think a regression test is necessary for it. Tested locally by temporarily locally adding `result = result * 1.5` near the end of `calculate_total_face_areas()`, to ensure bad results actually lead to raising warning and failing FESOM area regression test.

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**General**
- [X] An issue is created and linked
- [X] Added appropriate labels (if your uxarray repo permissions allow it)
- [X] Filled out Overview and Expected Usage (if applicable) sections

**Testing & Benchmarking**
<!--  If this PR does not update any functionality or tests and is unlikely to affect efficiency,
    e.g. by affecting computation time or memory usage, remove this section (Testing & Benchmarking) -->
- [N/A] Adequate tests are created if there is new functionality
- [X] Tests are not too basic (such as simply calling a function and nothing else)
- [X] Tests cover all major paths in your new functions
- [N/A] If this PR could affect performance, ran ASV benchmarks and confirmed they show expected behavior (add a new benchmark if necessary)
<!-- Adding the run-benchmark label (if your uxarray repo permissions allow it) will run ASV benchmarks.
    If you need benchmarks to be run but don't have permissions, leave this item unchecked for now. -->

**Documentation**
<!--  If this PR does not update any functionality or docstrings, remove this section (Documentation) -->
- [N/A] Docstrings have been added to all new functions
- [X] Docstrings have been updated with any function changes
- [N/A] User (public) functions have been added to `docs/api.rst`
- [N/A] Internal (private) function names start with an underscore (`_`)
