### PR TITLE
Fix TypeError from HEALPix `grid.node_lat` when not yet populated

### DIFF
--- a/test/io/test_healpix.py
+++ b/test/io/test_healpix.py
@@ -280,3 +280,17 @@ def test_healpix_round_trip_consistency(tmp_path):
     # Validate grid dimensions are preserved
     assert reloaded_ugrid.n_face == original_grid.n_face
     assert reloaded_exodus.n_face == original_grid.n_face
+
+def test_healpix_grid_attr_access_order():
+    """Ensure can access node_lon & node_lat attributes of healpix grid in any order.
+    (If problem turns out to exists with other attributes, can add them here later.)
+    Regression test for #1637.
+    """
+    grid = ux.Grid.from_healpix(zoom=1)
+    grid.node_lon
+    grid.node_lat
+
+    # just making sure this doesn't crash:
+    grid = ux.Grid.from_healpix(zoom=1)
+    grid.node_lat
+    grid.node_lon

--- a/uxarray/grid/grid.py
+++ b/uxarray/grid/grid.py
@@ -1002,7 +1002,7 @@ class Grid:
         """
         if "node_lat" not in self._ds:
             if self.source_grid_spec == "HEALPix":
-                _populate_healpix_boundaries(self)
+                _populate_healpix_boundaries(self._ds)
             else:
                 _set_desired_longitude_range(self)
                 _populate_node_latlon(self)


### PR DESCRIPTION
Closes #1637 

## Overview
`Grid.node_lat` was failing on any HEALPix grid when `node_lat` was not already been populated. For example, `ux.Grid.from_healpix(zoom=2).node_lat` was causing TypeError.

The fix here is exactly the one proposed in that issue:
> Fix is `_populate_healpix_boundaries(self._ds)` at `grid.py:1003`.

Adds a regression test which would have failed before but now succeeds.

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**General**
- [X] An issue is created and linked
- [X] Added appropriate labels (if your uxarray repo permissions allow it)
- [X] Filled out Overview and Expected Usage (if applicable) sections

**Testing & Benchmarking**
<!--  If this PR does not update any functionality or tests and is unlikely to affect efficiency,
    e.g. by affecting computation time or memory usage, remove this section (Testing & Benchmarking) -->
- [N/A] Adequate tests are created if there is new functionality
- [X] Tests are not too basic (such as simply calling a function and nothing else)
- [N/A] Tests cover all major paths in your new functions
- [N/A] If this PR could affect performance, ran ASV benchmarks and confirmed they show expected behavior (add a new benchmark if necessary)
<!-- Adding the run-benchmark label (if your uxarray repo permissions allow it) will run ASV benchmarks.
    If you need benchmarks to be run but don't have permissions, leave this item unchecked for now. -->


## AI Disclosure
<!-- Please specify all AI tools used. Optionally, include model and/or briefly describe usage. Examples:
    "AI Usage: Claude (Fable 5), Gemini"
    "AI Usage: ChatGPT (5.5 Instant) to help understand cause of this bug, but I wrote all updates myself."
    "AI Usage: just GitHub Copilot's inline code suggestions."
    If you did not use AI, please write "AI Usage: N/A" and remove these checklist items or mark as [N/A].-->

AI Usage: just GitHub Copilot inline code suggestions.

- [X] I take responsibility for all AI-generated content in my PR.
- [X] I have tested all AI-generated content in my PR.