### PR TITLE
Implements `Grid.compute_skewness(..., method="equiangle")`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -195,6 +195,7 @@ Methods
    Grid.calculate_total_face_area
    Grid.compute_face_areas
    Grid.compute_face_node_angles
+   Grid.compute_skewness
    Grid.construct_face_centers
    Grid.get_ball_tree
    Grid.get_kd_tree

--- a/test/grid/geometry/test_angles.py
+++ b/test/grid/geometry/test_angles.py
@@ -65,3 +65,47 @@ def test_face_node_angles_hexagons_and_pentagons():
     spherical_excess = angles.sum('n_max_face_nodes') - (grid.n_nodes_per_face - 2) * np.pi
     face_areas = grid.compute_face_areas()
     assert np.allclose(spherical_excess, face_areas, atol=0, rtol=1e-9)
+
+def test_equiangle_skewness():
+    """just some tests about Grid.compute_skewness(method="equiangle")..."""
+
+    ## spot check with some triangles
+    # make a tiny 90,60,30 degrees triangle:
+    # (n1)
+    #  |   %%
+    #  |       %%
+    # (n0) ------ (n2)
+    node_lon = [0, 0, np.sqrt(3)]
+    node_lat = [0, 1, 0]
+    face_node_connectivity = [[0, 1, 2]]
+    grid = ux.Grid.from_topology(node_lon, node_lat, face_node_connectivity)
+    # expect skewness = max((Amax - Areg) / (180 degrees - Areg), (Areg - Amin) / Areg)
+    # here, Areg ~= 60 degrees (it's a tiny triangle), Amax = 90 degrees, Amin = 30 degrees
+    #   --> max((90 - 60) / (180 - 60), (60 - 30) / 60) --> max(0.25, 0.5)
+    skewness = grid.compute_skewness(method="equiangle")
+    assert np.isclose(skewness, 0.5, atol=1e-4, rtol=0)
+
+    ## much larger "would-be 90,60,30" triangle, to ensure accounting for spherical geometry.
+    # It's actually 90, 68.6, 36.2 degrees, due to spherical geometry.
+    node_lon = [0, 0, 30*np.sqrt(3)]
+    node_lat = [0, 30, 0]
+    face_node_connectivity = [[0, 1, 2]]
+    grid = ux.Grid.from_topology(node_lon, node_lat, face_node_connectivity)
+    skewness = grid.compute_skewness(method="equiangle")
+    assert not np.isclose(skewness, 0.5, atol=1e-2, rtol=0)
+    assert 0.42 < skewness < 0.46  # hard-coding "expected" answer.
+    # If using correct angles but not spherical geometry in Areg, would assume Areg = 60
+    #   --> skewness = max((90 - 68.6) / (180 - 68.6), (68.6 - 36.2) / 68.6) --> max(0.192, 0.472)
+    # Therefore, the test above is indeed sensitive to
+    #   "does the skewness formula actually use the proper Areg based on spherical geometry?"
+
+    ## spot check of grid with "not all faces have same number of nodes"
+    grid = ux.tutorial.open_grid('mpas-QU-480')
+    skewness = grid.compute_skewness(method="equiangle")
+    assert isinstance(skewness, xr.DataArray)
+    # there happens to be at least one very non-skew shape in this grid
+    assert 0 < skewness.min() < 1e-8
+    # there aren't any very skew shapes in this grid
+    assert skewness.max() < 0.15
+    # skewness is well defined for all faces
+    assert not np.any(skewness.isnull())

--- a/uxarray/grid/angles.py
+++ b/uxarray/grid/angles.py
@@ -16,8 +16,7 @@ def _compute_face_node_angles_convex(
     face_node_connectivity,
     n_nodes_per_face,
 ):
-    """
-    Calculate the angles at each node for each face, assuming convex faces
+    """Returns angles [in radians] at each node for each face, assuming convex faces
     and a spherical geometry (these assumptions occur throughout uxarray).
 
     Parameters
@@ -75,3 +74,43 @@ def _compute_face_node_angles_convex(
             )
             result[i, j] = _small_angle_of_2_vectors(v1, v2)
     return result
+
+def _regular_polygon_angle(n, *, degrees=False):
+    """returns the internal angle for a regular polygon with n sides.
+    Equivalent to (n-2)*180/n degrees or (n-2)*pi/n radians.
+
+    n can be a scalar or an array of integers (e.g., can use n = n_nodes_per_face)
+    """
+    if degrees:
+        return (n - 2) * 180 / n
+    else:
+        return (n - 2) * np.pi / n
+
+def _compute_equiangle_skewness(face_node_angles, n_nodes_per_face):
+    """Returns the equiangle skewness at each face:
+        max((Amax - Areg) / (pi - Areg), (Amin - Areg) / Areg)
+    where
+        Amin, Amax = min, max of the angles at the nodes of the face
+        Areg = ideal angle for a regular polygon with n_nodes_per_face sides.
+
+    Parameters
+    ----------
+    face_node_angles : xr.DataArray or UxDataArray with dims 'n_face', 'n_max_face_nodes'
+        Angles [in radians] at each node of each face.
+    n_nodes_per_face : xr.DataArray or UxDataArray with dims 'n_face'
+        Number of nodes for each face.
+
+    Returns
+    -------
+    xr.DataArray or UxDataArray with dims 'n_face'
+        Equiangle skewness for each face.
+        Type matches the input type (xr.DataArray or UxDataArray).
+    """
+    Amin = face_node_angles.min('n_max_face_nodes', skipna=True)
+    Amax = face_node_angles.max('n_max_face_nodes', skipna=True)
+    Areg = _regular_polygon_angle(n_nodes_per_face, degrees=False)
+    term0 = (Amax - Areg) / (np.pi - Areg)
+    term1 = (Amin - Areg) / Areg
+    # Should just use np.maximum(term0, term1), but that drops UxDataArray type currently,
+    # so use where as a workaround for now. TODO: swap to np.maximum after fixing issue #1685.
+    return term0.where(term0 > term1, term1)

--- a/uxarray/grid/angles.py
+++ b/uxarray/grid/angles.py
@@ -75,6 +75,7 @@ def _compute_face_node_angles_convex(
             result[i, j] = _small_angle_of_2_vectors(v1, v2)
     return result
 
+
 def _regular_polygon_angle(n, *, degrees=False):
     """returns the internal angle for a regular polygon with n sides.
     Equivalent to (n-2)*180/n degrees or (n-2)*pi/n radians.
@@ -85,6 +86,7 @@ def _regular_polygon_angle(n, *, degrees=False):
         return (n - 2) * 180 / n
     else:
         return (n - 2) * np.pi / n
+
 
 def _compute_equiangle_skewness(face_node_angles, n_nodes_per_face):
     """Returns the equiangle skewness at each face:
@@ -106,8 +108,8 @@ def _compute_equiangle_skewness(face_node_angles, n_nodes_per_face):
         Equiangle skewness for each face.
         Type matches the input type (xr.DataArray or UxDataArray).
     """
-    Amin = face_node_angles.min('n_max_face_nodes', skipna=True)
-    Amax = face_node_angles.max('n_max_face_nodes', skipna=True)
+    Amin = face_node_angles.min("n_max_face_nodes", skipna=True)
+    Amax = face_node_angles.max("n_max_face_nodes", skipna=True)
     Areg = _regular_polygon_angle(n_nodes_per_face, degrees=False)
     term0 = (Amax - Areg) / (np.pi - Areg)
     term1 = (Amin - Areg) / Areg

--- a/uxarray/grid/angles.py
+++ b/uxarray/grid/angles.py
@@ -78,7 +78,7 @@ def _compute_face_node_angles_convex(
 
 def _compute_equiangle_skewness(face_node_angles, n_nodes_per_face):
     """Returns the equiangle skewness at each face:
-        max((Amax - Areg) / (pi - Areg), (Amin - Areg) / Areg)
+        max((Amax - Areg) / (pi - Areg), (Areg - Amin) / Areg)
     where
         Amin, Amax = min, max of the angles at the nodes of the face
         Areg = internal angle at all nodes for a regular polygon with
@@ -109,7 +109,7 @@ def _compute_equiangle_skewness(face_node_angles, n_nodes_per_face):
     Amax = face_node_angles.max("n_max_face_nodes", skipna=True)
     Areg = face_node_angles.sum("n_max_face_nodes", skipna=True) / n_nodes_per_face
     term0 = (Amax - Areg) / (np.pi - Areg)
-    term1 = (Amin - Areg) / Areg
+    term1 = (Areg - Amin) / Areg
     # Should just use np.maximum(term0, term1), but that drops UxDataArray type currently,
     # so use where as a workaround for now. TODO: swap to np.maximum after fixing issue #1685.
     return term0.where(term0 > term1, term1)

--- a/uxarray/grid/angles.py
+++ b/uxarray/grid/angles.py
@@ -76,24 +76,21 @@ def _compute_face_node_angles_convex(
     return result
 
 
-def _regular_polygon_angle(n, *, degrees=False):
-    """returns the internal angle for a regular polygon with n sides.
-    Equivalent to (n-2)*180/n degrees or (n-2)*pi/n radians.
-
-    n can be a scalar or an array of integers (e.g., can use n = n_nodes_per_face)
-    """
-    if degrees:
-        return (n - 2) * 180 / n
-    else:
-        return (n - 2) * np.pi / n
-
-
 def _compute_equiangle_skewness(face_node_angles, n_nodes_per_face):
     """Returns the equiangle skewness at each face:
         max((Amax - Areg) / (pi - Areg), (Amin - Areg) / Areg)
     where
         Amin, Amax = min, max of the angles at the nodes of the face
-        Areg = ideal angle for a regular polygon with n_nodes_per_face sides.
+        Areg = internal angle at all nodes for a regular polygon with
+            the same number of sides and covering the same area as this face.
+
+    In a flat geometry, the sum of angles in a polygon with n sides is (n-2)*pi.
+    Splitting the angles equally to form a regular polygon yields Areg_flat = (n-2)*pi/n.
+    However, for a spherical geometry, the sum of angles depends on face area:
+        sum(angles) = (n-2)*pi + face_area / sphere_radius^2
+    Areg should be based on a regular polygon with same area as the corresponding face,
+    so, splitting the angles equally to form a regular polygon yields simply:
+        Areg = sum(angles)/n.
 
     Parameters
     ----------
@@ -110,7 +107,7 @@ def _compute_equiangle_skewness(face_node_angles, n_nodes_per_face):
     """
     Amin = face_node_angles.min("n_max_face_nodes", skipna=True)
     Amax = face_node_angles.max("n_max_face_nodes", skipna=True)
-    Areg = _regular_polygon_angle(n_nodes_per_face, degrees=False)
+    Areg = face_node_angles.sum("n_max_face_nodes", skipna=True) / n_nodes_per_face
     term0 = (Amax - Areg) / (np.pi - Areg)
     term1 = (Amin - Areg) / Areg
     # Should just use np.maximum(term0, term1), but that drops UxDataArray type currently,

--- a/uxarray/grid/grid.py
+++ b/uxarray/grid/grid.py
@@ -1978,12 +1978,19 @@ class Grid:
 
     def compute_skewness(self, *, method: str = "equiangle", as_uxarray: bool = False):
         """Returns the skewness of each face in the grid, computed using the specified method.
+        Skewness is a measure of how much a face deviates from being regular,
+        e.g. having equal angles at all nodes. Values close to 0 indicate a regular face,
+        while values close to 1 indicate a highly skewed / nearly degenerate face.
 
         Parameters
         ----------
         method: str, defaults to "equiangle"
             The method to use for computing skewness. Options are:
-            - "equiangle": computes the equiangular skewness of each face.
+            - "equiangle": computes the equiangular skewness of each face:
+                equiangle_skewness = max((Amax - Areg) / (pi - Areg), (Amin - Areg) / Areg)
+                where Amin, Amax = min, max of the angles at the nodes of the face,
+                and Areg = internal angle at all nodes for a regular polygon with
+                the same number of sides and covering the same area as this face.
             - (other options not yet implemented)
         as_uxarray: bool, defaults to False
             Whether to return a uxarray.DataArray (if True) or an xarray.DataArray (if False).

--- a/uxarray/grid/grid.py
+++ b/uxarray/grid/grid.py
@@ -1976,7 +1976,7 @@ class Grid:
             source_dims_dict=self._source_dims_dict,
         )
 
-    def compute_skewness(self, *, method: str = "equiangle", as_uxarray: bool = False):
+    def compute_skewness(self, method: str = "equiangle", *, as_uxarray: bool = False):
         """Returns the skewness of each face in the grid, computed using the specified method.
         Skewness is a measure of how much a face deviates from being regular,
         e.g. having equal angles at all nodes. Values close to 0 indicate a regular face,
@@ -1987,7 +1987,7 @@ class Grid:
         method: str, defaults to "equiangle"
             The method to use for computing skewness. Options are:
             - "equiangle": computes the equiangular skewness of each face:
-                equiangle_skewness = max((Amax - Areg) / (pi - Areg), (Amin - Areg) / Areg)
+                equiangle_skewness = max((Amax - Areg) / (pi - Areg), (Areg - Amin) / Areg)
                 where Amin, Amax = min, max of the angles at the nodes of the face,
                 and Areg = internal angle at all nodes for a regular polygon with
                 the same number of sides and covering the same area as this face.

--- a/uxarray/grid/grid.py
+++ b/uxarray/grid/grid.py
@@ -19,7 +19,10 @@ from uxarray.core.utils import _open_dataset_with_fallback
 from uxarray.cross_sections import GridCrossSectionAccessor
 from uxarray.errors import DataCenteringError, DimensionError, GridInvalidError
 from uxarray.formatting_html import grid_repr
-from uxarray.grid.angles import _compute_face_node_angles_convex
+from uxarray.grid.angles import (
+    _compute_equiangle_skewness,
+    _compute_face_node_angles_convex,
+)
 from uxarray.grid.area import _get_all_face_area_from_coords
 from uxarray.grid.bounds import _populate_face_bounds
 from uxarray.grid.connectivity import (
@@ -1972,6 +1975,37 @@ class Grid:
             source_grid_spec=self.source_grid_spec,
             source_dims_dict=self._source_dims_dict,
         )
+
+    def compute_skewness(self,
+        *,
+        method: str = "equiangle",
+        as_uxarray: bool = False
+    ):
+        """Returns the skewness of each face in the grid, computed using the specified method.
+
+        Parameters
+        ----------
+        method: str, defaults to "equiangle"
+            The method to use for computing skewness. Options are:
+            - "equiangle": computes the equiangular skewness of each face.
+            - (other options not yet implemented)
+        as_uxarray: bool, defaults to False
+            Whether to return a uxarray.DataArray (if True) or an xarray.DataArray (if False).
+            If True, equivalent to uxarray.DataArray(self.compute_skewness(..., as_uxarray=False), uxgrid=self).
+
+        Returns
+        -------
+        skewness : xr.DataArray or uxarray.UxDataArray (if as_uxarray=True)
+            The skewness of each face in the grid.
+            Has 'n_face' dimension, with same size as in self.
+        """
+        if method == "equiangle":
+            face_node_angles = self.compute_face_node_angles(as_uxarray=as_uxarray)
+            return _compute_equiangle_skewness(face_node_angles, self.n_nodes_per_face)
+        else:
+            raise NotImplementedError(
+                f"Skewness computation method '{method}' is not implemented."
+            )
 
     def compute_face_node_angles(
         self,

--- a/uxarray/grid/grid.py
+++ b/uxarray/grid/grid.py
@@ -1976,11 +1976,7 @@ class Grid:
             source_dims_dict=self._source_dims_dict,
         )
 
-    def compute_skewness(self,
-        *,
-        method: str = "equiangle",
-        as_uxarray: bool = False
-    ):
+    def compute_skewness(self, *, method: str = "equiangle", as_uxarray: bool = False):
         """Returns the skewness of each face in the grid, computed using the specified method.
 
         Parameters


### PR DESCRIPTION
Closes #1686 

## Overview
Creates `Grid.compute_skewness` and implements `Grid.compute_skewness(..., method="equiangle")`. This computes the skewness of all faces based on the equiangle method. See #1686 for more detailed description.

Similarly to `Grid.compute_face_node_angles`, the result is an xarray.DataArray by default, but can be returned as a UxDataArray if desired, by setting `as_uxarray=True`.

**Tiny expansion of scope**: clarifies in `_compute_face_node_angles_convex` docstring that the angles there are returned in radians.

## Expected Usage
<!--  If this PR adds a new feature, please provide a short example of it in action.
      You may ignore this step if it is not applicable (delete this section). -->
```Python
import uxarray as ux

grid_path = "/path/to/grid.nc"
data_path = "/path/to/data.nc"

uxds = ux.open_dataset(grid_path, data_path)
grid = uxds.uxgrid   # or use: ux.open_grid(grid_path)

# result is an xarray.DataArray by default
skewness = grid.compute_skewness()

# Easier to visualize when getting result as UxDataArray instead:
skewness_as_uxarray = grid.compute_skewness(as_uxarray=True)
skewness_as_uxarray.plot()
```

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**General**
- [X] An issue is created and linked
- [X] Added appropriate labels (if your uxarray repo permissions allow it)
- [X] Filled out Overview and Expected Usage (if applicable) sections

**Testing & Benchmarking**
<!--  If this PR does not update any functionality or tests and is unlikely to affect efficiency,
    e.g. by affecting computation time or memory usage, remove this section (Testing & Benchmarking) -->
- [X] Adequate tests are created if there is new functionality
- [X] Tests are not too basic (such as simply calling a function and nothing else)
- [X] Tests cover all major paths in your new functions
- [N/A] If this PR could affect performance, ran ASV benchmarks and confirmed they show expected behavior (add a new benchmark if necessary)
<!-- Adding the run-benchmark label (if your uxarray repo permissions allow it) will run ASV benchmarks.
    If you need benchmarks to be run but don't have permissions, leave this item unchecked for now. -->

**Documentation**
<!--  If this PR does not update any functionality or docstrings, remove this section (Documentation) -->
- [X] Docstrings have been added to all new functions
- [N/A] Docstrings have been updated with any function changes
- [X] User (public) functions have been added to `docs/api.rst`
- [X] Internal (private) function names start with an underscore (`_`)


## AI Disclosure
<!-- Please specify all AI tools used. Optionally, include model and/or briefly describe usage. Examples:
    "AI Usage: Claude (Fable 5), Gemini"
    "AI Usage: ChatGPT (5.5 Instant) to help understand cause of this bug, but I wrote all updates myself."
    "AI Usage: just GitHub Copilot's inline code suggestions."
    If you did not use AI, please write "AI Usage: N/A" and remove these checklist items or mark as [N/A].-->

AI Usage: GitHub Copilot's inline code suggestions, plus chats with Claude, ChatGPT, Gemini for learning about skewness. 

- [X] I take responsibility for all AI-generated content in my PR.
- [X] I have tested all AI-generated content in my PR.