### PR TITLE
Scalarized `gca_gca_intersection`

### DIFF
--- a/benchmarks/geometry_kernels.py
+++ b/benchmarks/geometry_kernels.py
@@ -14,7 +14,6 @@ benchmark in this directory.
 """
 
 import numpy as np
-from asv_runner.benchmarks.mark import skip_benchmark_if
 
 
 def _unit(v):
@@ -143,54 +142,32 @@ class OrientPredicates:
         self.on_minor_arc(_V0, _W0, _W1)
 
 
-# ``gca_gca_intersection`` (Layer 3) calls scalar-argument L1/L2 kernels
-# (``_accux_gca_scalar``, ``_try_gca_gca_intersection_scalar``) rather than the
-# array-returning ``_accux_gca``/``_try_gca_gca_intersection`` that predate them
-# -- the array forms each allocated a ``(3,)`` (or ``(2,3)``) result per call,
-# which no longer happens on the hot path. Benchmarking the array forms would
-# time functions the dispatcher does not call, so they are skipped -- not
-# measured -- on commits before the scalar kernels existed.
-try:
-    from uxarray.grid.intersections import (  # noqa: F401
-        _accux_gca_scalar,
-        _try_gca_gca_intersection_scalar,
-    )
-
-    _HAS_SCALAR_GCA_KERNELS = True
-except ImportError:
-    _HAS_SCALAR_GCA_KERNELS = False
-
-
 class GCAGCAIntersection:
     """Benchmark all three layers of the GCA-GCA intersection stack."""
 
     def setup(self):
-        from uxarray.grid.intersections import gca_gca_intersection
+        from uxarray.grid.intersections import (
+            _accux_gca_scalar,
+            _try_gca_gca_intersection_scalar,
+            gca_gca_intersection
+        )
 
         self.gca_gca_intersection = gca_gca_intersection
         self.gca_a = np.stack([_W0, _W1])
         self.gca_b = np.stack([_V0, _V1])
         gca_gca_intersection(self.gca_a, self.gca_b)
 
-        if _HAS_SCALAR_GCA_KERNELS:
-            from uxarray.grid.intersections import (
-                _accux_gca_scalar,
-                _try_gca_gca_intersection_scalar,
-            )
+        self._accux_gca_scalar = _accux_gca_scalar
+        self._try_gca_gca_intersection_scalar = _try_gca_gca_intersection_scalar
+        _accux_gca_scalar(*_W0, *_W1, *_V0, *_V1)
+        _try_gca_gca_intersection_scalar(*_W0, *_W1, *_V0, *_V1)
 
-            self._accux_gca_scalar = _accux_gca_scalar
-            self._try_gca_gca_intersection_scalar = _try_gca_gca_intersection_scalar
-            _accux_gca_scalar(*_W0, *_W1, *_V0, *_V1)
-            _try_gca_gca_intersection_scalar(*_W0, *_W1, *_V0, *_V1)
-
-    @skip_benchmark_if(not _HAS_SCALAR_GCA_KERNELS)
     def time_accux_gca_kernel(self):
-        """Layer 1: pure numerical kernel (scalar form; allocation-free)."""
+        """Layer 1: pure numerical kernel."""
         self._accux_gca_scalar(*_W0, *_W1, *_V0, *_V1)
 
-    @skip_benchmark_if(not _HAS_SCALAR_GCA_KERNELS)
     def time_try_gca_gca_intersection(self):
-        """Layer 2: batch/status layer (scalar form; allocation-free)."""
+        """Layer 2: batch/status layer."""
         self._try_gca_gca_intersection_scalar(*_W0, *_W1, *_V0, *_V1)
 
     def time_gca_gca_intersection(self):

--- a/benchmarks/geometry_kernels.py
+++ b/benchmarks/geometry_kernels.py
@@ -147,8 +147,8 @@ class GCAGCAIntersection:
 
     def setup(self):
         from uxarray.grid.intersections import (
-            _accux_gca_scalar,
-            _try_gca_gca_intersection_scalar,
+            _accux_gca,
+            _try_gca_gca_intersection,
             gca_gca_intersection
         )
 
@@ -157,18 +157,18 @@ class GCAGCAIntersection:
         self.gca_b = np.stack([_V0, _V1])
         gca_gca_intersection(self.gca_a, self.gca_b)
 
-        self._accux_gca_scalar = _accux_gca_scalar
-        self._try_gca_gca_intersection_scalar = _try_gca_gca_intersection_scalar
-        _accux_gca_scalar(*_W0, *_W1, *_V0, *_V1)
-        _try_gca_gca_intersection_scalar(*_W0, *_W1, *_V0, *_V1)
+        self._accux_gca = _accux_gca
+        self._try_gca_gca_intersection = _try_gca_gca_intersection
+        _accux_gca(*_W0, *_W1, *_V0, *_V1)
+        _try_gca_gca_intersection(*_W0, *_W1, *_V0, *_V1)
 
     def time_accux_gca_kernel(self):
         """Layer 1: pure numerical kernel."""
-        self._accux_gca_scalar(*_W0, *_W1, *_V0, *_V1)
+        self._accux_gca(*_W0, *_W1, *_V0, *_V1)
 
     def time_try_gca_gca_intersection(self):
         """Layer 2: batch/status layer."""
-        self._try_gca_gca_intersection_scalar(*_W0, *_W1, *_V0, *_V1)
+        self._try_gca_gca_intersection(*_W0, *_W1, *_V0, *_V1)
 
     def time_gca_gca_intersection(self):
         """Layer 3: dispatcher (full public API)."""

--- a/benchmarks/geometry_kernels.py
+++ b/benchmarks/geometry_kernels.py
@@ -14,6 +14,7 @@ benchmark in this directory.
 """
 
 import numpy as np
+from asv_runner.benchmarks.mark import skip_benchmark_if
 
 
 def _unit(v):
@@ -142,33 +143,55 @@ class OrientPredicates:
         self.on_minor_arc(_V0, _W0, _W1)
 
 
+# ``gca_gca_intersection`` (Layer 3) calls scalar-argument L1/L2 kernels
+# (``_accux_gca_scalar``, ``_try_gca_gca_intersection_scalar``) rather than the
+# array-returning ``_accux_gca``/``_try_gca_gca_intersection`` that predate them
+# -- the array forms each allocated a ``(3,)`` (or ``(2,3)``) result per call,
+# which no longer happens on the hot path. Benchmarking the array forms would
+# time functions the dispatcher does not call, so they are skipped -- not
+# measured -- on commits before the scalar kernels existed.
+try:
+    from uxarray.grid.intersections import (  # noqa: F401
+        _accux_gca_scalar,
+        _try_gca_gca_intersection_scalar,
+    )
+
+    _HAS_SCALAR_GCA_KERNELS = True
+except ImportError:
+    _HAS_SCALAR_GCA_KERNELS = False
+
+
 class GCAGCAIntersection:
     """Benchmark all three layers of the GCA-GCA intersection stack."""
 
     def setup(self):
-        from uxarray.grid.intersections import (
-            _accux_gca,
-            _try_gca_gca_intersection,
-            gca_gca_intersection,
-        )
+        from uxarray.grid.intersections import gca_gca_intersection
 
-        self._accux_gca = _accux_gca
-        self._try_gca_gca_intersection = _try_gca_gca_intersection
         self.gca_gca_intersection = gca_gca_intersection
-
         self.gca_a = np.stack([_W0, _W1])
         self.gca_b = np.stack([_V0, _V1])
-        _accux_gca(_W0, _W1, _V0, _V1)
-        _try_gca_gca_intersection(_W0, _W1, _V0, _V1)
         gca_gca_intersection(self.gca_a, self.gca_b)
 
-    def time_accux_gca_kernel(self):
-        """Layer 1: pure numerical kernel."""
-        self._accux_gca(_W0, _W1, _V0, _V1)
+        if _HAS_SCALAR_GCA_KERNELS:
+            from uxarray.grid.intersections import (
+                _accux_gca_scalar,
+                _try_gca_gca_intersection_scalar,
+            )
 
+            self._accux_gca_scalar = _accux_gca_scalar
+            self._try_gca_gca_intersection_scalar = _try_gca_gca_intersection_scalar
+            _accux_gca_scalar(*_W0, *_W1, *_V0, *_V1)
+            _try_gca_gca_intersection_scalar(*_W0, *_W1, *_V0, *_V1)
+
+    @skip_benchmark_if(not _HAS_SCALAR_GCA_KERNELS)
+    def time_accux_gca_kernel(self):
+        """Layer 1: pure numerical kernel (scalar form; allocation-free)."""
+        self._accux_gca_scalar(*_W0, *_W1, *_V0, *_V1)
+
+    @skip_benchmark_if(not _HAS_SCALAR_GCA_KERNELS)
     def time_try_gca_gca_intersection(self):
-        """Layer 2: batch/status layer."""
-        self._try_gca_gca_intersection(_W0, _W1, _V0, _V1)
+        """Layer 2: batch/status layer (scalar form; allocation-free)."""
+        self._try_gca_gca_intersection_scalar(*_W0, *_W1, *_V0, *_V1)
 
     def time_gca_gca_intersection(self):
         """Layer 3: dispatcher (full public API)."""

--- a/uxarray/grid/intersections.py
+++ b/uxarray/grid/intersections.py
@@ -313,6 +313,55 @@ def _accux_gca(w0, w1, v0, v1):
     return pos, neg
 
 
+@njit(cache=True, inline="always", error_model="numpy")
+def _accux_gca_scalar(
+    w00, w01, w02, w10, w11, w12, v00, v01, v02, v10, v11, v12
+):
+    """Scalar-argument form of :func:`_accux_gca`: returns the six components.
+
+    Takes the twelve endpoint components directly and returns the candidate
+    components as scalars, so hot loops pay no heap allocation per edge. The
+    array form allocates two ``(3,)`` arrays per call; in the face-bounds path
+    that is two of the four allocations ``gca_gca_intersection`` used to make
+    for every edge of every face.
+
+    Arithmetic is identical to :func:`_accux_gca`, operation for operation, so
+    results are bit-for-bit the same.
+    """
+    n1x_hi, n1y_hi, n1z_hi, n1x_lo, n1y_lo, n1z_lo = accucross(
+        w00, w01, w02, w10, w11, w12
+    )
+    n2x_hi, n2y_hi, n2z_hi, n2x_lo, n2y_lo, n2z_lo = accucross(
+        v00, v01, v02, v10, v11, v12
+    )
+    vx_hi, vy_hi, vz_hi, vx_lo, vy_lo, vz_lo = accucross_pair(
+        n1x_hi,
+        n1y_hi,
+        n1z_hi,
+        n1x_lo,
+        n1y_lo,
+        n1z_lo,
+        n2x_hi,
+        n2y_hi,
+        n2z_hi,
+        n2x_lo,
+        n2y_lo,
+        n2z_lo,
+    )
+    vx = vx_hi + vx_lo
+    vy = vy_hi + vy_lo
+    vz = vz_hi + vz_lo
+    sum_hi, sum_lo = _sum_of_squares_c((vx_hi, vy_hi, vz_hi), (vx_lo, vy_lo, vz_lo))
+    vn, _ = acc_sqrt_re(sum_hi, sum_lo)
+    # vn==0 (coplanar arcs) yields inf via IEEE division under error_model="numpy",
+    # so the candidates become non-finite and the status layer masks them out.
+    inv = 1.0 / vn
+    pos_x = vx * inv
+    pos_y = vy * inv
+    pos_z = vz * inv
+    return pos_x, pos_y, pos_z, -pos_x, -pos_y, -pos_z
+
+
 @njit(cache=True, error_model="numpy")
 def _try_gca_gca_intersection(w0, w1, v0, v1):
     """Select the valid great-circle intersection and report a status code.
@@ -361,6 +410,55 @@ def _try_gca_gca_intersection(w0, w1, v0, v1):
     return point, status, pos, neg
 
 
+@njit(cache=True, inline="always", error_model="numpy")
+def _try_gca_gca_intersection_scalar(
+    w00, w01, w02, w10, w11, w12, v00, v01, v02, v10, v11, v12
+):
+    """Scalar-argument form of :func:`_try_gca_gca_intersection`.
+
+    Same mask arithmetic and the same status codes, but allocation-free: no
+    ``(3,)`` candidate arrays and no ``point`` array. Returns the selected point
+    components, the status code, and both candidates as scalars.
+
+    Note the selected point is still formed by multiply-add masking, exactly as
+    in the array form. That is safe *only because* the caller branches on
+    ``status``: when both candidates are non-finite the masks are zero,
+    ``0.0 * nan`` makes the selected point ``nan``, and ``status == 2`` routes
+    the caller away from it. Do not replace the caller's status branch with mask
+    arithmetic -- a zero mask propagates a non-finite discarded operand rather
+    than discarding it.
+    """
+    px, py, pz, ngx, ngy, ngz = _accux_gca_scalar(
+        w00, w01, w02, w10, w11, w12, v00, v01, v02, v10, v11, v12
+    )
+
+    pos_fin = (
+        int(math.isfinite(px)) * int(math.isfinite(py)) * int(math.isfinite(pz))
+    )
+    neg_fin = (
+        int(math.isfinite(ngx)) * int(math.isfinite(ngy)) * int(math.isfinite(ngz))
+    )
+    pos_on_a = pos_fin * _on_minor_arc_xyz(px, py, pz, w00, w01, w02, w10, w11, w12)
+    pos_on_b = pos_fin * _on_minor_arc_xyz(px, py, pz, v00, v01, v02, v10, v11, v12)
+    neg_on_a = neg_fin * _on_minor_arc_xyz(ngx, ngy, ngz, w00, w01, w02, w10, w11, w12)
+    neg_on_b = neg_fin * _on_minor_arc_xyz(ngx, ngy, ngz, v00, v01, v02, v10, v11, v12)
+
+    pos_valid = pos_fin * pos_on_a * pos_on_b
+    neg_valid = neg_fin * neg_on_a * neg_on_b
+
+    pos_mask = pos_valid * (1 - neg_valid)
+    neg_mask = neg_valid * (1 - pos_valid)
+
+    point_x = pos_mask * px + neg_mask * ngx
+    point_y = pos_mask * py + neg_mask * ngy
+    point_z = pos_mask * pz + neg_mask * ngz
+
+    both = pos_valid * neg_valid
+    none = (1 - pos_valid) * (1 - neg_valid)
+    status = both + none * 2
+    return point_x, point_y, point_z, status, px, py, pz, ngx, ngy, ngz
+
+
 @njit(cache=True, error_model="numpy")
 def gca_gca_intersection(gca_a_xyz, gca_b_xyz):
     """Return the intersection points of two great-circle arcs.
@@ -396,40 +494,71 @@ def gca_gca_intersection(gca_a_xyz, gca_b_xyz):
     if gca_a_xyz.shape[1] != 3 or gca_b_xyz.shape[1] != 3:
         raise DimensionError("The two GCAs must be in the cartesian [x, y, z] format")
 
-    w0 = gca_a_xyz[0]
-    w1 = gca_a_xyz[1]
-    v0 = gca_b_xyz[0]
-    v1 = gca_b_xyz[1]
+    # Unpack to scalars and run the allocation-free scalar chain. The array
+    # forms (_accux_gca, _try_gca_gca_intersection) allocated four (3,)/(2,3)
+    # arrays per call -- pos, neg, point, res -- which dominated this function
+    # in the face-bounds path, where it runs once per edge of every face. Only
+    # the (2, 3) result array remains, because the public return type is an
+    # array. The arithmetic is unchanged, so results are bit-for-bit identical.
+    w00 = gca_a_xyz[0, 0]
+    w01 = gca_a_xyz[0, 1]
+    w02 = gca_a_xyz[0, 2]
+    w10 = gca_a_xyz[1, 0]
+    w11 = gca_a_xyz[1, 1]
+    w12 = gca_a_xyz[1, 2]
+    v00 = gca_b_xyz[0, 0]
+    v01 = gca_b_xyz[0, 1]
+    v02 = gca_b_xyz[0, 2]
+    v10 = gca_b_xyz[1, 0]
+    v11 = gca_b_xyz[1, 1]
+    v12 = gca_b_xyz[1, 2]
 
-    point, status, pos, neg = _try_gca_gca_intersection(w0, w1, v0, v1)
+    (
+        point_x,
+        point_y,
+        point_z,
+        status,
+        pos_x,
+        pos_y,
+        pos_z,
+        neg_x,
+        neg_y,
+        neg_z,
+    ) = _try_gca_gca_intersection_scalar(
+        w00, w01, w02, w10, w11, w12, v00, v01, v02, v10, v11, v12
+    )
 
     res = np.empty((2, 3))
     count = 0
+    # The branch on ``status`` is load-bearing, not stylistic: when no candidate
+    # is valid both are non-finite, and the masked ``point_*`` above is nan. A
+    # mask-arithmetic rewrite of this dispatch would propagate that nan into the
+    # coplanar result (0.0 * nan == nan) instead of discarding it.
     if status == 0:
-        res[0, 0] = point[0]
-        res[0, 1] = point[1]
-        res[0, 2] = point[2]
+        res[0, 0] = point_x
+        res[0, 1] = point_y
+        res[0, 2] = point_z
         count = 1
     elif status == 1:
-        res[0, 0] = pos[0]
-        res[0, 1] = pos[1]
-        res[0, 2] = pos[2]
-        res[1, 0] = neg[0]
-        res[1, 1] = neg[1]
-        res[1, 2] = neg[2]
+        res[0, 0] = pos_x
+        res[0, 1] = pos_y
+        res[0, 2] = pos_z
+        res[1, 0] = neg_x
+        res[1, 1] = neg_y
+        res[1, 2] = neg_z
         count = 2
     else:
         # status == 2: no candidate on both arcs.
         # Check for coplanar overlap (shared endpoints) outside the kernel.
-        if on_minor_arc(v0, w0, w1):
-            res[count, 0] = v0[0]
-            res[count, 1] = v0[1]
-            res[count, 2] = v0[2]
+        if _on_minor_arc_xyz(v00, v01, v02, w00, w01, w02, w10, w11, w12):
+            res[count, 0] = v00
+            res[count, 1] = v01
+            res[count, 2] = v02
             count += 1
-        if on_minor_arc(v1, w0, w1):
-            res[count, 0] = v1[0]
-            res[count, 1] = v1[1]
-            res[count, 2] = v1[2]
+        if _on_minor_arc_xyz(v10, v11, v12, w00, w01, w02, w10, w11, w12):
+            res[count, 0] = v10
+            res[count, 1] = v11
+            res[count, 2] = v12
             count += 1
     return res[:count]
 

--- a/uxarray/grid/intersections.py
+++ b/uxarray/grid/intersections.py
@@ -319,14 +319,24 @@ def _accux_gca_scalar(
 ):
     """Scalar-argument form of :func:`_accux_gca`: returns the six components.
 
-    Takes the twelve endpoint components directly and returns the candidate
-    components as scalars, so hot loops pay no heap allocation per edge. The
-    array form allocates two ``(3,)`` arrays per call; in the face-bounds path
-    that is two of the four allocations ``gca_gca_intersection`` used to make
-    for every edge of every face.
+    Compute the candidate intersection points of two great-circle arcs.
 
-    Arithmetic is identical to :func:`_accux_gca`, operation for operation, so
-    results are bit-for-bit the same.
+    Pure numerical kernel (mirrors AccuSphGeom ``accux_gca``).
+
+    Computes the two antipodal candidate intersection points of the great-circle
+    arcs w0-w1 and v0-v1.  No branching, no validity filtering.
+
+    Parameters
+    ----------
+    w00, w01, w02, w10, w11, w12 : float
+        Cartesian endpoints of the first arc.
+    v00, v01, v02, v10, v11, v12 : float
+        Cartesian endpoints of the second arc.
+
+    Returns
+    -------
+    pos_x, pos_y, pos_z, neg_x, neg_y, neg_z : float
+        Two antipodal candidate unit vectors.
     """
     n1x_hi, n1y_hi, n1z_hi, n1x_lo, n1y_lo, n1z_lo = accucross(
         w00, w01, w02, w10, w11, w12
@@ -416,27 +426,31 @@ def _try_gca_gca_intersection_scalar(
 ):
     """Scalar-argument form of :func:`_try_gca_gca_intersection`.
 
-    Same mask arithmetic and the same status codes, but allocation-free: no
-    ``(3,)`` candidate arrays and no ``point`` array. Returns the selected point
-    components, the status code, and both candidates as scalars.
+    Select the valid great-circle intersection and report a status code.
 
-    Note the selected point is still formed by multiply-add masking, exactly as
-    in the array form. That is safe *only because* the caller branches on
-    ``status``: when both candidates are non-finite the masks are zero,
-    ``0.0 * nan`` makes the selected point ``nan``, and ``status == 2`` routes
-    the caller away from it. Do not replace the caller's status branch with mask
-    arithmetic -- a zero mask propagates a non-finite discarded operand rather
-    than discarding it.
+    Batch/status layer (mirrors AccuSphGeom ``try_gca_gca_intersection``).
+
+    Calls the pure numerical kernel, applies integer mask arithmetic to determine
+    validity, selects the output point without if/else branching in the hot path.
+
+    Status codes mirror AccuSphGeom:
+        0  exactly one candidate is valid
+        1  both candidates are valid
+        2  neither candidate is valid  (includes coplanar/parallel case)
     """
     px, py, pz, ngx, ngy, ngz = _accux_gca_scalar(
         w00, w01, w02, w10, w11, w12, v00, v01, v02, v10, v11, v12
     )
 
     pos_fin = (
-        int(math.isfinite(px)) * int(math.isfinite(py)) * int(math.isfinite(pz))
+        int(math.isfinite(px))
+        * int(math.isfinite(py))
+        * int(math.isfinite(pz))
     )
     neg_fin = (
-        int(math.isfinite(ngx)) * int(math.isfinite(ngy)) * int(math.isfinite(ngz))
+        int(math.isfinite(ngx))
+        * int(math.isfinite(ngy))
+        * int(math.isfinite(ngz))
     )
     pos_on_a = pos_fin * _on_minor_arc_xyz(px, py, pz, w00, w01, w02, w10, w11, w12)
     pos_on_b = pos_fin * _on_minor_arc_xyz(px, py, pz, v00, v01, v02, v10, v11, v12)

--- a/uxarray/grid/intersections.py
+++ b/uxarray/grid/intersections.py
@@ -252,68 +252,6 @@ def faces_within_lat_bounds(lats, face_bounds_lat):
 
 
 @njit(cache=True, inline="always", error_model="numpy")
-def _accux_gca(w0, w1, v0, v1):
-    """Compute the candidate intersection points of two great-circle arcs.
-
-    Pure numerical kernel (mirrors AccuSphGeom ``accux_gca``).
-
-    Computes the two antipodal candidate intersection points of the great-circle
-    arcs w0-w1 and v0-v1.  No branching, no validity filtering.
-
-    Parameters
-    ----------
-    w0, w1 : np.ndarray, shape (3,)
-        Cartesian endpoints of the first arc.
-    v0, v1 : np.ndarray, shape (3,)
-        Cartesian endpoints of the second arc.
-
-    Returns
-    -------
-    pos, neg : np.ndarray, shape (3,)
-        Two antipodal candidate unit vectors.
-    """
-    n1x_hi, n1y_hi, n1z_hi, n1x_lo, n1y_lo, n1z_lo = accucross(
-        w0[0], w0[1], w0[2], w1[0], w1[1], w1[2]
-    )
-    n2x_hi, n2y_hi, n2z_hi, n2x_lo, n2y_lo, n2z_lo = accucross(
-        v0[0], v0[1], v0[2], v1[0], v1[1], v1[2]
-    )
-    vx_hi, vy_hi, vz_hi, vx_lo, vy_lo, vz_lo = accucross_pair(
-        n1x_hi,
-        n1y_hi,
-        n1z_hi,
-        n1x_lo,
-        n1y_lo,
-        n1z_lo,
-        n2x_hi,
-        n2y_hi,
-        n2z_hi,
-        n2x_lo,
-        n2y_lo,
-        n2z_lo,
-    )
-    vx = vx_hi + vx_lo
-    vy = vy_hi + vy_lo
-    vz = vz_hi + vz_lo
-    # Compensated norm: sum_of_squares_c over the (hi, lo) vector, then acc_sqrt_re
-    # folding the low part into the root, matching AccuSphGeom accux_gca. n = root.hi.
-    sum_hi, sum_lo = _sum_of_squares_c((vx_hi, vy_hi, vz_hi), (vx_lo, vy_lo, vz_lo))
-    vn, _ = acc_sqrt_re(sum_hi, sum_lo)
-    # vn==0 (coplanar arcs) yields inf via IEEE division under error_model="numpy",
-    # so pos/neg become non-finite and the status layer masks them out. Branch-free.
-    inv = 1.0 / vn
-    pos = np.empty(3)
-    pos[0] = vx * inv
-    pos[1] = vy * inv
-    pos[2] = vz * inv
-    neg = np.empty(3)
-    neg[0] = -pos[0]
-    neg[1] = -pos[1]
-    neg[2] = -pos[2]
-    return pos, neg
-
-
-@njit(cache=True, inline="always", error_model="numpy")
 def _accux_gca_scalar(w00, w01, w02, w10, w11, w12, v00, v01, v02, v10, v11, v12):
     """Scalar-argument form of :func:`_accux_gca`: returns the six components.
 
@@ -359,6 +297,8 @@ def _accux_gca_scalar(w00, w01, w02, w10, w11, w12, v00, v01, v02, v10, v11, v12
     vx = vx_hi + vx_lo
     vy = vy_hi + vy_lo
     vz = vz_hi + vz_lo
+    # Compensated norm: sum_of_squares_c over the (hi, lo) vector, then acc_sqrt_re
+    # folding the low part into the root, matching AccuSphGeom accux_gca. n = root.hi.
     sum_hi, sum_lo = _sum_of_squares_c((vx_hi, vy_hi, vz_hi), (vx_lo, vy_lo, vz_lo))
     vn, _ = acc_sqrt_re(sum_hi, sum_lo)
     # vn==0 (coplanar arcs) yields inf via IEEE division under error_model="numpy",
@@ -370,52 +310,50 @@ def _accux_gca_scalar(w00, w01, w02, w10, w11, w12, v00, v01, v02, v10, v11, v12
     return pos_x, pos_y, pos_z, -pos_x, -pos_y, -pos_z
 
 
-@njit(cache=True, error_model="numpy")
-def _try_gca_gca_intersection(w0, w1, v0, v1):
-    """Select the valid great-circle intersection and report a status code.
+@njit(cache=True, inline="always", error_model="numpy")
+def _accux_gca(w0, w1, v0, v1):
+    """Compute the candidate intersection points of two great-circle arcs.
 
-    Batch/status layer (mirrors AccuSphGeom ``try_gca_gca_intersection``).
+    Pure numerical kernel (mirrors AccuSphGeom ``accux_gca``).
 
-    Calls the pure numerical kernel, applies integer mask arithmetic to determine
-    validity, selects the output point without if/else branching in the hot path.
+    Computes the two antipodal candidate intersection points of the great-circle
+    arcs w0-w1 and v0-v1.  No branching, no validity filtering.
 
-    Status codes mirror AccuSphGeom:
-        0  exactly one candidate is valid
-        1  both candidates are valid
-        2  neither candidate is valid  (includes coplanar/parallel case)
+    Parameters
+    ----------
+    w0, w1 : np.ndarray, shape (3,)
+        Cartesian endpoints of the first arc.
+    v0, v1 : np.ndarray, shape (3,)
+        Cartesian endpoints of the second arc.
+
+    Returns
+    -------
+    pos, neg : np.ndarray, shape (3,)
+        Two antipodal candidate unit vectors.
     """
-    pos, neg = _accux_gca(w0, w1, v0, v1)
-
-    pos_fin = (
-        int(math.isfinite(pos[0]))
-        * int(math.isfinite(pos[1]))
-        * int(math.isfinite(pos[2]))
+    pos_x, pos_y, pos_z, neg_x, neg_y, neg_z = _accux_gca_scalar(
+        w0[0],
+        w0[1],
+        w0[2],
+        w1[0],
+        w1[1],
+        w1[2],
+        v0[0],
+        v0[1],
+        v0[2],
+        v1[0],
+        v1[1],
+        v1[2],
     )
-    neg_fin = (
-        int(math.isfinite(neg[0]))
-        * int(math.isfinite(neg[1]))
-        * int(math.isfinite(neg[2]))
-    )
-    pos_on_a = pos_fin * on_minor_arc(pos, w0, w1)
-    pos_on_b = pos_fin * on_minor_arc(pos, v0, v1)
-    neg_on_a = neg_fin * on_minor_arc(neg, w0, w1)
-    neg_on_b = neg_fin * on_minor_arc(neg, v0, v1)
-
-    pos_valid = pos_fin * pos_on_a * pos_on_b
-    neg_valid = neg_fin * neg_on_a * neg_on_b
-
-    pos_mask = pos_valid * (1 - neg_valid)
-    neg_mask = neg_valid * (1 - pos_valid)
-
-    point = np.empty(3)
-    point[0] = pos_mask * pos[0] + neg_mask * neg[0]
-    point[1] = pos_mask * pos[1] + neg_mask * neg[1]
-    point[2] = pos_mask * pos[2] + neg_mask * neg[2]
-
-    both = pos_valid * neg_valid
-    none = (1 - pos_valid) * (1 - neg_valid)
-    status = both + none * 2
-    return point, status, pos, neg
+    pos = np.empty(3)
+    pos[0] = pos_x
+    pos[1] = pos_y
+    pos[2] = pos_z
+    neg = np.empty(3)
+    neg[0] = neg_x
+    neg[1] = neg_y
+    neg[2] = neg_z
+    return pos, neg
 
 
 @njit(cache=True, inline="always", error_model="numpy")
@@ -466,6 +404,61 @@ def _try_gca_gca_intersection_scalar(
 
 
 @njit(cache=True, error_model="numpy")
+def _try_gca_gca_intersection(w0, w1, v0, v1):
+    """Select the valid great-circle intersection and report a status code.
+
+    Batch/status layer (mirrors AccuSphGeom ``try_gca_gca_intersection``).
+
+    Calls the pure numerical kernel, applies integer mask arithmetic to determine
+    validity, selects the output point without if/else branching in the hot path.
+
+    Status codes mirror AccuSphGeom:
+        0  exactly one candidate is valid
+        1  both candidates are valid
+        2  neither candidate is valid  (includes coplanar/parallel case)
+    """
+    (
+        point_x,
+        point_y,
+        point_z,
+        status,
+        pos_x,
+        pos_y,
+        pos_z,
+        neg_x,
+        neg_y,
+        neg_z,
+    ) = _try_gca_gca_intersection_scalar(
+        w0[0],
+        w0[1],
+        w0[2],
+        w1[0],
+        w1[1],
+        w1[2],
+        v0[0],
+        v0[1],
+        v0[2],
+        v1[0],
+        v1[1],
+        v1[2],
+    )
+
+    point = np.empty(3)
+    point[0] = point_x
+    point[1] = point_y
+    point[2] = point_z
+    pos = np.empty(3)
+    pos[0] = pos_x
+    pos[1] = pos_y
+    pos[2] = pos_z
+    neg = np.empty(3)
+    neg[0] = neg_x
+    neg[1] = neg_y
+    neg[2] = neg_z
+    return point, status, pos, neg
+
+
+@njit(cache=True, error_model="numpy")
 def gca_gca_intersection(gca_a_xyz, gca_b_xyz):
     """Return the intersection points of two great-circle arcs.
 
@@ -500,12 +493,7 @@ def gca_gca_intersection(gca_a_xyz, gca_b_xyz):
     if gca_a_xyz.shape[1] != 3 or gca_b_xyz.shape[1] != 3:
         raise DimensionError("The two GCAs must be in the cartesian [x, y, z] format")
 
-    # Unpack to scalars and run the allocation-free scalar chain. The array
-    # forms (_accux_gca, _try_gca_gca_intersection) allocated four (3,)/(2,3)
-    # arrays per call -- pos, neg, point, res -- which dominated this function
-    # in the face-bounds path, where it runs once per edge of every face. Only
-    # the (2, 3) result array remains, because the public return type is an
-    # array. The arithmetic is unchanged, so results are bit-for-bit identical.
+    # Unpack to scalars and run the allocation-free scalar chain.
     w00 = gca_a_xyz[0, 0]
     w01 = gca_a_xyz[0, 1]
     w02 = gca_a_xyz[0, 2]
@@ -536,10 +524,6 @@ def gca_gca_intersection(gca_a_xyz, gca_b_xyz):
 
     res = np.empty((2, 3))
     count = 0
-    # The branch on ``status`` is load-bearing, not stylistic: when no candidate
-    # is valid both are non-finite, and the masked ``point_*`` above is nan. A
-    # mask-arithmetic rewrite of this dispatch would propagate that nan into the
-    # coplanar result (0.0 * nan == nan) instead of discarding it.
     if status == 0:
         res[0, 0] = point_x
         res[0, 1] = point_y

--- a/uxarray/grid/intersections.py
+++ b/uxarray/grid/intersections.py
@@ -314,9 +314,7 @@ def _accux_gca(w0, w1, v0, v1):
 
 
 @njit(cache=True, inline="always", error_model="numpy")
-def _accux_gca_scalar(
-    w00, w01, w02, w10, w11, w12, v00, v01, v02, v10, v11, v12
-):
+def _accux_gca_scalar(w00, w01, w02, w10, w11, w12, v00, v01, v02, v10, v11, v12):
     """Scalar-argument form of :func:`_accux_gca`: returns the six components.
 
     Compute the candidate intersection points of two great-circle arcs.
@@ -442,15 +440,9 @@ def _try_gca_gca_intersection_scalar(
         w00, w01, w02, w10, w11, w12, v00, v01, v02, v10, v11, v12
     )
 
-    pos_fin = (
-        int(math.isfinite(px))
-        * int(math.isfinite(py))
-        * int(math.isfinite(pz))
-    )
+    pos_fin = int(math.isfinite(px)) * int(math.isfinite(py)) * int(math.isfinite(pz))
     neg_fin = (
-        int(math.isfinite(ngx))
-        * int(math.isfinite(ngy))
-        * int(math.isfinite(ngz))
+        int(math.isfinite(ngx)) * int(math.isfinite(ngy)) * int(math.isfinite(ngz))
     )
     pos_on_a = pos_fin * _on_minor_arc_xyz(px, py, pz, w00, w01, w02, w10, w11, w12)
     pos_on_b = pos_fin * _on_minor_arc_xyz(px, py, pz, v00, v01, v02, v10, v11, v12)

--- a/uxarray/grid/intersections.py
+++ b/uxarray/grid/intersections.py
@@ -252,10 +252,8 @@ def faces_within_lat_bounds(lats, face_bounds_lat):
 
 
 @njit(cache=True, inline="always", error_model="numpy")
-def _accux_gca_scalar(w00, w01, w02, w10, w11, w12, v00, v01, v02, v10, v11, v12):
-    """Scalar-argument form of :func:`_accux_gca`: returns the six components.
-
-    Compute the candidate intersection points of two great-circle arcs.
+def _accux_gca(w00, w01, w02, w10, w11, w12, v00, v01, v02, v10, v11, v12):
+    """Compute the candidate intersection points of two great-circle arcs.
 
     Pure numerical kernel (mirrors AccuSphGeom ``accux_gca``).
 
@@ -311,58 +309,10 @@ def _accux_gca_scalar(w00, w01, w02, w10, w11, w12, v00, v01, v02, v10, v11, v12
 
 
 @njit(cache=True, inline="always", error_model="numpy")
-def _accux_gca(w0, w1, v0, v1):
-    """Compute the candidate intersection points of two great-circle arcs.
-
-    Pure numerical kernel (mirrors AccuSphGeom ``accux_gca``).
-
-    Computes the two antipodal candidate intersection points of the great-circle
-    arcs w0-w1 and v0-v1.  No branching, no validity filtering.
-
-    Parameters
-    ----------
-    w0, w1 : np.ndarray, shape (3,)
-        Cartesian endpoints of the first arc.
-    v0, v1 : np.ndarray, shape (3,)
-        Cartesian endpoints of the second arc.
-
-    Returns
-    -------
-    pos, neg : np.ndarray, shape (3,)
-        Two antipodal candidate unit vectors.
-    """
-    pos_x, pos_y, pos_z, neg_x, neg_y, neg_z = _accux_gca_scalar(
-        w0[0],
-        w0[1],
-        w0[2],
-        w1[0],
-        w1[1],
-        w1[2],
-        v0[0],
-        v0[1],
-        v0[2],
-        v1[0],
-        v1[1],
-        v1[2],
-    )
-    pos = np.empty(3)
-    pos[0] = pos_x
-    pos[1] = pos_y
-    pos[2] = pos_z
-    neg = np.empty(3)
-    neg[0] = neg_x
-    neg[1] = neg_y
-    neg[2] = neg_z
-    return pos, neg
-
-
-@njit(cache=True, inline="always", error_model="numpy")
-def _try_gca_gca_intersection_scalar(
+def _try_gca_gca_intersection(
     w00, w01, w02, w10, w11, w12, v00, v01, v02, v10, v11, v12
 ):
-    """Scalar-argument form of :func:`_try_gca_gca_intersection`.
-
-    Select the valid great-circle intersection and report a status code.
+    """Select the valid great-circle intersection and report a status code.
 
     Batch/status layer (mirrors AccuSphGeom ``try_gca_gca_intersection``).
 
@@ -374,7 +324,7 @@ def _try_gca_gca_intersection_scalar(
         1  both candidates are valid
         2  neither candidate is valid  (includes coplanar/parallel case)
     """
-    px, py, pz, ngx, ngy, ngz = _accux_gca_scalar(
+    px, py, pz, ngx, ngy, ngz = _accux_gca(
         w00, w01, w02, w10, w11, w12, v00, v01, v02, v10, v11, v12
     )
 
@@ -401,61 +351,6 @@ def _try_gca_gca_intersection_scalar(
     none = (1 - pos_valid) * (1 - neg_valid)
     status = both + none * 2
     return point_x, point_y, point_z, status, px, py, pz, ngx, ngy, ngz
-
-
-@njit(cache=True, error_model="numpy")
-def _try_gca_gca_intersection(w0, w1, v0, v1):
-    """Select the valid great-circle intersection and report a status code.
-
-    Batch/status layer (mirrors AccuSphGeom ``try_gca_gca_intersection``).
-
-    Calls the pure numerical kernel, applies integer mask arithmetic to determine
-    validity, selects the output point without if/else branching in the hot path.
-
-    Status codes mirror AccuSphGeom:
-        0  exactly one candidate is valid
-        1  both candidates are valid
-        2  neither candidate is valid  (includes coplanar/parallel case)
-    """
-    (
-        point_x,
-        point_y,
-        point_z,
-        status,
-        pos_x,
-        pos_y,
-        pos_z,
-        neg_x,
-        neg_y,
-        neg_z,
-    ) = _try_gca_gca_intersection_scalar(
-        w0[0],
-        w0[1],
-        w0[2],
-        w1[0],
-        w1[1],
-        w1[2],
-        v0[0],
-        v0[1],
-        v0[2],
-        v1[0],
-        v1[1],
-        v1[2],
-    )
-
-    point = np.empty(3)
-    point[0] = point_x
-    point[1] = point_y
-    point[2] = point_z
-    pos = np.empty(3)
-    pos[0] = pos_x
-    pos[1] = pos_y
-    pos[2] = pos_z
-    neg = np.empty(3)
-    neg[0] = neg_x
-    neg[1] = neg_y
-    neg[2] = neg_z
-    return point, status, pos, neg
 
 
 @njit(cache=True, error_model="numpy")
@@ -518,7 +413,7 @@ def gca_gca_intersection(gca_a_xyz, gca_b_xyz):
         neg_x,
         neg_y,
         neg_z,
-    ) = _try_gca_gca_intersection_scalar(
+    ) = _try_gca_gca_intersection(
         w00, w01, w02, w10, w11, w12, v00, v01, v02, v10, v11, v12
     )
 


### PR DESCRIPTION
<!--  The PR title should summarize the changes, for example "Add `Grid._build_face_dimension` function".
      Avoid non-descriptive titles such as "Addresses issue #229". -->

<!--  Replace XXX with the issue number resolved by this PR, if this PR fully resolves an issue.
      If it does not fully resolve any issues, replace with something like "Related to #XXX",
          or "Fixes part of #YYY but does not fully close it."
      If it resolves multiple issues, repeat "closes" for each, like "Closes #XXX, closes #YYY." -->


Tangent issue to #1623, also related to #1648

## Overview
<!--  Please provide a few bullet points summarizing the changes in this PR. This should include
      points on any bug fixes, new functions, or other changes that have been made. -->

The existing `gca_gca_intersection` uses four `np.ndarray` objects of size 3. The overhead incurred by using these python objects is njit compiled loops is significant, and we get about a 2x speedup in there by scalarizing `gca_gca_intersection`, `_try_gca_gca_intersection`, and `_accux_gca`, and using `_on_minor_arc_xyz` instead of `on_minor_arc`. That precipitates a ~10% speedup overall of `_gca_gca_intersection`.

This PR mainly provides scalarized versions of `_accux_gca_scalar` and `_try_gca_gca_intersection`. The vector versions are preserved, as established with `_accux_constlat`, but I think it's reasonable to delete all the vector versions if they aren't being used otherwise. Benchmarks for scalarized routines are added separately, but we could also delete the vector benchmarks if the vector routines go.

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**General**
- [x] An issue is created and linked
- [x] Added appropriate labels (if your uxarray repo permissions allow it)
- [x] Filled out Overview and Expected Usage (if applicable) sections

**Testing & Benchmarking**
<!--  If this PR does not update any functionality or tests and is unlikely to affect efficiency,
    e.g. by affecting computation time or memory usage, remove this section (Testing & Benchmarking) -->
- [NA] Adequate tests are created if there is new functionality
- [NA] Tests are not too basic (such as simply calling a function and nothing else)
- [NA] Tests cover all major paths in your new functions
- [x] If this PR could affect performance, ran ASV benchmarks and confirmed they show expected behavior (add a new benchmark if necessary)
<!-- Adding the run-benchmark label (if your uxarray repo permissions allow it) will run ASV benchmarks.
    If you need benchmarks to be run but don't have permissions, leave this item unchecked for now. -->

**Documentation**
<!--  If this PR does not update any functionality or docstrings, remove this section (Documentation) -->
- [x] Docstrings have been added to all new functions
- [x] Docstrings have been updated with any function changes
- [x] Internal (private) function names start with an underscore (`_`)


## AI Disclosure
<!-- Please specify all AI tools used. Optionally, include model and/or briefly describe usage. Examples:
    "AI Usage: Claude (Fable 5), Gemini"
    "AI Usage: ChatGPT (5.5 Instant) to help understand cause of this bug, but I wrote all updates myself."
    "AI Usage: just GitHub Copilot's inline code suggestions."
    If you did not use AI, please write "AI Usage: N/A" and remove these checklist items or mark as [N/A].-->

AI Usage: Claude Opus 5 / Sonnet 5

- [x] I take responsibility for all AI-generated content in my PR.
- [x] I have tested all AI-generated content in my PR.

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

**PR Etiquette Reminders**
- This PR should be listed as a draft PR until you are ready for it to be reviewed

- After making changes in accordance with any reviews, re-request reviews from the same reviewers

- Do *not* mark conversations as resolved if you didn't start them

- Do mark conversations as resolved *if you opened them* and are satisfied with the changes/discussion.
-->
