### PR TITLE
Fix: `.sel()` now actually slices the uxgrid too, for UxDataArray and UxDataset

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -244,6 +244,7 @@ Selection & Indexing
    :toctree: generated/
 
    UxDataArray.isel
+   UxDataArray.sel
    UxDataArray.where
 
 

--- a/test/core/test_indexing.py
+++ b/test/core/test_indexing.py
@@ -1,0 +1,85 @@
+"""
+Purpose: tests related to indexing Grid, UxDataArray, and/or UxDataset,
+e.g. UxDataArray's and UxDataset's .isel() and .sel() methods.
+
+(Some .isel() and sel() tests are in test_dataarray.py and test_dataset.py,
+but could maybe be moved here? Having test_indexing.py as its own file helps
+to ensure consistency between UxDataArray and UxDataset indexing.)
+"""
+import numpy as np
+import uxarray as ux
+
+def test_sel_indexes_grid():
+    """ensure obj.sel({grid_dim: ...}) actually indexes the result.uxgrid, too,
+    for UxDataArrays and UxDatasets. Regression test for #1641.
+    """
+    # extremely simple case:
+    uxds = ux.tutorial.open_dataset("quad-hexagon")
+    result = uxds.sel(n_face=0)
+    assert result.sizes['n_face'] == result.uxgrid.n_face == 1
+    # (similar check for UxDataArray)
+    uxarr = uxds['t2m']
+    result = uxarr.sel(n_face=0)
+    assert result.sizes['n_face'] == result.uxgrid.n_face == 1
+
+    # more complicated case:
+    uxds = ux.tutorial.open_dataset("outCSne30-timeseries")
+    assert uxds.sizes['n_face'] > 5000
+    result = uxds.sel(time=['2018-04-28T00', '2018-04-28T03'], n_face=range(0, 5000, 100))
+    assert result.sizes == {'time': 2, 'n_face': 50}
+    assert result.uxgrid.n_face == 50
+    # (similar check for UxDataArray)
+    uxarr = uxds['psi']
+    result = uxarr.sel(time=['2018-04-28T00', '2018-04-28T03'], n_face=range(0, 5000, 100))
+    assert result.sizes == {'time': 2, 'n_face': 50}
+    assert result.uxgrid.n_face == 50
+
+def test_sel_uses_grid_dim_labels():
+    """ensure obj.sel({grid_dim: ...}) actually utilizes coordinate labels on that grid dim,
+    for UxDataArrays and UxDatasets. Regression test for #1641.
+    TODO: fix #1714 then uncomment the UxDataset tests below
+    """
+    # test corresponding to the workflow described in #1641, but for UxDataset
+    uxds = ux.tutorial.open_dataset("outCSne30-vortex")
+    # (uncomment the next few lines after fixing #1714)
+    # uxds1 = uxds.assign_coords(n_face=np.arange(uxds.n_face.size))
+    # uxds2 = uxds1.isel(n_face=range(0, 100, 5))
+    # uxds3 = uxds2 + 7
+    # # "check what the results look like on what were originally faces 20, 30, and 40"
+    # uxds4 = uxds3.sel(n_face=[20,30,40])
+    # assert uxds4.sizes['n_face'] == uxds4.uxgrid.n_face == 3
+
+    # test corresponding to the workflow described in #1641, for UxDataArray
+    uxarr = uxds['psi']
+    uxarr1 = uxarr.assign_coords(n_face=np.arange(uxarr.n_face.size))
+    uxarr2 = uxarr1.isel(n_face=range(0, 100, 5))
+    uxarr3 = uxarr2 + 7
+    # "check what the results look like on what were originally faces 20, 30, and 40"
+    uxarr4 = uxarr3.sel(n_face=[20,30,40])
+    assert uxarr4.sizes['n_face'] == uxarr4.uxgrid.n_face == 3
+
+    # test to check what happens if using coordinate labels not equal to indexes:
+    uxarr1 = uxarr.assign_coords(n_face=10*np.arange(uxarr.n_face.size))
+    uxarr2 = uxarr1.isel(n_face=[5,6,7,8])
+    assert np.all(uxarr2 == uxarr1.sel(n_face=[50,60,70,80]))
+    assert np.all(uxarr2['n_face'] == [50,60,70,80])  # (isel shouldn't drop coord labels)
+    uxarr3 = uxarr2.isel(n_face=2)
+    assert np.all(uxarr3 == uxarr2.sel(n_face=70))
+
+def test_can_index_grid_dim_not_in_data():
+    """ensure isel() and sel() can both index a grid dim even if that dim is not present in the data itself;
+    for UxDataArrays and UxDatasets. TODO: fix #1713 then uncomment the UxDataset tests below.
+    """
+    ds = ux.tutorial.open_dataset("outCSne30-vortex")
+    # (uncomment the next few lines after fixing #1713)
+    # assert "n_face" in ds.dims
+    # result = ds.isel(n_edge=7)
+    # assert result.sizes["n_face"] == result.uxgrid.n_face == 2
+    # result = ds.sel(n_edge=7)
+    # assert result.sizes["n_face"] == result.uxgrid.n_face == 2
+
+    arr = ds["psi"]
+    result = arr.isel(n_edge=7)
+    assert result.sizes["n_face"] == result.uxgrid.n_face == 2
+    result = arr.sel(n_edge=7)
+    assert result.sizes["n_face"] == result.uxgrid.n_face == 2

--- a/test/core/test_indexing.py
+++ b/test/core/test_indexing.py
@@ -7,6 +7,7 @@ but could maybe be moved here? Having test_indexing.py as its own file helps
 to ensure consistency between UxDataArray and UxDataset indexing.)
 """
 import numpy as np
+import pytest
 import uxarray as ux
 
 def test_sel_indexes_grid():
@@ -83,3 +84,172 @@ def test_can_index_grid_dim_not_in_data():
     assert result.sizes["n_face"] == result.uxgrid.n_face == 2
     result = arr.sel(n_edge=7)
     assert result.sizes["n_face"] == result.uxgrid.n_face == 2
+
+def test_sel_can_use_slice():
+    """ensure sel() can use slice() objects as indexers, and provides expected results,
+    with expected sizes, for UxDataArrays and UxDatasets.
+    Regression test inspired by reviewer comment in #1641.
+    TODO: fix #1714 then uncomment the relevant UxDataset tests below
+    """
+    grid = ux.Grid.from_healpix(zoom=0)  # 12 faces
+    arr = ux.UxDataArray(
+        np.arange(grid.n_face, dtype=float), dims="n_face", uxgrid=grid
+    )
+    # check with unlabeled data:
+    result = arr.sel(n_face=slice(0, 2))
+    assert result.n_face.size == result.uxgrid.n_face == 2
+    # check with labeled data (includes both endpoints,
+    #   as per docstring and in agreement with xarray behavior)
+    labeled = arr.assign_coords(n_face=np.arange(grid.n_face))
+    result = labeled.sel(n_face=slice(0, 2))
+    assert result.n_face.size == result.uxgrid.n_face == 3
+
+    # repeat test above but with UxDataset:
+    uxds = ux.UxDataset({'data': arr.to_xarray()}, uxgrid=grid)
+    result = uxds.sel(n_face=slice(0, 2))
+    assert result.n_face.size == result.uxgrid.n_face == 2
+    # (uncomment the next few lines after fixing #1714)
+    # labeled_ds = uxds.assign_coords(n_face=np.arange(grid.n_face))
+    # result = labeled_ds.sel(n_face=slice(0, 2))
+    # assert result.n_face.size == result.uxgrid.n_face == 3
+
+def test_sel_crash_if_provided_selection_options_with_coordless_dims():
+    """ensure sel() crashes if providing `tolerance` and/or `method` options
+    whenever any of the indexed dims have no associated coordinates.
+    (Tests below also demonstrate that this behavior is consistent with xarray.)
+    Regression test inspired by reviewer comment in #1641.
+    TODO: fix #1714 then uncomment the relevant UxDataset tests below
+    """
+    kw_options = ({"method": "nearest"}, {"method": "nearest", "tolerance": 0.1})
+
+    # ---- 1D example ---- #
+    # -- UxDataset tests -- #
+    ds0 = ux.tutorial.open_dataset("quad-hexagon")
+    assert set(ds0.coords) == set()
+    assert set(ds0.dims) == {'n_face'}
+    ds0_labeled = ds0.assign_coords({'n_face': [0,10,20,30]})
+
+    # (uncomment the next few lines after fixing #1714)
+    # ds0.sel(n_face=[0,1])  # (sanity check: no crash when no options provided)
+    # for kw in kw_options:
+    #     with pytest.raises(ValueError, match=r"cannot supply selection options.+for dimension 'n_face'"):
+    #         ds0.sel(n_face=[0,1], **kw)  # provides method, tolerance, or both.
+    #     # separately: checking to ensure that passing these options is fine in "labeled" case.
+    #     ds0_labeled.sel(n_face=[0,10], **kw)
+
+    # ensure same behavior for xarray objects:
+    ds0.to_xarray().sel(n_face=[0,1])
+    for kw in kw_options:
+        with pytest.raises(ValueError, match=r"cannot supply selection options.+for dimension 'n_face'"):
+            ds0.to_xarray().sel(n_face=[0,1], **kw)
+        ds0_labeled.to_xarray().sel(n_face=[0,10], **kw)
+
+    # ensure supplying just tolerance raises a different error, if indexing is otherwise valid:
+    # (uncomment the next few lines after fixing #1714)
+    # with pytest.raises(ValueError, match=r"tolerance argument only valid if doing.+"):
+    #     ds0_labeled.sel(n_face=[0,10], tolerance=0.1)
+    with pytest.raises(ValueError, match=r"tolerance argument only valid if doing.+"):
+        ds0_labeled.to_xarray().sel(n_face=[0,10], tolerance=0.1)
+
+    # -- UxDataArray tests -- #
+    # (like above, but for UxDataArray objects. Fewer comments; see comments above.)
+    arr0 = ds0['t2m']
+    arr0_labeled = ds0_labeled['t2m']
+    arr0.sel(n_face=[0,1])
+    for kw in kw_options:
+        with pytest.raises(ValueError, match=r"cannot supply selection options.+for dimension 'n_face'"):
+            arr0.sel(n_face=[0,1], **kw)
+        arr0_labeled.sel(n_face=[0,10], **kw)
+
+    arr0.to_xarray().sel(n_face=[0,1])
+    for kw in kw_options:
+        with pytest.raises(ValueError, match=r"cannot supply selection options.+for dimension 'n_face'"):
+            arr0.to_xarray().sel(n_face=[0,1], **kw)
+        arr0_labeled.to_xarray().sel(n_face=[0,10], **kw)
+
+    with pytest.raises(ValueError, match=r"tolerance argument only valid if doing.+"):
+        arr0_labeled.sel(n_face=[0,10], tolerance=0.1)
+    with pytest.raises(ValueError, match=r"tolerance argument only valid if doing.+"):
+        arr0_labeled.to_xarray().sel(n_face=[0,10], tolerance=0.1)
+
+    # ---- 2D example ---- #
+    # -- UxDataset tests -- #
+    ds1_labeled = ux.tutorial.open_dataset("outCSne30-timeseries")
+    assert set(ds1_labeled.coords) == {'time'}
+    assert set(ds1_labeled.dims) == {'time', 'n_face'}
+    ds1 = ds1_labeled.drop_vars('time')
+
+    # (sanity checks: no crash when no options provided)
+    ds1_labeled.sel(time='2018-04-28T02')
+    ds1_labeled.sel(time='2018-04-28T02', n_face=[0,1])
+    ds1_labeled.sel(n_face=2)
+    ds1.sel(time=4)
+    ds1.sel(time=4, n_face=[3])
+    # loop with options
+    for kw in kw_options:
+        # passing options is fine when all indexed dims have coordinates.
+        ds1_labeled.sel(time='2018-04-28T02', **kw)
+        # (otherwise, should crash!)
+        with pytest.raises(ValueError, match=r"cannot supply selection options.+for dimension 'n_face'"):
+            ds1_labeled.sel(time='2018-04-28T02', n_face=[0,1], **kw)
+        with pytest.raises(ValueError, match=r"cannot supply selection options.+for dimension 'n_face'"):
+            ds1.sel(n_face=2, **kw)
+        with pytest.raises(ValueError, match=r"cannot supply selection options.+for dimension 'time'"):
+            ds1.sel(time=4, **kw)
+        with pytest.raises(ValueError, match=r"cannot supply selection options"):
+            # (message might mention either dimension in this case)
+            ds1.sel(time=4, n_face=[3], **kw)
+
+    # ensure same behavior for xarray objects:
+    ds1_labeled.to_xarray().sel(time='2018-04-28T02')
+    ds1_labeled.to_xarray().sel(time='2018-04-28T02', n_face=[0,1])
+    ds1_labeled.to_xarray().sel(n_face=2)
+    ds1.to_xarray().sel(time=4)
+    ds1.to_xarray().sel(time=4, n_face=[3])
+    for kw in kw_options:
+        ds1_labeled.to_xarray().sel(time='2018-04-28T02', **kw)
+        with pytest.raises(ValueError, match=r"cannot supply selection options.+for dimension 'n_face'"):
+            ds1_labeled.to_xarray().sel(time='2018-04-28T02', n_face=[0,1], **kw)
+        with pytest.raises(ValueError, match=r"cannot supply selection options.+for dimension 'n_face'"):
+            ds1.to_xarray().sel(n_face=2, **kw)
+        with pytest.raises(ValueError, match=r"cannot supply selection options.+for dimension 'time'"):
+            ds1.to_xarray().sel(time=4, **kw)
+        with pytest.raises(ValueError, match=r"cannot supply selection options"):
+            ds1.to_xarray().sel(time=4, n_face=[3], **kw)
+
+    # -- UxDataArray tests -- #
+    # (like above, but for UxDataArray objects. Fewer comments; see comments above.)
+    arr1_labeled = ds1_labeled['psi']
+    arr1 = ds1['psi']
+
+    arr1_labeled.sel(time='2018-04-28T02')
+    arr1_labeled.sel(time='2018-04-28T02', n_face=[0,1])
+    arr1_labeled.sel(n_face=2)
+    arr1.sel(time=4)
+    arr1.sel(time=4, n_face=[3])
+    for kw in kw_options:
+        arr1_labeled.sel(time='2018-04-28T02', **kw)
+        with pytest.raises(ValueError, match=r"cannot supply selection options.+for dimension 'n_face'"):
+            arr1_labeled.sel(time='2018-04-28T02', n_face=[0,1], **kw)
+        with pytest.raises(ValueError, match=r"cannot supply selection options.+for dimension 'n_face'"):
+            arr1.sel(n_face=2, **kw)
+        with pytest.raises(ValueError, match=r"cannot supply selection options.+for dimension 'time'"):
+            arr1.sel(time=4, **kw)
+        with pytest.raises(ValueError, match=r"cannot supply selection options"):
+            arr1.sel(time=4, n_face=[3], **kw)
+
+    arr1_labeled.to_xarray().sel(time='2018-04-28T02')
+    arr1_labeled.to_xarray().sel(time='2018-04-28T02', n_face=[0,1])
+    arr1_labeled.to_xarray().sel(n_face=2)
+    arr1.to_xarray().sel(time=4)
+    arr1.to_xarray().sel(time=4, n_face=[3])
+    for kw in kw_options:
+        arr1_labeled.to_xarray().sel(time='2018-04-28T02', **kw)
+        with pytest.raises(ValueError, match=r"cannot supply selection options.+for dimension 'n_face'"):
+            arr1_labeled.to_xarray().sel(time='2018-04-28T02', n_face=[0,1], **kw)
+        with pytest.raises(ValueError, match=r"cannot supply selection options.+for dimension 'n_face'"):
+            arr1.to_xarray().sel(n_face=2, **kw)
+        with pytest.raises(ValueError, match=r"cannot supply selection options.+for dimension 'time'"):
+            arr1.to_xarray().sel(time=4, **kw)
+        with pytest.raises(ValueError, match=r"cannot supply selection options"):
+            arr1.to_xarray().sel(time=4, n_face=[3], **kw)

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -2101,7 +2101,8 @@ class UxDataArray(xr.DataArray):
         indexing. This means you can use string shortcuts for datetime indexes
         (e.g., '2000-01' to select all values in January 2000). It also means
         that slices are treated as inclusive of both the start and stop values,
-        unlike normal Python indexing.
+        unlike normal Python indexing, for any dimensions with coordinate labels.
+        (Dimensions without coordinates treat slices normally.)
 
         Parameters
         ----------
@@ -2120,10 +2121,15 @@ class UxDataArray(xr.DataArray):
             * pad / ffill: propagate last valid index value forward
             * backfill / bfill: propagate next valid index value backward
             * nearest: use nearest valid index value
+
+            Can only provide ``method`` if all indexed dims actually have coords,
+            else raises ValueError (consistent with xarray sel() behavior).
         tolerance : optional
             Maximum distance between original and new labels for inexact
             matches. The values of the index at the matching locations must
             satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
+            Can only provide ``tolerance`` if all indexed dims actually have coords,
+            else raises ValueError (consistent with xarray sel() behavior).
         drop : bool, optional
             If ``drop=True``, drop coordinates variables in `indexers` instead
             of making them scalar.
@@ -2173,7 +2179,17 @@ class UxDataArray(xr.DataArray):
                     tolerance=tolerance,
                 )
             else:  # index-based indexing
+                # crash if provided `method` or `tolerance`, as promised in docstring;
+                if method is not None or tolerance is not None:
+                    raise ValueError(
+                        f"cannot supply selection options {dict(method=method, tolerance=tolerance)} "
+                        f"for dimension {grid_dim!r} that has no associated coordinate or index"
+                    )
                 grid_indices = grid_indexer
+                # temporary workaround for "isel fails with slice";
+                # remove the next two lines once issue #1639 gets fixed.
+                if isinstance(grid_indices, slice):
+                    grid_indices = range(*grid_indices.indices(self.sizes[grid_dim]))
 
             # offload the grid-indexing work to isel():
             result = self.isel({grid_dim: grid_indices}, drop=drop)

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from html import escape
-from typing import TYPE_CHECKING, Any, Hashable, Literal, Mapping, Optional
+from typing import TYPE_CHECKING, Any, Hashable, Iterable, Literal, Mapping, Optional
 from warnings import warn
 
 import numpy as np
@@ -19,7 +19,11 @@ from uxarray.core.gradient import (
     _calculate_edge_node_difference,
     _compute_gradient,
 )
-from uxarray.core.utils import _map_dims_to_ugrid
+from uxarray.core.utils import (
+    _map_dims_to_ugrid,
+    _resolve_coordinate_labels_to_indices,
+    _validate_indexers,
+)
 from uxarray.core.zonal import (
     _compute_conservative_zonal_mean_bands,
     _compute_non_conservative_zonal_mean,
@@ -2026,8 +2030,6 @@ class UxDataArray(xr.DataArray):
             If parameters are invalid for xarray's .isel(), such as if
             slicing by a nonexistent dimension, or using invalid indexers.
         """
-        from uxarray.core.utils import _validate_indexers
-
         indexers, grid_dims = _validate_indexers(
             indexers, indexers_kwargs, "isel", ignore_grid
         )
@@ -2063,6 +2065,128 @@ class UxDataArray(xr.DataArray):
 
             # no other dims, return the grid‐sliced da
             return da
+        else:  # len(grid_dims)>1; _validate_indexers should have crashed.
+            raise AssertionError("internal implementation error if reached this line")
+
+    def sel(
+        self,
+        indexers: Mapping[Any, Any] | None = None,
+        method: str | None = None,
+        tolerance: int | float | Iterable[int | float] | None = None,
+        drop: bool = False,
+        **indexers_kwargs: Any,
+    ):
+        """Returns a new array indexed by labels, instead of indices, along the specified dimension(s).
+
+        Grid dimensions ('n_node', 'n_edge', 'n_face') are treated specially.
+        Providing one of them will slice to the specified nodes, edges, or faces,
+        regardless of data location. If the data does not contain the specified dimension,
+        the result will have the minimal grid region containing everything specified.
+        For example, using n_edge=7 for data on 'n_face' makes a result with 'n_face'
+        with just the two faces on edge 7.
+
+        By default, grid dims do not have coordinates assigned. But, if they have
+        been assigned, `.sel()` respects them in the intuitive way. For example,
+        using `.sel(n_face=30)` for data with `n_face` coordinates [0,10,20,30,40]
+        would be equivalent to using `.isel(n_face=3)`. Meanwhile, if the data
+        does not contain the specified grid dim (as in the n_edge=7 example above),
+        it also cannot contain coordinates along that grid dim,
+        so in that case `.sel()` performs index-based selection just like `.isel()`.
+
+        Under the hood, this method is powered by using pandas's powerful Index
+        objects. This makes label based indexing essentially just as fast as
+        using integer indexing.
+
+        It also means this method uses pandas's (well documented) logic for
+        indexing. This means you can use string shortcuts for datetime indexes
+        (e.g., '2000-01' to select all values in January 2000). It also means
+        that slices are treated as inclusive of both the start and stop values,
+        unlike normal Python indexing.
+
+        Parameters
+        ----------
+        indexers : dict, optional
+            A dict with keys matching dimensions and values given
+            by scalars, slices or arrays of tick labels. For dimensions with
+            multi-index, the indexer may also be a dict-like object with keys
+            matching index level names.
+            If DataArrays are passed as indexers, xarray-style indexing will be
+            carried out. See :ref:`indexing` for the details.
+            One of indexers or indexers_kwargs must be provided.
+        method : {None, "nearest", "pad", "ffill", "backfill", "bfill"}, optional
+            Method to use for inexact matches:
+
+            * None (default): only exact matches
+            * pad / ffill: propagate last valid index value forward
+            * backfill / bfill: propagate next valid index value backward
+            * nearest: use nearest valid index value
+        tolerance : optional
+            Maximum distance between original and new labels for inexact
+            matches. The values of the index at the matching locations must
+            satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
+        drop : bool, optional
+            If ``drop=True``, drop coordinates variables in `indexers` instead
+            of making them scalar.
+        **indexers_kwargs : {dim: indexer, ...}, optional
+            The keyword arguments form of ``indexers``.
+            One of indexers or indexers_kwargs must be provided.
+
+        Returns
+        -------
+        obj : UxDataArray
+            A new UxDataArray with each dimension is indexed appropriately,
+            and the uxgrid indexed appropriately as well, if indexing any grid dim.
+            If indexer DataArrays have coordinates that do not conflict with
+            this object, then these coordinates will be attached,
+            except for indexers along a grid dimension (see issue #1712).
+            In general, the result's data will be a view of the data in this array,
+            unless indexing along a grid dimension or otherwise
+            triggering vectorized indexing by using an array indexer,
+            in which case the data will be a copy.
+        """
+        indexers, grid_dims = _validate_indexers(
+            indexers, indexers_kwargs, "sel", ignore_grid=False
+        )  # (sel doesn't support ignore_grid=True option)
+
+        if len(grid_dims) == 0:
+            # no grid dims --> just call xarray's sel
+            return type(self)(
+                self.to_xarray().sel(
+                    indexers=indexers,
+                    method=method,
+                    tolerance=tolerance,
+                    drop=drop,
+                ),
+                uxgrid=self.uxgrid,
+            )
+        elif len(grid_dims) == 1:
+            # pop off the one grid‐dim indexer
+            grid_dim = list(grid_dims)[0]
+            indexers = indexers.copy()  # don't modify the original dict
+            grid_indexer = indexers.pop(grid_dim)
+            if grid_dim in self.coords:  # label-based indexing
+                grid_indices = _resolve_coordinate_labels_to_indices(
+                    grid_dim,
+                    grid_indexer,
+                    self.coords[grid_dim],
+                    method=method,
+                    tolerance=tolerance,
+                )
+            else:  # index-based indexing
+                grid_indices = grid_indexer
+
+            # offload the grid-indexing work to isel():
+            result = self.isel({grid_dim: grid_indices}, drop=drop)
+
+            # index by other dims if any remain:
+            ds = result.to_xarray().sel(
+                indexers=indexers,  # (grid_dim indexer was popped)
+                method=method,
+                tolerance=tolerance,
+                drop=drop,
+            )
+
+            return type(self)(ds, uxgrid=result.uxgrid)
         else:  # len(grid_dims)>1; _validate_indexers should have crashed.
             raise AssertionError("internal implementation error if reached this line")
 

--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -424,7 +424,7 @@ class UxDataset(xr.Dataset):
         inverse_indices: bool = False,
         **indexers_kwargs,
     ):
-        """Return a new UxDataset with indexed along the specified dimension(s).
+        """Return a new UxDataset with arrays indexed along the specified dimension(s).
         Each data array is indexed appropriately,
         along with the underlying grid when applicable.
 

--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -551,7 +551,8 @@ class UxDataset(xr.Dataset):
         indexing. This means you can use string shortcuts for datetime indexes
         (e.g., '2000-01' to select all values in January 2000). It also means
         that slices are treated as inclusive of both the start and stop values,
-        unlike normal Python indexing.
+        unlike normal Python indexing, for any dimensions with coordinate labels.
+        (Dimensions without coordinates treat slices normally.)
 
         Parameters
         ----------
@@ -570,10 +571,15 @@ class UxDataset(xr.Dataset):
             * pad / ffill: propagate last valid index value forward
             * backfill / bfill: propagate next valid index value backward
             * nearest: use nearest valid index value
+
+            Can only provide ``method`` if all indexed dims actually have coords,
+            else raises ValueError (consistent with xarray sel() behavior).
         tolerance : optional
             Maximum distance between original and new labels for inexact
             matches. The values of the index at the matching locations must
             satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
+            Can only provide ``tolerance`` if all indexed dims actually have coords,
+            else raises ValueError (consistent with xarray sel() behavior).
         drop : bool, optional
             If ``drop=True``, drop coordinates variables in `indexers` instead
             of making them scalar.
@@ -624,7 +630,18 @@ class UxDataset(xr.Dataset):
                     tolerance=tolerance,
                 )
             else:  # index-based indexing
+                # crash if provided `method` or `tolerance`, as promised in docstring;
+                # (this error logic matches xarray's error logic in this case.)
+                if method is not None or tolerance is not None:
+                    raise ValueError(
+                        f"cannot supply selection options {dict(method=method, tolerance=tolerance)} "
+                        f"for dimension {grid_dim!r} that has no associated coordinate or index"
+                    )
                 grid_indices = grid_indexer
+                # temporary workaround for "isel fails with slice";
+                # remove the next two lines once issue #1639 gets fixed.
+                if isinstance(grid_indices, slice):
+                    grid_indices = range(*grid_indices.indices(self.sizes[grid_dim]))
 
             # offload the grid-indexing work to isel():
             result = self.isel({grid_dim: grid_indices}, drop=drop)

--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import sys
 from html import escape
-from typing import IO, Any, Hashable, Mapping
+from typing import IO, Any, Hashable, Iterable, Mapping
 from warnings import warn
 
 import xarray as xr
@@ -13,7 +13,12 @@ from xarray.core.utils import UncachedAccessor
 
 import uxarray
 from uxarray.core.dataarray import UxDataArray
-from uxarray.core.utils import _map_dims_to_ugrid, _open_dataset_with_fallback
+from uxarray.core.utils import (
+    _map_dims_to_ugrid,
+    _open_dataset_with_fallback,
+    _resolve_coordinate_labels_to_indices,
+    _validate_indexers,
+)
 from uxarray.errors import DimensionError, GridInvalidError
 from uxarray.formatting_html import dataset_repr
 from uxarray.grid import Grid
@@ -473,8 +478,6 @@ class UxDataset(xr.Dataset):
             If parameters are invalid for xarray's .isel(), such as if
             slicing by a nonexistent dimension, or using invalid indexers.
         """
-        from uxarray.core.utils import _validate_indexers
-
         indexers, grid_dims = _validate_indexers(
             indexers, indexers_kwargs, "isel", ignore_grid
         )
@@ -511,6 +514,130 @@ class UxDataset(xr.Dataset):
                 )
 
             return type(self)(ds, uxgrid=sliced_grid)
+        else:  # len(grid_dims)>1; _validate_indexers should have crashed.
+            raise AssertionError("internal implementation error if reached this line")
+
+    def sel(
+        self,
+        indexers: Mapping[Any, Any] | None = None,
+        method: str | None = None,
+        tolerance: int | float | Iterable[int | float] | None = None,
+        drop: bool = False,
+        **indexers_kwargs: Any,
+    ):
+        """Returns a new dataset with each array indexed by labels, instead of indices,
+        along the specified dimension(s).
+
+        Grid dimensions ('n_node', 'n_edge', 'n_face') are treated specially.
+        Providing one of them will slice to the specified nodes, edges, or faces,
+        regardless of data location. If the data does not contain the specified dimension,
+        the result will have the minimal grid region containing everything specified.
+        For example, using n_edge=7 for data on 'n_face' makes a result with 'n_face'
+        with just the two faces on edge 7.
+
+        By default, grid dims do not have coordinates assigned. But, if they have
+        been assigned, `.sel()` respects them in the intuitive way. For example,
+        using `.sel(n_face=30)` for data with `n_face` coordinates [0,10,20,30,40]
+        would be equivalent to using `.isel(n_face=3)`. Meanwhile, if the data
+        does not contain the specified grid dim (as in the n_edge=7 example above),
+        it also cannot contain coordinates along that grid dim,
+        so in that case `.sel()` performs index-based selection just like `.isel()`.
+
+        Under the hood, this method is powered by using pandas's powerful Index
+        objects. This makes label based indexing essentially just as fast as
+        using integer indexing.
+
+        It also means this method uses pandas's (well documented) logic for
+        indexing. This means you can use string shortcuts for datetime indexes
+        (e.g., '2000-01' to select all values in January 2000). It also means
+        that slices are treated as inclusive of both the start and stop values,
+        unlike normal Python indexing.
+
+        Parameters
+        ----------
+        indexers : dict, optional
+            A dict with keys matching dimensions and values given
+            by scalars, slices or arrays of tick labels. For dimensions with
+            multi-index, the indexer may also be a dict-like object with keys
+            matching index level names.
+            If DataArrays are passed as indexers, xarray-style indexing will be
+            carried out. See :ref:`indexing` for the details.
+            One of indexers or indexers_kwargs must be provided.
+        method : {None, "nearest", "pad", "ffill", "backfill", "bfill"}, optional
+            Method to use for inexact matches:
+
+            * None (default): only exact matches
+            * pad / ffill: propagate last valid index value forward
+            * backfill / bfill: propagate next valid index value backward
+            * nearest: use nearest valid index value
+        tolerance : optional
+            Maximum distance between original and new labels for inexact
+            matches. The values of the index at the matching locations must
+            satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
+        drop : bool, optional
+            If ``drop=True``, drop coordinates variables in `indexers` instead
+            of making them scalar.
+        **indexers_kwargs : {dim: indexer, ...}, optional
+            The keyword arguments form of ``indexers``.
+            One of indexers or indexers_kwargs must be provided.
+
+        Returns
+        -------
+        obj : UxDataset
+            A new UxDataset with the same contents as this dataset, except each
+            variable and dimension is indexed by the appropriate indexers,
+            and the uxgrid indexed appropriately as well, if indexing any grid dim.
+            If indexer DataArrays have coordinates that do not conflict with
+            this object, then these coordinates will be attached,
+            except for indexers along a grid dimension (see issue #1712).
+            In general, each array's data will be a view of the array's data
+            in this dataset, unless indexing along a grid dimension or otherwise
+            triggering vectorized indexing by using an array indexer,
+            in which case the data will be a copy.
+        """
+        indexers, grid_dims = _validate_indexers(
+            indexers, indexers_kwargs, "sel", ignore_grid=False
+        )  # (sel doesn't support ignore_grid=True option)
+
+        if len(grid_dims) == 0:
+            # no grid dims --> just call xarray's sel
+            return type(self)(
+                self.to_xarray().sel(
+                    indexers=indexers,
+                    method=method,
+                    tolerance=tolerance,
+                    drop=drop,
+                ),
+                uxgrid=self.uxgrid,
+            )
+        elif len(grid_dims) == 1:
+            # pop off the one grid‐dim indexer
+            grid_dim = list(grid_dims)[0]
+            indexers = indexers.copy()  # don't modify the original dict
+            grid_indexer = indexers.pop(grid_dim)
+            if grid_dim in self.coords:  # label-based indexing
+                grid_indices = _resolve_coordinate_labels_to_indices(
+                    grid_dim,
+                    grid_indexer,
+                    self.coords[grid_dim],
+                    method=method,
+                    tolerance=tolerance,
+                )
+            else:  # index-based indexing
+                grid_indices = grid_indexer
+
+            # offload the grid-indexing work to isel():
+            result = self.isel({grid_dim: grid_indices}, drop=drop)
+
+            # index by other dims if any remain:
+            ds = result.to_xarray().sel(
+                indexers=indexers,  # (grid_dim indexer was popped)
+                method=method,
+                tolerance=tolerance,
+                drop=drop,
+            )
+
+            return type(self)(ds, uxgrid=result.uxgrid)
         else:  # len(grid_dims)>1; _validate_indexers should have crashed.
             raise AssertionError("internal implementation error if reached this line")
 
@@ -801,22 +928,6 @@ class UxDataset(xr.Dataset):
         return UxDataset(self.to_xarray().where(cond, other, drop), uxgrid=self._uxgrid)
 
     where.__doc__ = xr.Dataset.where.__doc__
-
-    def sel(
-        self, indexers=None, method=None, tolerance=None, drop=False, **indexers_kwargs
-    ):
-        return UxDataset(
-            self.to_xarray().sel(
-                indexers=indexers,
-                method=method,
-                tolerance=tolerance,
-                drop=drop,
-                **indexers_kwargs,
-            ),
-            uxgrid=self.uxgrid,
-        )
-
-    sel.__doc__ = xr.Dataset.sel.__doc__
 
     def fillna(self, value: Any):
         return UxDataset(super().fillna(value), uxgrid=self._uxgrid)

--- a/uxarray/core/utils.py
+++ b/uxarray/core/utils.py
@@ -1,5 +1,8 @@
+import numpy as np
 import xarray as xr
+from xarray.core.utils import either_dict_or_kwargs
 
+from uxarray.constants import GRID_DIMS
 from uxarray.errors import DimensionError
 from uxarray.io.utils import _get_source_dims_dict, _parse_grid_type
 
@@ -123,9 +126,31 @@ def match_chunks_to_ugrid(grid_filename_or_obj, chunks):
 
 
 def _validate_indexers(indexers, indexers_kwargs, func_name, ignore_grid):
-    from xarray.core.utils import either_dict_or_kwargs
+    """returns (dict of indexers, set of grid_dim strs).
 
-    from uxarray.constants import GRID_DIMS
+    Parameters
+    ----------
+    indexers: dict
+        indexers originally provided as dict. E.g., uxarr.isel({'n_face': 0}).
+        Provide indexers or indexers_kwargs but not both.
+    indexers_kwargs: dict
+        indexers originally provided as kwargs. E.g. uxarr.isel(n_face=0).
+        Provide indexers or indexers_kwargs but not both.
+    func_name: str
+        name of the function calling _validate_indexers. E.g. "isel".
+        Included in error message if provided both indexers and indexers_kwargs.
+    ignore_grid: bool
+        whether ignore_grid=True flag was set in the indexing operation.
+        If False, ensure len(grid_dims) <= 1 else raise DimensionError.
+
+    Returns
+    -------
+    indexers: dict
+        validated dict of indexers, including grid dims indexers if present.
+    grid_dims: set
+        set of grid dimension names (from ``GRID_DIMS``) present as keys in indexers;
+        values from {"n_face", "n_node", "n_edge"} (at most 1 value if ignore_grid=False).
+    """
 
     # Used to filter out slices containing all Nones (causes subscription errors, i.e., var[0])
     _is_full_none_slice = lambda v: (
@@ -147,3 +172,34 @@ def _validate_indexers(indexers, indexers_kwargs, func_name, ignore_grid):
         )
 
     return indexers, grid_dims
+
+
+def _resolve_coordinate_labels_to_indices(
+    dim, labels_to_sel, coord_array, *, method=None, tolerance=None
+):
+    """returns indices which would be selected by coord_array.sel({dim: labels_to_sel}, ...)
+    coord_array.isel({dim: result}) should be equivalent to coord_array.sel({dim: labels_to_sel}, ...).
+
+    (Implementation here drops extra coordinates from any indexers,
+    but if it is being applied to grid dims for sel() then it will produce behavior
+    which is consistent with isel(), unless issue #1712 gets fixed.)
+
+    dim: str
+        dimension name to select along
+    labels_to_sel: any valid indexer which can be passed to .sel()
+        values to select along dim
+    coord_array: xr.DataArray or UxDataArray
+        coordinate array to select from.
+    method, tolerance: passed directly to .sel().
+    """
+    # just using xarray's .sel() on a simple np.arange(), to ensure exactly consistent behavior with sel().
+    # (Maybe a more efficient implementation exists, but this is simple and gives correct results.)
+    indices = xr.DataArray(np.arange(coord_array.sizes[dim]), dims=dim)
+    _indices_coord_name = f"__{dim}_indices__"  # just needs to be any unused name.
+    if hasattr(coord_array, "to_xarray"):  # convert to xarray to avoid recursive sel()
+        coord_array = coord_array.to_xarray()
+    coord_with_indices = coord_array.assign_coords({_indices_coord_name: indices})
+    selected = coord_with_indices.sel(
+        {dim: labels_to_sel}, method=method, tolerance=tolerance
+    )
+    return selected[_indices_coord_name].values  # (return as np.ndarray, not DataArray)


### PR DESCRIPTION
Closes #1641 

## Overview
<!--  Please summarize the changes in this PR. How does it solve the original issue? -->
Adds implementations for `UxDataset.sel()` and `UxDataArray.sel()` which actually slice the uxgrid too, ensuring the result's uxgrid and the result's data do not get out of synch. Followed the plan described in #1641, i.e., offload grid dimension indexing to `.isel()` (if there are coordinate labels for a grid dim, convert labels into indices first), and just utilize xarray's `.sel()` for non-grid dims.

Adds regression tests (see `test_sel_indexes_grid()`, which ensures the originally-reported bug is fixed, and `test_sel_uses_grid_dim_labels()`, which ensures sel() is using the actual coordinate labels for grid dimensions if there is a corresponding coordinate value). Also adds a test to ensure sel() still works even for grid dimensions which are not part of the data.

Tiny expansion of scope: fills out the docstring for the `_validate_indexers` function. Aside from that, there is no expansion of scope, the changes here all relate to fixing the original bug.


## PR Checklist
<!-- Please mark each item as [X] when completed, or [N/A] if not applicable to this PR. -->

**General**
- [X] An issue is created and linked
- [X] Added appropriate labels (if your uxarray repo permissions allow it)
- [X] Filled out Overview and Expected Usage (if applicable) sections

**Testing & Benchmarking**
- [X] There is adequate test coverage of changes from this PR (add new tests if needed)
- [N/A] If this PR could affect performance, ran ASV benchmarks and confirmed they show expected behavior (add a new benchmark if necessary)
<!-- Adding the run-benchmark label (if your uxarray repo permissions allow it) will run ASV benchmarks.
    If you need benchmarks to be run but don't have permissions, leave this item unchecked for now. -->

**Documentation and Examples**
- [X] Docstrings updated with any function changes, and included in all new functions
- [X] User (public) functions added to `docs/api.rst`; internal (private) function names start with an underscore (`_`)
- [N/A] If touched any notebook files, cleared the output of all cells before committing
- [N/A] If added new notebook files, put into appropriate directories and referenced in appropriate files
<!-- For appropriate directories/files for notebooks, see
    https://uxarray.readthedocs.io/en/latest/contributing.html#usage-examples -->

## AI Disclosure
<!-- Please specify all AI tools used. Optionally, include model and/or briefly describe usage. Examples:
    "AI Usage: Claude (Fable 5), Gemini"
    "AI Usage: ChatGPT (5.5 Instant) to help understand cause of this bug, but I wrote all updates myself."
    "AI Usage: just GitHub Copilot's inline code suggestions."
    If you did not use AI, please write "AI Usage: N/A" and remove these checklist items or mark as [N/A].-->

AI Usage: GitHub Copilot's inline code suggestions, and probably some small discussions with Claude

- [X] I have tested and take responsibility for all AI-generated content in my PR.

<!-- **PR Etiquette Reminders**
- Please list as "draft PR" until ready for review.
- Please do NOT mark any review comment threads as resolved.
- Instead, please notify reviewers after addressing their comments, via @username or the "re-request review" button.
- (Reviewers: please mark your own threads as resolved after confirming your comments have been addressed.)
-->
