### PR TITLE
Fix misleading/confusing error types throughout uxarray

### DIFF
--- a/test/core/test_api.py
+++ b/test/core/test_api.py
@@ -85,7 +85,7 @@ def test_open_dataset_single_argument_rejects_invalid_combined_file(datasetpath)
 
     data_path = datasetpath("ugrid", "outCSne30", "outCSne30_var2.nc")
 
-    with pytest.raises(RuntimeError, match="Failed to parse uxgrid information from xarray.Dataset."):
+    with pytest.raises(ux.errors.GridInvalidError, match="Failed to parse uxgrid information from xarray.Dataset."):
         ux.open_dataset(data_path)
 
 

--- a/test/grid/grid/test_core.py
+++ b/test/grid/grid/test_core.py
@@ -131,5 +131,5 @@ def test_dual_mesh_mpas(gridpath):
 def test_dual_duplicate(gridpath):
     """Test dual mesh creation with duplicate grids."""
     dataset = ux.open_dataset(gridpath("ugrid", "geoflow-small", "grid.nc"), gridpath("ugrid", "geoflow-small", "grid.nc"))
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ux.errors.GridInvalidError):
         dataset.get_dual()

--- a/test/io/test_utils.py
+++ b/test/io/test_utils.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from uxarray.errors import GridInvalidError
 from uxarray.io.utils import _parse_grid_type
 
 
@@ -61,5 +62,5 @@ def test_parse_grid_type_detects_structured_grid():
     ],
 )
 def test_parse_grid_type_rejects_incomplete_format_signals(dataset):
-    with pytest.raises(RuntimeError, match="Failed to parse uxgrid information from xarray.Dataset."):
+    with pytest.raises(GridInvalidError, match="Failed to parse uxgrid information from xarray.Dataset."):
         _parse_grid_type(dataset)

--- a/uxarray/__init__.py
+++ b/uxarray/__init__.py
@@ -1,3 +1,4 @@
+from . import errors
 from . import tutorial
 from .constants import INT_DTYPE, INT_FILL_VALUE
 from .core.api import (
@@ -37,4 +38,5 @@ __all__ = (
     "INT_DTYPE",
     "INT_FILL_VALUE",
     "Grid",
+    "errors",
 )

--- a/uxarray/__init__.py
+++ b/uxarray/__init__.py
@@ -1,5 +1,4 @@
-from . import errors
-from . import tutorial
+from . import errors, tutorial
 from .constants import INT_DTYPE, INT_FILL_VALUE
 from .core.api import (
     concat,

--- a/uxarray/core/aggregation.py
+++ b/uxarray/core/aggregation.py
@@ -90,7 +90,7 @@ def _node_to_face_aggregation(uxda, aggregation, aggregation_func_kwargs):
             uxda, NUMPY_AGGREGATIONS[aggregation], aggregation_func_kwargs
         )
     else:
-        raise ValueError
+        raise TypeError
 
     return uxarray.core.dataarray.UxDataArray(
         uxgrid=uxda.uxgrid,
@@ -158,7 +158,7 @@ def _node_to_edge_aggregation(uxda, aggregation, aggregation_func_kwargs):
             uxda, NUMPY_AGGREGATIONS[aggregation], aggregation_func_kwargs
         )
     else:
-        raise ValueError
+        raise TypeError
 
     return uxarray.core.dataarray.UxDataArray(
         uxgrid=uxda.uxgrid,

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -860,7 +860,7 @@ class UxDataArray(xr.DataArray):
         elif isinstance(lat, (list, np.ndarray)):
             edges = np.asarray(lat, dtype=float)
         else:
-            raise ValueError(
+            raise TypeError(
                 "Invalid value for 'lat'. Must be a tuple (start, end, step) or array-like band edges."
             )
 
@@ -2167,7 +2167,7 @@ class UxDataArray(xr.DataArray):
         """
 
         if _check_duplicate_nodes_indices(self.uxgrid):
-            raise RuntimeError("Duplicate nodes found, cannot construct dual")
+            raise GridInvalidError("Duplicate nodes found, cannot construct dual")
 
         if self.uxgrid.partial_sphere_coverage:
             warn(

--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -708,7 +708,7 @@ class UxDataset(xr.Dataset):
         """
 
         if _check_duplicate_nodes_indices(self.uxgrid):
-            raise RuntimeError("Duplicate nodes found, cannot construct dual")
+            raise GridInvalidError("Duplicate nodes found, cannot construct dual")
 
         if self.uxgrid.partial_sphere_coverage:
             warn(

--- a/uxarray/grid/bounds.py
+++ b/uxarray/grid/bounds.py
@@ -416,7 +416,7 @@ def insert_pt_in_latlonbox(old_box, new_pt, is_lon_periodic=True):
     else:
         # Validate longitude point
         if not np.isnan(lon_pt) and (lon_pt < 0.0 or lon_pt > 2.0 * np.pi):
-            raise Exception("Longitude point out of range")
+            raise ValueError("Longitude point out of range")
 
         # Check for pole points
         is_pole_point = False
@@ -465,7 +465,7 @@ def insert_pt_in_latlonbox(old_box, new_pt, is_lon_periodic=True):
 
                         # Ensure widths are non-negative
                         if (d_width_a < 0.0) or (d_width_b < 0.0):
-                            raise Exception(
+                            raise AssertionError(
                                 "Logic error in longitude box width calculation"
                             )
 

--- a/uxarray/grid/grid.py
+++ b/uxarray/grid/grid.py
@@ -17,7 +17,7 @@ from uxarray.conventions import ugrid
 # Import the utility function for opening datasets with fallback
 from uxarray.core.utils import _open_dataset_with_fallback
 from uxarray.cross_sections import GridCrossSectionAccessor
-from uxarray.errors import DataCenteringError, GridInvalidError
+from uxarray.errors import DataCenteringError, DimensionError, GridInvalidError
 from uxarray.formatting_html import grid_repr
 from uxarray.grid.area import _get_all_face_area_from_coords
 from uxarray.grid.bounds import _populate_face_bounds
@@ -569,7 +569,7 @@ class Grid:
             Indicates whether the inputted vertices are in lat/lon, with units in degrees
         """
         if not isinstance(face_vertices, (list, tuple, np.ndarray)):
-            raise ValueError("Input must be either a list, tuple, or np.ndarray")
+            raise TypeError("Input must be either a list, tuple, or np.ndarray")
 
         face_vertices = np.asarray(face_vertices)
 
@@ -580,7 +580,7 @@ class Grid:
             grid_ds = _read_face_vertices(np.array([face_vertices]), latlon)
 
         else:
-            raise RuntimeError(
+            raise DimensionError(
                 f"Invalid Input Dimension: {face_vertices.ndim}. Expected dimension should be "
                 f"3: [n_face, n_node, two/three] or 2 when only "
                 f"one face is passed in."
@@ -633,7 +633,7 @@ class Grid:
             print("Mesh validation successful.")
             return True
         else:
-            raise RuntimeError("Mesh validation failed.")
+            raise GridInvalidError("Mesh validation failed.")
 
     def construct_face_centers(self, method="cartesian average"):
         """Constructs face centers, this method provides users direct control
@@ -1612,7 +1612,7 @@ class Grid:
         """Indices of nodes that border regions not covered by any geometry
         (holes) in a partial grid."""
         if "boundary_node_indices" not in self._ds:
-            raise ValueError
+            raise NotImplementedError
 
         return self._ds["boundary_node_indices"]
 
@@ -1663,7 +1663,7 @@ class Grid:
         if self.is_subset:
             return self._inverse_indices
         else:
-            raise Exception(
+            raise AttributeError(
                 "Grid is not a subset, therefore no inverse face indices exist"
             )
 
@@ -2534,7 +2534,7 @@ class Grid:
         if check_duplicate_nodes:
             if _check_duplicate_nodes_indices(self):
                 # TODO: This is very slow
-                raise RuntimeError("Duplicate nodes found, cannot construct dual")
+                raise GridInvalidError("Duplicate nodes found, cannot construct dual")
 
         # Get dual mesh node face connectivity
         dual_node_face_conn = construct_dual(grid=self)

--- a/uxarray/grid/neighbors.py
+++ b/uxarray/grid/neighbors.py
@@ -4,6 +4,7 @@ from numba import njit
 from numpy import deg2rad
 
 from uxarray.constants import ERROR_TOLERANCE, INT_DTYPE, INT_FILL_VALUE
+from uxarray.errors import DimensionError
 
 
 class KDTree:
@@ -96,7 +97,7 @@ class KDTree:
                 ).T
 
             else:
-                raise TypeError(
+                raise ValueError(
                     f"Unknown coordinate_system, {self.coordinate_system}, use either 'cartesian' or "
                     f"'spherical'"
                 )
@@ -192,7 +193,7 @@ class KDTree:
         elif self._coordinates == "edge centers":
             _tree = self._tree_from_edge_centers
         else:
-            raise TypeError(
+            raise ValueError(
                 f"Unknown coordinates location, {self._coordinates}, use either 'nodes', 'face centers', "
                 f"or 'edge centers'"
             )
@@ -1010,13 +1011,13 @@ def _prepare_xy_for_query(xy, use_radians, distance_metric):
 
     # expected shape is [n_pairs, 2]
     if xy.shape[1] == 3:
-        raise AssertionError(
+        raise DimensionError(
             "The dimension of each coordinate pair must be two (lon, lat). Did you attempt to query using Cartesian "
             "(x, y, z) coordinates?"
         )
 
     if xy.shape[1] != 2:
-        raise AssertionError(
+        raise DimensionError(
             "The dimension of each coordinate pair must be two (lon, lat).)"
         )
 
@@ -1044,13 +1045,13 @@ def _prepare_xyz_for_query(xyz):
 
     # expected shape is [n_pairs, 3]
     if xyz.shape[1] == 2:
-        raise AssertionError(
+        raise DimensionError(
             "The dimension of each coordinate pair must be three (x, y, z). Did you attempt to query using latlon "
             "(lat, lon) coordinates?"
         )
 
     if xyz.shape[1] != 3:
-        raise AssertionError(
+        raise DimensionError(
             "The dimension of each coordinate pair must be three (x, y, z).)"
         )
 

--- a/uxarray/grid/slice.py
+++ b/uxarray/grid/slice.py
@@ -32,7 +32,7 @@ def _slice_node_indices(
     """
 
     if inclusive is False:
-        raise ValueError("Exclusive slicing is not yet supported.")
+        raise NotImplementedError("Exclusive slicing is not yet supported.")
 
     # faces that saddle nodes given in 'indices'
     face_indices = np.unique(grid.node_face_connectivity.values[indices].ravel())
@@ -62,7 +62,7 @@ def _slice_edge_indices(
     """
 
     if inclusive is False:
-        raise ValueError("Exclusive slicing is not yet supported.")
+        raise NotImplementedError("Exclusive slicing is not yet supported.")
 
     # faces that saddle nodes given in 'indices'
     face_indices = np.unique(grid.edge_face_connectivity.values[indices].ravel())

--- a/uxarray/grid/utils.py
+++ b/uxarray/grid/utils.py
@@ -439,7 +439,7 @@ def make_setter(key: str):
 
     def setter(self, value):
         if not isinstance(value, xr.DataArray):
-            raise ValueError(f"{key} must be an xr.DataArray")
+            raise TypeError(f"{key} must be an xr.DataArray")
         self._ds[key] = value
 
     return setter

--- a/uxarray/io/_esmf.py
+++ b/uxarray/io/_esmf.py
@@ -76,7 +76,7 @@ def _read_esmf(in_ds):
             )
 
     else:
-        raise ValueError(
+        raise NotImplementedError(
             "Reading in ESMF grids with Cartesian coordinates not yet supported"
         )
 

--- a/uxarray/io/_icon.py
+++ b/uxarray/io/_icon.py
@@ -156,4 +156,4 @@ def _read_icon(ext_ds, use_dual=False):
     if not use_dual:
         return _primal_to_ugrid(ext_ds, out_ds)
     else:
-        raise ValueError("Conversion of the ICON Dual mesh is not yet supported.")
+        raise NotImplementedError("Conversion of the ICON Dual mesh is not yet supported.")

--- a/uxarray/io/_icon.py
+++ b/uxarray/io/_icon.py
@@ -156,4 +156,6 @@ def _read_icon(ext_ds, use_dual=False):
     if not use_dual:
         return _primal_to_ugrid(ext_ds, out_ds)
     else:
-        raise NotImplementedError("Conversion of the ICON Dual mesh is not yet supported.")
+        raise NotImplementedError(
+            "Conversion of the ICON Dual mesh is not yet supported."
+        )

--- a/uxarray/io/_scrip.py
+++ b/uxarray/io/_scrip.py
@@ -120,7 +120,7 @@ def _to_ugrid(in_ds, out_ds):
         )
 
     else:
-        raise Exception("Structured scrip files are not yet supported")
+        raise NotImplementedError("Structured scrip files are not yet supported")
 
     # populate source dims
     source_dims_dict[in_ds["grid_center_lon"].dims[0]] = "n_face"

--- a/uxarray/io/utils.py
+++ b/uxarray/io/utils.py
@@ -121,7 +121,9 @@ def _parse_grid_type(dataset):
         mesh_type = "Structured"
         return mesh_type, lon_name, lat_name
     else:
-        raise GridInvalidError("Failed to parse uxgrid information from xarray.Dataset.")
+        raise GridInvalidError(
+            "Failed to parse uxgrid information from xarray.Dataset."
+        )
 
     return mesh_type, None, None
 

--- a/uxarray/io/utils.py
+++ b/uxarray/io/utils.py
@@ -1,6 +1,7 @@
 import numpy as np
 import xarray as xr
 
+from uxarray.errors import GridInvalidError
 from uxarray.io._esmf import _esmf_to_ugrid_dims
 from uxarray.io._icon import _icon_to_ugrid_dims
 from uxarray.io._mpas import _mpas_to_ugrid_dims
@@ -120,7 +121,7 @@ def _parse_grid_type(dataset):
         mesh_type = "Structured"
         return mesh_type, lon_name, lat_name
     else:
-        raise RuntimeError("Failed to parse uxgrid information from xarray.Dataset.")
+        raise GridInvalidError("Failed to parse uxgrid information from xarray.Dataset.")
 
     return mesh_type, None, None
 

--- a/uxarray/remap/yac.py
+++ b/uxarray/remap/yac.py
@@ -122,7 +122,7 @@ def _get_lon_lat(grid, dim: str) -> tuple[np.ndarray, np.ndarray]:
     lon = getattr(grid, lon_attr, None)
     lat = getattr(grid, lat_attr, None)
     if lon is None or lat is None:
-        raise ValueError(
+        raise AttributeError(
             f"Grid does not provide {lon_attr}/{lat_attr} required for YAC remapping."
         )
     return np.deg2rad(np.asarray(lon.values, dtype=np.float64)), np.deg2rad(


### PR DESCRIPTION
Closes #1622

## Overview
Fixes error types which did correspond closely to the actual error being reported. For example, for an error like "This functionality is not yet supported" the error type should be NotImplementedError, not ValueError. This PR addresses all cases mentioned in #1622, which is an exhaustive list of all such cases throughout uxarray.

Test suite has been updated accordingly for all tests which failed due to expecting old error types.

**Slight expansion beyond original scope:** this PR also adds an import of `uxarray.errors` module in uxarray's top-level `__init__.py`, to make custom error types easier to refer to. Now users can reliably write something like `ux.errors.DimensionError`, instead of possibly needing to `import uxarray.errors` specifically and then do `uxarray.errors.DimensionError`. **Questions for reviewers: (A) is this okay to bundle here? (B) Do I also need to add something to `docs/api.rst` page?**

Below copies the list of changes enumerated in issue 1622, and marks them as (done), possibly with minor notes to show how they have been completed here.

1. (done) Exception → ValueError in grid.bounds.insert_pt_in_latlonbox: "Longitude point out of range"
2. (done - chose AssertionError) Exception → AssertionError or ValueError(?) in grid.bounds.insert_pt_in_latlonbox: "Logic error in longitude box width calculation"
3. (done) Exception → AttributeError in property Grid.inverse_indices: "Grid is not a subset, therefore no inverse face indices exist"
4. (done) ValueError → TypeError in core.aggregation._node_to_face_aggregation and core.aggregation._node_to_edge_aggregation: (error currently has no message, but is raised to indicate: not isinstance(uxda.data, (np.ndarray, da.Array)).)
5. (done) ValueError → TypeError in UxDataArray.zonal_anomaly: "Invalid value for 'lat'. Must be a tuple (start, end, step) or array-like band edges."
6. (done) ValueError → TypeError in Grid.from_face_vertices: "Input must be either a list, tuple, or np.ndarray"
7. (done) ValueError → NotImplementedError in Grid.boundary_node_indices: (error currently has no message, but seems like it is supposed to indicate that construction of boundary_node_indices is not yet implemented.)
8. (done) TypeError → ValueError in grid.neighbors.KDTree._build_from_nodes: f"Unknown coordinate_system, {self.coordinate_system}, use either 'cartesian' or 'spherical'".
9. (done) TypeError → ValueError in grid.neighbors.KDTree._current_tree and grid.neighbors.BallTree._current_tree: f"Unknown coordinates location, {self._coordinates}, use either 'nodes', 'face centers', or 'edge centers'"
10. (done) ValueError → NotImplementedError in grid.slice._slice_node_indices, grid.slice._slice_node_indices, and grid.slice._slice_face_indices: "Exclusive slicing is not yet supported."
11. (done) ValueError → TypeError in grid.utils.make_setter: f"{key} must be an xr.DataArray" (raised if not isinstance(value, xr.DataArray)).
12. (done) ValueError → NotImplementedError in io._esmf._read_esmf: "Reading in ESMF grids with Cartesian coordinates not yet supported"
13. (done) ValueError → NotImplementedError in io._icon._read_icon: "Conversion of the ICON Dual mesh is not yet supported."
14. (done) Exception → NotImplementedError in io._scrip._to_ugrid: "Structured scrip files are not yet supported"
15. (done) ValueError → AttributeError in remap.yac._get_lon_lat: f"Grid does not provide {lon_attr}/{lat_attr} required for YAC remapping."
16. (done) RuntimeError → GridInvalidError, in UxDataArray.get_dual, UxDataset.get_dual, and Grid.get_dual: "Duplicate nodes found, cannot construct dual"
17. (done) RuntimeError → DimensionError, in Grid.from_face_vertices: f"Invalid Input Dimension: {face_vertices.ndim}. Expected dimension should be 3: [n_face, n_node, two/three] or 2 when only one face is passed in."
18. (done) RuntimeError → GridInvalidError, in Grid.validate: "Mesh validation failed."
19. (done) AssertionError → DimensionError, in grid.neighbors._prepare_xy_for_query: "The dimension of each coordinate pair must be two (lon, lat). Did you attempt to query using Cartesian (x, y, z) coordinates?", **and** "The dimension of each coordinate pair must be two (lon, lat).)"
20. (done) AssertionError → DimensionError, in grid.neighbors._prepare_xyz_for_query: (similar messages as above)
21. (done) RuntimeError → GridInvalidError, in io.utils._parse_grid_type: "Failed to parse uxgrid information from xarray.Dataset."


## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**General**
- [X] An issue is created and linked
- [X] Added appropriate labels (if your uxarray repo permissions allow it)
- [X] Filled out Overview and Expected Usage (if applicable) sections

**Testing & Benchmarking**
<!--  If this PR does not update any functionality or tests and is unlikely to affect efficiency,
    e.g. by affecting computation time or memory usage, remove this section (Testing & Benchmarking) -->
- [X] Adequate tests are created if there is new functionality
- [X] Tests are not too basic (such as simply calling a function and nothing else)
- [N/A] Tests cover all major paths in your new functions
- [N/A] If this PR could affect performance, ran ASV benchmarks and confirmed they show expected behavior (add a new benchmark if necessary)
<!-- Adding the run-benchmark label (if your uxarray repo permissions allow it) will run ASV benchmarks.
    If you need benchmarks to be run but don't have permissions, leave this item unchecked for now. -->