### PR TITLE
(Checking how ASV benchmarks look without any code changes)

### DIFF
--- a/.github/workflows/asv-benchmarking-pr.yml
+++ b/.github/workflows/asv-benchmarking-pr.yml
@@ -1,4 +1,5 @@
 name: ASV Benchmarking (PR)
+# (testing how benchmarks look when not making any code changes.)
 
 # This workflow runs untrusted fork code, so it only gets a read-only token and
 # no write access. It must NOT post comments itself (forks get a read-only token


### PR DESCRIPTION
Not intended to be merged to main, just trying to check how ASV benchmarks look currently when the code is unchanged.

There's probably a better solution than having a draft PR for this, but this is the simplest/fastest way I could think of right now. I already attempted but struggled to generate ASV benchmark runs on my local machine with the same output format as what the run-benchmark label produces via github CI.

I originally created this with the intention of determining whether the reported benchmark performance degradation in #1705 is actually caused by the code changes there or not. Maybe this should be closed soon after that check, or maybe it should be open for a longer-term basis to repeat checks like this in the future? For example, it might have been useful to have something like this available for initially discovering #1605.