### PR TITLE
Lazy neighborhood filter kernel compilation

### DIFF
--- a/benchmarks/mpas_ocean.py
+++ b/benchmarks/mpas_ocean.py
@@ -107,7 +107,8 @@ class Gradient(DatasetBenchmark):
 
     def track_peakmem_gradient(self, resolution):
         """Transient high-water allocation of taking a gradient."""
-        return peak_allocated(lambda: self.uxds[data_var].gradient())
+        with numba_threads(1):
+            return peak_allocated(lambda: self.uxds[data_var].gradient())
 
     track_peakmem_gradient.unit = "bytes"
 

--- a/test/test_dependencies.py
+++ b/test/test_dependencies.py
@@ -38,4 +38,34 @@ def test_hvplot_optional():
     _assert_not_imported_after_import_uxarray("hvplot")
 
 
+def test_no_numba_kernels_built_on_import():
+    """Test that `import uxarray` does not build any numba kernel.
+
+    ``guvectorize`` compiles at decoration time when it is given explicit
+    signatures, so a kernel assigned at module scope is built during the
+    import. This compilation can dominate the uxarray import, and building a
+    ``target="parallel"`` kernel starts numba's threading layer, which
+    leaves a thread pool running, making forks unsafe.
+    """
+    code = (
+        "import numba, uxarray\n"
+        "try:\n"
+        "    layer = numba.threading_layer()\n"
+        "except ValueError:\n"
+        "    pass\n"
+        "else:\n"
+        "    raise AssertionError(\n"
+        "        f'`import uxarray` started numba threading layer {layer!r}. '\n"
+        "        'Something it imports builds a parallel kernel at module '\n"
+        "        'scope; build it on first use instead.'\n"
+        "    )\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
 # TODO: similar tests for cartopy, holoviews, and other optional deps.

--- a/uxarray/grid/neighbors.py
+++ b/uxarray/grid/neighbors.py
@@ -1512,14 +1512,20 @@ class Neighborhood:
     _sum_kernel = staticmethod(_make_kernel(lambda window, _: np.sum(window)))
     _min_kernel = staticmethod(_make_kernel(lambda window, _: np.min(window)))
     _max_kernel = staticmethod(_make_kernel(lambda window, _: np.max(window)))
-    _ptp_kernel = staticmethod(_make_kernel(lambda window, _: np.max(window) - np.min(window)))
+    _ptp_kernel = staticmethod(
+        _make_kernel(lambda window, _: np.max(window) - np.min(window))
+    )
     _median_kernel = staticmethod(_make_kernel(_median))
     _var_kernel = staticmethod(_make_kernel(_variance))
-    _std_kernel = staticmethod(_make_kernel(lambda window, ddof: np.sqrt(_variance(window, ddof))))
+    _std_kernel = staticmethod(
+        _make_kernel(lambda window, ddof: np.sqrt(_variance(window, ddof)))
+    )
 
     # ``percentile`` is ``quantile`` on a 0-100 scale, so both methods
     # rescale onto this one kernel rather than compiling a near-duplicate.
-    _quantile_kernel = staticmethod(_make_kernel(lambda window, q: np.quantile(window, q)))
+    _quantile_kernel = staticmethod(
+        _make_kernel(lambda window, q: np.quantile(window, q))
+    )
 
     def mean(self, uxda):
         """Mean of each neighborhood."""

--- a/uxarray/grid/neighbors.py
+++ b/uxarray/grid/neighbors.py
@@ -1,4 +1,4 @@
-import threading
+import functools
 import warnings
 from typing import Callable
 
@@ -1247,43 +1247,6 @@ def _make_kernel(reduce_fn):
     return kernel
 
 
-class _LazyKernel:
-    """A kernel that builds itself the first time it is called.
-
-    ``guvectorize`` compiles at decoration time when it is given explicit
-    signatures, so calling :func:`_make_kernel` at module scope would compile
-    every reduction during ``import uxarray``
-    """
-
-    __slots__ = ("_reduce_fn", "_kernel", "_lock")
-
-    def __init__(self, reduce_fn):
-        self._reduce_fn = reduce_fn
-        self._kernel = None
-        self._lock = threading.Lock()
-
-    def __call__(self, *args):
-        kernel = self._kernel
-        if kernel is None:
-            # Checked again under the lock: dask's threaded scheduler can call
-            # one reduction from several workers at once
-            with self._lock:
-                kernel = self._kernel
-                if kernel is None:
-                    kernel = self._kernel = _make_kernel(self._reduce_fn)
-        return kernel(*args)
-
-    def __getstate__(self):
-        # Only the reducer travels. A compiled gufunc is a ``numpy.ufunc``,
-        # which pickle cannot address by name and so refuses outright.
-        return self._reduce_fn
-
-    def __setstate__(self, reduce_fn):
-        self._reduce_fn = reduce_fn
-        self._kernel = None
-        self._lock = threading.Lock()
-
-
 # Reducers take ``(window, param)``; those without a parameter ignore the
 # second argument. Numba keys its cache by code object rather than qualified
 # name, so the identically-named lambdas below do not collide.
@@ -1315,30 +1278,62 @@ def _median(window, _):
     return np.median(window)
 
 
-# One compiled kernel per reduction. The methods on ``Neighborhood`` below name
-# these directly, so there is no dispatch table between the public API and the
-# gufuncs: a reduction is reachable only if a method exists for it, and a method
-# can only reach the kernel it names. ``Neighborhood`` is the only class that
-# names them -- the data-bound classes reach a kernel by naming the
-# ``Neighborhood`` method for it, so there is one place per reduction where its
-# kernel and parameter are chosen.
+# One compiled kernel per reduction. The methods on ``Neighborhood`` below call
+# into these directly. Non-compiled functions are only provided hooks through
+# ``Neighborhood.reduce``. If new compiled reductions are desired, they should
+# follow this pattern.
 #
-# Naming a kernel is what binds a reduction to it; building it is deferred to
-# the first call, for the reasons in :class:`_LazyKernel`. The two are
-# separate on purpose -- each name below still resolves to its own object when
-# this module is read, so a reduction that names no kernel is a ``NameError``
-# here rather than a lookup that fails once someone runs it.
-_MEAN_KERNEL = _LazyKernel(lambda window, _: np.mean(window))
-_SUM_KERNEL = _LazyKernel(lambda window, _: np.sum(window))
-_MIN_KERNEL = _LazyKernel(lambda window, _: np.min(window))
-_MAX_KERNEL = _LazyKernel(lambda window, _: np.max(window))
-_PTP_KERNEL = _LazyKernel(lambda window, _: np.max(window) - np.min(window))
-_MEDIAN_KERNEL = _LazyKernel(_median)
-_VAR_KERNEL = _LazyKernel(_variance)
-_STD_KERNEL = _LazyKernel(lambda window, ddof: np.sqrt(_variance(window, ddof)))
+# ``functools.cache`` defers each build to the first call. The deferred compilation
+# ensures that these kernels will only be compiled individually and lazily. Further,
+# the lazy compilation prevents gufuncs from spawning threadpools eagerly and
+# disrupting threading and forking in other contexts.
+
+
+@functools.cache
+def _mean_kernel():
+    return _make_kernel(lambda window, _: np.mean(window))
+
+
+@functools.cache
+def _sum_kernel():
+    return _make_kernel(lambda window, _: np.sum(window))
+
+
+@functools.cache
+def _min_kernel():
+    return _make_kernel(lambda window, _: np.min(window))
+
+
+@functools.cache
+def _max_kernel():
+    return _make_kernel(lambda window, _: np.max(window))
+
+
+@functools.cache
+def _ptp_kernel():
+    return _make_kernel(lambda window, _: np.max(window) - np.min(window))
+
+
+@functools.cache
+def _median_kernel():
+    return _make_kernel(_median)
+
+
+@functools.cache
+def _var_kernel():
+    return _make_kernel(_variance)
+
+
+@functools.cache
+def _std_kernel():
+    return _make_kernel(lambda window, ddof: np.sqrt(_variance(window, ddof)))
+
+
 # ``percentile`` is ``quantile`` on a 0-100 scale, so both methods rescale onto
 # this one kernel rather than compiling a near-duplicate.
-_QUANTILE_KERNEL = _LazyKernel(lambda window, q: np.quantile(window, q))
+@functools.cache
+def _quantile_kernel():
+    return _make_kernel(lambda window, q: np.quantile(window, q))
 
 
 def _as_quantile(q, scale: float):
@@ -1553,45 +1548,45 @@ class Neighborhood:
 
     def mean(self, uxda):
         """Mean of each neighborhood."""
-        return self._apply_kernel(uxda, _MEAN_KERNEL, 0.0)
+        return self._apply_kernel(uxda, _mean_kernel, 0.0)
 
     def sum(self, uxda):
         """Sum of each neighborhood."""
-        return self._apply_kernel(uxda, _SUM_KERNEL, 0.0)
+        return self._apply_kernel(uxda, _sum_kernel, 0.0)
 
     def min(self, uxda):
         """Smallest value in each neighborhood."""
-        return self._apply_kernel(uxda, _MIN_KERNEL, 0.0)
+        return self._apply_kernel(uxda, _min_kernel, 0.0)
 
     def max(self, uxda):
         """Largest value in each neighborhood."""
-        return self._apply_kernel(uxda, _MAX_KERNEL, 0.0)
+        return self._apply_kernel(uxda, _max_kernel, 0.0)
 
     def ptp(self, uxda):
         """Peak-to-peak spread (``max - min``) of each neighborhood."""
-        return self._apply_kernel(uxda, _PTP_KERNEL, 0.0)
+        return self._apply_kernel(uxda, _ptp_kernel, 0.0)
 
     def median(self, uxda):
         """Median of each neighborhood."""
-        return self._apply_kernel(uxda, _MEDIAN_KERNEL, 0.0)
+        return self._apply_kernel(uxda, _median_kernel, 0.0)
 
     def var(self, uxda, ddof: int = 0):
         """Variance of each neighborhood, with ``ddof`` delta degrees of
         freedom."""
-        return self._apply_kernel(uxda, _VAR_KERNEL, float(ddof))
+        return self._apply_kernel(uxda, _var_kernel, float(ddof))
 
     def std(self, uxda, ddof: int = 0):
         """Standard deviation of each neighborhood, with ``ddof`` delta degrees
         of freedom."""
-        return self._apply_kernel(uxda, _STD_KERNEL, float(ddof))
+        return self._apply_kernel(uxda, _std_kernel, float(ddof))
 
     def quantile(self, uxda, q: float):
         """Quantile ``q`` (between 0 and 1) of each neighborhood."""
-        return self._apply_kernel(uxda, _QUANTILE_KERNEL, _as_quantile(q, 1.0))
+        return self._apply_kernel(uxda, _quantile_kernel, _as_quantile(q, 1.0))
 
     def percentile(self, uxda, q: float):
         """Percentile ``q`` (between 0 and 100) of each neighborhood."""
-        return self._apply_kernel(uxda, _QUANTILE_KERNEL, _as_quantile(q, 100.0))
+        return self._apply_kernel(uxda, _quantile_kernel, _as_quantile(q, 100.0))
 
     def reduce(self, uxda, func: Callable):
         """Reduces each neighborhood with an arbitrary callable.
@@ -1636,7 +1631,7 @@ class Neighborhood:
             # path does too by writing into a float64 output.
             if block.dtype not in (np.float64, np.float32):
                 block = block.astype(np.float64)
-            return kernel(block, *arrays, param)
+            return kernel()(block, *arrays, param)
 
         return self._apply(uxda, run)
 

--- a/uxarray/grid/neighbors.py
+++ b/uxarray/grid/neighbors.py
@@ -1,3 +1,4 @@
+import threading
 import warnings
 from typing import Callable
 
@@ -1246,6 +1247,43 @@ def _make_kernel(reduce_fn):
     return kernel
 
 
+class _LazyKernel:
+    """A kernel that builds itself the first time it is called.
+
+    ``guvectorize`` compiles at decoration time when it is given explicit
+    signatures, so calling :func:`_make_kernel` at module scope would compile
+    every reduction during ``import uxarray``
+    """
+
+    __slots__ = ("_reduce_fn", "_kernel", "_lock")
+
+    def __init__(self, reduce_fn):
+        self._reduce_fn = reduce_fn
+        self._kernel = None
+        self._lock = threading.Lock()
+
+    def __call__(self, *args):
+        kernel = self._kernel
+        if kernel is None:
+            # Checked again under the lock: dask's threaded scheduler can call
+            # one reduction from several workers at once
+            with self._lock:
+                kernel = self._kernel
+                if kernel is None:
+                    kernel = self._kernel = _make_kernel(self._reduce_fn)
+        return kernel(*args)
+
+    def __getstate__(self):
+        # Only the reducer travels. A compiled gufunc is a ``numpy.ufunc``,
+        # which pickle cannot address by name and so refuses outright.
+        return self._reduce_fn
+
+    def __setstate__(self, reduce_fn):
+        self._reduce_fn = reduce_fn
+        self._kernel = None
+        self._lock = threading.Lock()
+
+
 # Reducers take ``(window, param)``; those without a parameter ignore the
 # second argument. Numba keys its cache by code object rather than qualified
 # name, so the identically-named lambdas below do not collide.
@@ -1284,17 +1322,23 @@ def _median(window, _):
 # names them -- the data-bound classes reach a kernel by naming the
 # ``Neighborhood`` method for it, so there is one place per reduction where its
 # kernel and parameter are chosen.
-_MEAN_KERNEL = _make_kernel(lambda window, _: np.mean(window))
-_SUM_KERNEL = _make_kernel(lambda window, _: np.sum(window))
-_MIN_KERNEL = _make_kernel(lambda window, _: np.min(window))
-_MAX_KERNEL = _make_kernel(lambda window, _: np.max(window))
-_PTP_KERNEL = _make_kernel(lambda window, _: np.max(window) - np.min(window))
-_MEDIAN_KERNEL = _make_kernel(_median)
-_VAR_KERNEL = _make_kernel(_variance)
-_STD_KERNEL = _make_kernel(lambda window, ddof: np.sqrt(_variance(window, ddof)))
+#
+# Naming a kernel is what binds a reduction to it; building it is deferred to
+# the first call, for the reasons in :class:`_LazyKernel`. The two are
+# separate on purpose -- each name below still resolves to its own object when
+# this module is read, so a reduction that names no kernel is a ``NameError``
+# here rather than a lookup that fails once someone runs it.
+_MEAN_KERNEL = _LazyKernel(lambda window, _: np.mean(window))
+_SUM_KERNEL = _LazyKernel(lambda window, _: np.sum(window))
+_MIN_KERNEL = _LazyKernel(lambda window, _: np.min(window))
+_MAX_KERNEL = _LazyKernel(lambda window, _: np.max(window))
+_PTP_KERNEL = _LazyKernel(lambda window, _: np.max(window) - np.min(window))
+_MEDIAN_KERNEL = _LazyKernel(_median)
+_VAR_KERNEL = _LazyKernel(_variance)
+_STD_KERNEL = _LazyKernel(lambda window, ddof: np.sqrt(_variance(window, ddof)))
 # ``percentile`` is ``quantile`` on a 0-100 scale, so both methods rescale onto
 # this one kernel rather than compiling a near-duplicate.
-_QUANTILE_KERNEL = _make_kernel(lambda window, q: np.quantile(window, q))
+_QUANTILE_KERNEL = _LazyKernel(lambda window, q: np.quantile(window, q))
 
 
 def _as_quantile(q, scale: float):

--- a/uxarray/grid/neighbors.py
+++ b/uxarray/grid/neighbors.py
@@ -1215,8 +1215,8 @@ _GUFUNC_KWARGS = {"nopython": True, "cache": True, "target": "parallel"}
 
 
 def _make_kernel(reduce_fn):
-    """Builds a kernel that gathers each neighborhood, then calls
-    ``reduce_fn(window, param)`` on the 1-D result.
+    """Returns a kernel, compiled on its first call, that gathers each
+    neighborhood, then calls ``reduce_fn(window, param)`` on the 1-D result.
 
     ``reduce_fn`` must be numba-compilable, and must be defined in a real
     source file for ``cache=True`` to find it.
@@ -1226,23 +1226,30 @@ def _make_kernel(reduce_fn):
     if not hasattr(reduce_fn, "py_func"):
         reduce_fn = njit(cache=True)(reduce_fn)
 
-    @guvectorize(_GUFUNC_SIGNATURES, _GUFUNC_LAYOUT, **_GUFUNC_KWARGS)
-    def kernel(data, flat, starts, counts, param, out):
-        widest = 0
-        for i in range(counts.shape[0]):
-            if counts[i] > widest:
-                widest = counts[i]
-        buffer = np.empty(widest, dtype=np.float64)
+    @functools.cache
+    def build():
+        @guvectorize(_GUFUNC_SIGNATURES, _GUFUNC_LAYOUT, **_GUFUNC_KWARGS)
+        def kernel(data, flat, starts, counts, param, out):
+            widest = 0
+            for i in range(counts.shape[0]):
+                if counts[i] > widest:
+                    widest = counts[i]
+            buffer = np.empty(widest, dtype=np.float64)
 
-        for i in range(starts.shape[0]):
-            count = counts[i]
-            if count == 0:
-                out[i] = np.nan
-                continue
-            start = starts[i]
-            for j in range(count):
-                buffer[j] = data[flat[start + j]]
-            out[i] = reduce_fn(buffer[:count], param)
+            for i in range(starts.shape[0]):
+                count = counts[i]
+                if count == 0:
+                    out[i] = np.nan
+                    continue
+                start = starts[i]
+                for j in range(count):
+                    buffer[j] = data[flat[start + j]]
+                out[i] = reduce_fn(buffer[:count], param)
+
+        return kernel
+
+    def kernel(*args):
+        return build()(*args)
 
     return kernel
 
@@ -1493,60 +1500,26 @@ class Neighborhood:
     # ``reduce``. If new compiled reductions are desired, they should follow
     # this pattern.
     #
-    # ``functools.cache`` defers each build to the first call. The deferred
-    # compilation ensures that these kernels will only be compiled individually
-    # and lazily. Further, the lazy compilation prevents gufuncs from spawning
-    # threadpools eagerly and disrupting threading and forking in other
-    # contexts. They are ``staticmethod``s rather than attributes for the same
-    # reason: a class body runs at import, so assigning them there would
-    # compile all nine during ``import uxarray``.
+    # ``_make_kernel`` defers each build to the kernel's first call. The
+    # deferred compilation ensures that these kernels will only be compiled
+    # individually and lazily. Further, the lazy compilation prevents gufuncs
+    # from spawning threadpools eagerly and disrupting threading and forking in
+    # other contexts. They are wrapped in ``staticmethod`` because a plain
+    # function in a class body would bind ``self`` as the kernel's first
+    # argument.
 
-    @staticmethod
-    @functools.cache
-    def _mean_kernel():
-        return _make_kernel(lambda window, _: np.mean(window))
-
-    @staticmethod
-    @functools.cache
-    def _sum_kernel():
-        return _make_kernel(lambda window, _: np.sum(window))
-
-    @staticmethod
-    @functools.cache
-    def _min_kernel():
-        return _make_kernel(lambda window, _: np.min(window))
-
-    @staticmethod
-    @functools.cache
-    def _max_kernel():
-        return _make_kernel(lambda window, _: np.max(window))
-
-    @staticmethod
-    @functools.cache
-    def _ptp_kernel():
-        return _make_kernel(lambda window, _: np.max(window) - np.min(window))
-
-    @staticmethod
-    @functools.cache
-    def _median_kernel():
-        return _make_kernel(_median)
-
-    @staticmethod
-    @functools.cache
-    def _var_kernel():
-        return _make_kernel(_variance)
-
-    @staticmethod
-    @functools.cache
-    def _std_kernel():
-        return _make_kernel(lambda window, ddof: np.sqrt(_variance(window, ddof)))
+    _mean_kernel = staticmethod(_make_kernel(lambda window, _: np.mean(window)))
+    _sum_kernel = staticmethod(_make_kernel(lambda window, _: np.sum(window)))
+    _min_kernel = staticmethod(_make_kernel(lambda window, _: np.min(window)))
+    _max_kernel = staticmethod(_make_kernel(lambda window, _: np.max(window)))
+    _ptp_kernel = staticmethod(_make_kernel(lambda window, _: np.max(window) - np.min(window)))
+    _median_kernel = staticmethod(_make_kernel(_median))
+    _var_kernel = staticmethod(_make_kernel(_variance))
+    _std_kernel = staticmethod(_make_kernel(lambda window, ddof: np.sqrt(_variance(window, ddof))))
 
     # ``percentile`` is ``quantile`` on a 0-100 scale, so both methods
     # rescale onto this one kernel rather than compiling a near-duplicate.
-    @staticmethod
-    @functools.cache
-    def _quantile_kernel():
-        return _make_kernel(lambda window, q: np.quantile(window, q))
+    _quantile_kernel = staticmethod(_make_kernel(lambda window, q: np.quantile(window, q)))
 
     def mean(self, uxda):
         """Mean of each neighborhood."""
@@ -1633,7 +1606,7 @@ class Neighborhood:
             # path does too by writing into a float64 output.
             if block.dtype not in (np.float64, np.float32):
                 block = block.astype(np.float64)
-            return kernel()(block, *arrays, param)
+            return kernel(block, *arrays, param)
 
         return self._apply(uxda, run)
 

--- a/uxarray/grid/neighbors.py
+++ b/uxarray/grid/neighbors.py
@@ -1278,64 +1278,6 @@ def _median(window, _):
     return np.median(window)
 
 
-# One compiled kernel per reduction. The methods on ``Neighborhood`` below call
-# into these directly. Non-compiled functions are only provided hooks through
-# ``Neighborhood.reduce``. If new compiled reductions are desired, they should
-# follow this pattern.
-#
-# ``functools.cache`` defers each build to the first call. The deferred compilation
-# ensures that these kernels will only be compiled individually and lazily. Further,
-# the lazy compilation prevents gufuncs from spawning threadpools eagerly and
-# disrupting threading and forking in other contexts.
-
-
-@functools.cache
-def _mean_kernel():
-    return _make_kernel(lambda window, _: np.mean(window))
-
-
-@functools.cache
-def _sum_kernel():
-    return _make_kernel(lambda window, _: np.sum(window))
-
-
-@functools.cache
-def _min_kernel():
-    return _make_kernel(lambda window, _: np.min(window))
-
-
-@functools.cache
-def _max_kernel():
-    return _make_kernel(lambda window, _: np.max(window))
-
-
-@functools.cache
-def _ptp_kernel():
-    return _make_kernel(lambda window, _: np.max(window) - np.min(window))
-
-
-@functools.cache
-def _median_kernel():
-    return _make_kernel(_median)
-
-
-@functools.cache
-def _var_kernel():
-    return _make_kernel(_variance)
-
-
-@functools.cache
-def _std_kernel():
-    return _make_kernel(lambda window, ddof: np.sqrt(_variance(window, ddof)))
-
-
-# ``percentile`` is ``quantile`` on a 0-100 scale, so both methods rescale onto
-# this one kernel rather than compiling a near-duplicate.
-@functools.cache
-def _quantile_kernel():
-    return _make_kernel(lambda window, q: np.quantile(window, q))
-
-
 def _as_quantile(q, scale: float):
     """Validates ``q`` on a 0-``scale`` scale and returns it as a 0-1 fraction."""
     value = float(q)
@@ -1546,47 +1488,107 @@ class Neighborhood:
             f"neighbors_per_element=[{self._counts.min()}, {self._counts.max()}]>"
         )
 
+    # One compiled kernel per reduction. The methods below call into these
+    # directly. Non-compiled functions are only provided hooks through
+    # ``reduce``. If new compiled reductions are desired, they should follow
+    # this pattern.
+    #
+    # ``functools.cache`` defers each build to the first call. The deferred
+    # compilation ensures that these kernels will only be compiled individually
+    # and lazily. Further, the lazy compilation prevents gufuncs from spawning
+    # threadpools eagerly and disrupting threading and forking in other
+    # contexts. They are ``staticmethod``s rather than attributes for the same
+    # reason: a class body runs at import, so assigning them there would
+    # compile all nine during ``import uxarray``.
+
+    @staticmethod
+    @functools.cache
+    def _mean_kernel():
+        return _make_kernel(lambda window, _: np.mean(window))
+
+    @staticmethod
+    @functools.cache
+    def _sum_kernel():
+        return _make_kernel(lambda window, _: np.sum(window))
+
+    @staticmethod
+    @functools.cache
+    def _min_kernel():
+        return _make_kernel(lambda window, _: np.min(window))
+
+    @staticmethod
+    @functools.cache
+    def _max_kernel():
+        return _make_kernel(lambda window, _: np.max(window))
+
+    @staticmethod
+    @functools.cache
+    def _ptp_kernel():
+        return _make_kernel(lambda window, _: np.max(window) - np.min(window))
+
+    @staticmethod
+    @functools.cache
+    def _median_kernel():
+        return _make_kernel(_median)
+
+    @staticmethod
+    @functools.cache
+    def _var_kernel():
+        return _make_kernel(_variance)
+
+    @staticmethod
+    @functools.cache
+    def _std_kernel():
+        return _make_kernel(lambda window, ddof: np.sqrt(_variance(window, ddof)))
+
+    # ``percentile`` is ``quantile`` on a 0-100 scale, so both methods
+    # rescale onto this one kernel rather than compiling a near-duplicate.
+    @staticmethod
+    @functools.cache
+    def _quantile_kernel():
+        return _make_kernel(lambda window, q: np.quantile(window, q))
+
     def mean(self, uxda):
         """Mean of each neighborhood."""
-        return self._apply_kernel(uxda, _mean_kernel, 0.0)
+        return self._apply_kernel(uxda, self._mean_kernel, 0.0)
 
     def sum(self, uxda):
         """Sum of each neighborhood."""
-        return self._apply_kernel(uxda, _sum_kernel, 0.0)
+        return self._apply_kernel(uxda, self._sum_kernel, 0.0)
 
     def min(self, uxda):
         """Smallest value in each neighborhood."""
-        return self._apply_kernel(uxda, _min_kernel, 0.0)
+        return self._apply_kernel(uxda, self._min_kernel, 0.0)
 
     def max(self, uxda):
         """Largest value in each neighborhood."""
-        return self._apply_kernel(uxda, _max_kernel, 0.0)
+        return self._apply_kernel(uxda, self._max_kernel, 0.0)
 
     def ptp(self, uxda):
         """Peak-to-peak spread (``max - min``) of each neighborhood."""
-        return self._apply_kernel(uxda, _ptp_kernel, 0.0)
+        return self._apply_kernel(uxda, self._ptp_kernel, 0.0)
 
     def median(self, uxda):
         """Median of each neighborhood."""
-        return self._apply_kernel(uxda, _median_kernel, 0.0)
+        return self._apply_kernel(uxda, self._median_kernel, 0.0)
 
     def var(self, uxda, ddof: int = 0):
         """Variance of each neighborhood, with ``ddof`` delta degrees of
         freedom."""
-        return self._apply_kernel(uxda, _var_kernel, float(ddof))
+        return self._apply_kernel(uxda, self._var_kernel, float(ddof))
 
     def std(self, uxda, ddof: int = 0):
         """Standard deviation of each neighborhood, with ``ddof`` delta degrees
         of freedom."""
-        return self._apply_kernel(uxda, _std_kernel, float(ddof))
+        return self._apply_kernel(uxda, self._std_kernel, float(ddof))
 
     def quantile(self, uxda, q: float):
         """Quantile ``q`` (between 0 and 1) of each neighborhood."""
-        return self._apply_kernel(uxda, _quantile_kernel, _as_quantile(q, 1.0))
+        return self._apply_kernel(uxda, self._quantile_kernel, _as_quantile(q, 1.0))
 
     def percentile(self, uxda, q: float):
         """Percentile ``q`` (between 0 and 100) of each neighborhood."""
-        return self._apply_kernel(uxda, _quantile_kernel, _as_quantile(q, 100.0))
+        return self._apply_kernel(uxda, self._quantile_kernel, _as_quantile(q, 100.0))
 
     def reduce(self, uxda, func: Callable):
         """Reduces each neighborhood with an arbitrary callable.


### PR DESCRIPTION
<!--  The PR title should summarize the changes, for example "Add `Grid._build_face_dimension` function".
      Avoid non-descriptive titles such as "Addresses issue #229". -->

<!--  Replace XXX with the issue number resolved by this PR, if this PR fully resolves an issue.
      If it does not fully resolve any issues, replace with something like "Related to #XXX",
          or "Fixes part of #YYY but does not fully close it."
      If it resolves multiple issues, repeat "closes" for each, like "Closes #XXX, closes #YYY." -->
Closes #1706

## Overview
<!--  Please provide a few bullet points summarizing the changes in this PR. This should include
      points on any bug fixes, new functions, or other changes that have been made. -->

This PR should solve an issue introduced with PR #941, wherein the neighborhood filter gufunc-based kernels would compile eagerly, forcing a major slowdown of basic `import uxarray` imports, as well as creating threadpools that would eventually block safe forking that is needed in PR #1700.

The idea is to have lazy compilation of gufuncs introduced with neighborhood filters for performant reductions. This prevents the otherwise eager compilation of every one of these kernels upon `import uxarray`.

Combined, this PR and PR #1700 can bring the total benchmark suit runtime down to about half of the pre-neighborhood filters runtime of ~40min, yielding about 20min without neighborhood filter benchmarks and 26-40ish minutes with them. 

On its own, this PR can at least mitigate some of the benchmark performance regression, on the order of about 30-50% or so.

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**General**
- [x] An issue is created and linked
- [x] Added appropriate labels (if your uxarray repo permissions allow it)
- [x] Filled out Overview and Expected Usage (if applicable) sections

**Testing & Benchmarking**
<!--  If this PR does not update any functionality or tests and is unlikely to affect efficiency,
    e.g. by affecting computation time or memory usage, remove this section (Testing & Benchmarking) -->
- [x] Adequate tests are created if there is new functionality
- [x] Tests are not too basic (such as simply calling a function and nothing else)
- [x] Tests cover all major paths in your new functions
- [x] If this PR could affect performance, ran ASV benchmarks and confirmed they show expected behavior (add a new benchmark if necessary)
<!-- Adding the run-benchmark label (if your uxarray repo permissions allow it) will run ASV benchmarks.
    If you need benchmarks to be run but don't have permissions, leave this item unchecked for now. -->

**Documentation**
<!--  If this PR does not update any functionality or docstrings, remove this section (Documentation) -->
- [x] Docstrings have been added to all new functions
- [x] Docstrings have been updated with any function changes


## AI Disclosure
<!-- Please specify all AI tools used. Optionally, include model and/or briefly describe usage. Examples:
    "AI Usage: Claude (Fable 5), Gemini"
    "AI Usage: ChatGPT (5.5 Instant) to help understand cause of this bug, but I wrote all updates myself."
    "AI Usage: just GitHub Copilot's inline code suggestions."
    If you did not use AI, please write "AI Usage: N/A" and remove these checklist items or mark as [N/A].-->

AI Usage: Claude Opus 5

- [x] I take responsibility for all AI-generated content in my PR.
- [x] I have tested all AI-generated content in my PR.

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

**PR Etiquette Reminders**
- This PR should be listed as a draft PR until you are ready for it to be reviewed

- After making changes in accordance with any reviews, re-request reviews from the same reviewers

- Do *not* mark conversations as resolved if you didn't start them

- Do mark conversations as resolved *if you opened them* and are satisfied with the changes/discussion.
-->
