### PR TITLE
Fixes `uxarray.concat` bugs and adds docstring

### DIFF
--- a/test/core/test_api.py
+++ b/test/core/test_api.py
@@ -284,3 +284,67 @@ def test_open_multigrid_missing_grid_error(gridpath):
 
     with pytest.raises(ValueError, match="Grid 'land' not found"):
         ux.open_multigrid(grid_file, gridnames=["land"])
+
+
+def test_concat_various_inputs():
+    """Ensure concat() requires uxarray objs and raises clear TypeError otherwise,
+    and that concat() works in basic cases (exactly two UxDataArrays or two UxDatasets)
+    Includes regression test for first and third bugs mentioned in #1642.
+    """
+    # ensure reasonable crash when providing no inputs
+    with pytest.raises(ValueError, match="requires at least one object"):
+        ux.concat((), dim='anything')
+    # ensure crash when providing no uxarray objects
+    with pytest.raises(TypeError, match="expected either all UxDataArray or all UxDataset"):
+        ux.concat((7, "not a uxarray object"), dim='anything')
+    # ensure crash when providing some non-uxarray objects
+    uxds0 = ux.tutorial.open_dataset('quad-hexagon')
+    uxds1 = uxds0 + 10
+    with pytest.raises(TypeError, match="expected either all UxDataArray or all UxDataset"):
+        ux.concat((uxds0, "not a uxarray object", uxds1), dim='new_dim')
+    # ensure crash when providing a mix of UxDataArray and UxDataset objects
+    uxarr0 = uxds0['t2m']
+    with pytest.raises(TypeError, match="expected either all UxDataArray or all UxDataset"):
+        ux.concat((uxds0, uxds1, uxarr0), dim='new_dim')
+    with pytest.raises(TypeError, match="expected either all UxDataArray or all UxDataset"):
+        ux.concat((uxarr0, uxds0), dim='new_dim')
+    # ensure concat works in basic cases: two UxDatasets or two UxDataArrays
+    ux.concat((uxds0, uxds1), 'new_dim')  # also ensures can provide dim as positional arg.
+    uxarr1 = uxds1['t2m']
+    assert uxarr0.uxgrid == uxarr1.uxgrid
+    result = ux.concat((uxarr0, uxarr1), 'new_dim')
+    # ^^ also serves as regression test for third bug in #1642,
+    # i.e.: ensures can actually concat UxDataArray objects.
+    # include a few quick tests that the result looks reasonable:
+    assert isinstance(result, ux.UxDataArray)
+    assert result.uxgrid == uxarr0.uxgrid
+    assert result.sizes == {**uxarr0.sizes, 'new_dim': 2}
+
+    # regression test for first bug in #1642: using non-uxarray objects with equal uxgrid
+    #    should raise error message mentioning uxarray objects, not xarray objects.
+    class Foo():
+        def __init__(self, uxgrid):
+            self.uxgrid = uxgrid
+    foo0 = Foo(7)
+    foo1 = Foo(7)  # also 7 because: want to use the same uxgrid value in both cases.
+    with pytest.raises(TypeError, match="expected either all UxDataArray or all UxDataset"):
+        ux.concat([foo0, foo1], dim='anything')
+
+
+def test_concat_checks_uxgrid():
+    """Ensure concat() requires all objects' uxgrids to be equal,
+    but not necessarily the same exact object.
+    Includes regression test for second bug mentioned in #1642.
+    """
+    arrA = ux.tutorial.open_dataset("outCSne30-vortex")['psi']
+    arrB = arrA.copy()
+    assert arrA.uxgrid == arrB.uxgrid
+    assert arrA.uxgrid is not arrB.uxgrid
+    ux.concat([arrA, arrB], 'new_dim')
+
+    arrC = ux.tutorial.open_dataset("quad-hexagon")['t2m']
+    assert arrA.uxgrid != arrC.uxgrid
+    with pytest.raises(ux.errors.GridsMismatchError, match=r"got objs\[1\]\.uxgrid != objs\[0\]\.uxgrid"):
+        ux.concat([arrA, arrC], dim='new_dim')
+    with pytest.raises(ux.errors.GridsMismatchError, match=r"got objs\[2\]\.uxgrid != objs\[0\]\.uxgrid"):
+        ux.concat([arrA, arrB, arrC], dim='new_dim')

--- a/uxarray/core/api.py
+++ b/uxarray/core/api.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Any, Iterable, Hashable, Mapping, Sequence, TypeAlias
+from typing import Any, Hashable, Iterable, Mapping, Sequence, TypeAlias
 from warnings import warn
 
 import numpy as np

--- a/uxarray/core/api.py
+++ b/uxarray/core/api.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Any, Hashable, Mapping, Sequence, TypeAlias
+from typing import Any, Iterable, Hashable, Mapping, Sequence, TypeAlias
 from warnings import warn
 
 import numpy as np
@@ -578,7 +578,7 @@ def _get_grid(
 
 
 def concat(
-    objs: Sequence[UxDataArray | UxDataset],
+    objs: Iterable[UxDataArray | UxDataset],
     dim: Hashable | xr.Variable | xr.DataArray | pd.Index,
     **kwargs: dict[str, Any],
 ):
@@ -586,7 +586,7 @@ def concat(
 
     Parameters
     ----------
-    objs : sequence of UxDataArray or UxDataset
+    objs : iterable of UxDataArray or UxDataset
         uxarray objects to concatenate together. Each object is expected to
         consist of variables and coordinates with matching shapes except for
         along the concatenated dimension, and to have underlying grids which
@@ -606,18 +606,24 @@ def concat(
     concatenated: type of objs
         Concatenated uxarray object with the same type as the input objects.
     """
-    result_type = type(objs[0])
+    objs = tuple(objs)
+    try:
+        ref_obj = objs[0]
+    except IndexError as err:
+        raise ValueError("concat requires at least one object to concatenate.") from err
+
+    result_type = type(ref_obj)
     if not (
         issubclass(result_type, (UxDataArray, UxDataset))
         and all(isinstance(obj, result_type) for obj in objs)
     ):
         _types = {type(obj) for obj in objs}
         raise TypeError(
-            "concat(elements, ...) expected either all UxDataArray elements "
-            f"or all UxDataset elements, but got types: {_types}."
+            "concat(objs, ...) expected either all UxDataArray "
+            f"or all UxDataset objs, but got types: {_types}."
         )
 
-    result_uxgrid = objs[0].uxgrid
+    result_uxgrid = ref_obj.uxgrid
     for i, obj in enumerate(objs[1:], start=1):
         if result_uxgrid != obj.uxgrid:
             raise GridsMismatchError(

--- a/uxarray/core/api.py
+++ b/uxarray/core/api.py
@@ -2,19 +2,21 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Any, Mapping, Sequence, TypeAlias
+from typing import Any, Hashable, Mapping, Sequence, TypeAlias
 from warnings import warn
 
 import numpy as np
+import pandas as pd
 import xarray as xr
 
+from uxarray.core.dataarray import UxDataArray
 from uxarray.core.dataset import UxDataset
 from uxarray.core.utils import (
     _map_dims_to_ugrid,
     _open_dataset_with_fallback,
     match_chunks_to_ugrid,
 )
-from uxarray.errors import GridInvalidError
+from uxarray.errors import GridInvalidError, GridsMismatchError
 from uxarray.grid import Grid
 from uxarray.io._scrip import (
     _detect_multigrid,
@@ -575,25 +577,54 @@ def _get_grid(
     return open_grid(grid_filename_or_obj, use_dual=use_dual, **grid_kwargs)
 
 
-def concat(objs, *args, **kwargs):
-    # Ensure there is at least one object to concat.
-    if not objs:
-        raise ValueError("No objects provided for concatenation.")
+def concat(
+    objs: Sequence[UxDataArray | UxDataset],
+    dim: Hashable | xr.Variable | xr.DataArray | pd.Index,
+    **kwargs: dict[str, Any],
+):
+    """concatenate uxarray objects along a new or existing dimension.
 
-    ref_uxgrid = getattr(objs[0], "uxgrid", None)
-    if ref_uxgrid is None:
-        raise AttributeError("The first object does not have a 'uxgrid' attribute.")
+    Parameters
+    ----------
+    objs : sequence of UxDataArray or UxDataset
+        uxarray objects to concatenate together. Each object is expected to
+        consist of variables and coordinates with matching shapes except for
+        along the concatenated dimension, and to have underlying grids which
+        compare as equal. The first object's uxgrid is attached to the result.
+    dim : Hashable or Variable or DataArray or pandas.Index
+        Name of the dimension to concatenate along. This can either be a new
+        dimension name, in which case it is added along axis=0, or an existing
+        dimension name, in which case the location of the dimension is
+        unchanged. If dimension is provided as a Variable, DataArray or Index, its name
+        is used as the dimension to concatenate along and the values are added
+        as a coordinate.
+    **kwargs : dict, optional
+        All additional kwargs forwarded directly to :func:`xarray.concat`.
 
-    ref_id = id(ref_uxgrid)
+    Returns
+    -------
+    concatenated: type of objs
+        Concatenated uxarray object with the same type as the input objects.
+    """
+    result_type = type(objs[0])
+    if not (
+        issubclass(result_type, (UxDataArray, UxDataset))
+        and all(isinstance(obj, result_type) for obj in objs)
+    ):
+        _types = {type(obj) for obj in objs}
+        raise TypeError(
+            "concat(elements, ...) expected either all UxDataArray elements "
+            f"or all UxDataset elements, but got types: {_types}."
+        )
 
-    for i, obj in enumerate(objs):
-        uxgrid = getattr(obj, "uxgrid", None)
-        if uxgrid is None:
-            raise AttributeError(
-                f"Object at index {i} does not have a 'uxgrid' attribute."
+    result_uxgrid = objs[0].uxgrid
+    for i, obj in enumerate(objs[1:], start=1):
+        if result_uxgrid != obj.uxgrid:
+            raise GridsMismatchError(
+                "concat(objs, ...) expects equivalent grids for all objs, "
+                f"but got objs[{i}].uxgrid != objs[0].uxgrid."
             )
-        if id(uxgrid) != ref_id:
-            raise ValueError(f"Object at index {i} has a different 'uxgrid' attribute.")
 
-    res = xr.concat(objs, *args, **kwargs)
-    return UxDataset(res, uxgrid=uxgrid)
+    xarray_objs = [obj.to_xarray() for obj in objs]
+
+    return result_type(xr.concat(xarray_objs, dim=dim, **kwargs), uxgrid=result_uxgrid)

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -597,7 +597,7 @@ class UxDataArray(xr.DataArray):
 
         return uxds
 
-    def to_xarray(self):
+    def to_xarray(self) -> xr.DataArray:
         return xr.DataArray(self)
 
     def integrate(

--- a/uxarray/grid/grid.py
+++ b/uxarray/grid/grid.py
@@ -758,6 +758,8 @@ class Grid:
         -------
         If two grids are equal : bool
         """
+        if self is other:
+            return True
 
         if not isinstance(other, Grid):
             return False

--- a/uxarray/remap/utils.py
+++ b/uxarray/remap/utils.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-import uxarray.core.dataset
 from uxarray.errors import DimensionError
 
 # To preserve old names for remapping
@@ -76,7 +75,7 @@ def _construct_remapped_ds(source, remapped_vars, destination_grid, remap_to):
     UxDataset
         A new dataset containing only the remapped variables and retained coordinates.
     """
-
+    from uxarray.core.dataset import UxDataset
     from uxarray.remap.spatial_coords_remap import SpatialCoordsRemapper
 
     # Ensure handling of spatial coordinates between `source` and `destination_grid` for the remapped output
@@ -87,7 +86,7 @@ def _construct_remapped_ds(source, remapped_vars, destination_grid, remap_to):
     )
     output_coords = coords_remapper.construct_output_coords()
 
-    ds_remapped = uxarray.core.dataset.UxDataset(
+    ds_remapped = UxDataset(
         data_vars=remapped_vars,
         uxgrid=destination_grid,
         coords=output_coords,

--- a/uxarray/remap/utils.py
+++ b/uxarray/remap/utils.py
@@ -113,7 +113,9 @@ def _to_dataset(source):
     name : str or None
         The variable name of the original DataArray, or None for datasets.
     """
-    if isinstance(source, uxarray.core.dataarray.UxDataArray):
+    from uxarray.core.dataarray import UxDataArray
+
+    if isinstance(source, UxDataArray):
         is_da = True
         name = source.name if source.name is not None else "nearest_neighbor_remap"
         ds = source.to_dataset(name=name) if is_da else source


### PR DESCRIPTION
<!--  Thank you for opening a PR! To help us review your contribution, please follow instructions below
      while filling out this form, and read the etiquette reminders at the bottom. -->

<!--  Please ensure the PR title summarizes the changes, e.g. "Adds `Grid._build_face_dimension` function".
      Avoid non-descriptive titles such as "Addresses issue #229". -->

Closes #1642
<!--  Replace XXX with the issue number resolved by this PR, if this PR fully resolves an issue.
      If it resolves multiple issues, repeat "closes" for each, like "Closes #XXX, closes #YYY."
      If it does not fully resolve any issues, replace with something like "Related to #XXX",
          or "Fixes part of #YYY but does not fully close it." -->

## Overview
<!--  Please summarize the changes in this PR. How does it solve the original issue? -->
Addresses all bugs mentioned in #1642. This PR does the following (with numbers here corresponding to numbers in the original issue report):

0. Adds a clear docstring to `uxarray.concat`. Updates the function signature to clarify that `dim` is a required parameter (instead of hiding it inside `*args`).
1. Uses explicit type checking to ensure objects are either all UxDataArrays or all UxDatasets.
2. Compares uxgrids using `==` instead of `is` (well, technically, uses `!=`, but the important part is that the thing being compared is whether the grids are equal, not whether they refer to literally the same object).
3. Now supports concatenating UxDataArray objects, not just UxDatasets.
4. Adds regression tests for (1), (2), and (3), and a few tiny checks of correctness.

<!--  Does the scope of this PR do anything aside from just solving the original issue?
      And/or, does it not fully solve the issue as originally reported? If so, please clarify. -->
**Minor expansions of scope:**
- Adds a check for `self is other` in `Grid.__eq__` to possibly speed up comparison in a relatively common case. Spot checks currently seem to show negligible performance improvements for pre-existing code (e.g., in calculus operations like curl() which compare uxgrids). Might become relevant to performance in concat, now that it compares grids using `==` instead of `is`, or possibly in the future when fixing issue #1718. Even if impact on performance remains negligible in all normal use-cases, it definitely does not hurt to add this check, as it has negligibly tiny costs (`self is other` is blazingly fast compared to array comparison).
- Adds type hinting for UxDataArray.to_xarray() output type (xr.DataArray).
- Moves top-level `import uxarray.core.dataset` in uxarray/remap/utils.py to be inside the relevant function instead. It was causing a circular import error when adding explicit import of UxDataArray into api.py (see notes below). This solution feels like a better style than preventing UxDataArray import in api.py; I don't think it makes sense for internal utils files to eagerly import (at top of file) from such a core class file like dataset.
  - Also, uses explicit import of UxDataArray in `remap.utils._to_dataset` instead of brittle namespace population behavior (it previously assumed `uxarray.core.dataarray` existed after calling `import uxarray.core.dataset`, but without ever explicitly importing `uxarray.core.dataarray`).
- `concat()` now utilizes keyword-only arguments after the second possibly-positional argument (i.e. `concat(objs, dim, third_arg)` is no longer allowed, everything after `dim` must be passed as keyword argument); see #1573 for motivation. Normally I might hesitate to remove the ability to pass positional args without any deprecation cycle, however the numerous bugs with `concat`, lack of appearance in any documentation examples, and complete lack of a docstring, lead me to believe `concat` was not being used much (if at all) before this.

Misc notes:
- The new import of UxDataArray in api.py cannot degrade `import uxarray` performance, because UxDataset is already being imported in api.py, and the dataset.py file already imports UxDataArray.
- Similarly, the new import of pandas in api.py cannot degrade performance, because the dataarray.py file imports UxDataArrayPlotAccessor, and the plot/accessor.py file already imports pandas.
- Maybe it could be nice to support concat() with a mix of xarray and uxarray objects eventually? Though, users could also just turn them all into uxarray objects first, so that would probably not be a high priority.


## PR Checklist
<!-- Please mark each item as [X] when completed, or [N/A] if not applicable to this PR. -->

**General**
- [X] An issue is created and linked
- [X] Added appropriate labels (if your uxarray repo permissions allow it)
- [X] Filled out Overview and Expected Usage (if applicable) sections

**Testing & Benchmarking**
- [X] There is adequate test coverage of changes from this PR (add new tests if needed)
- [N/A] If this PR could affect performance, ran ASV benchmarks and confirmed they show expected behavior (add a new benchmark if necessary)
<!-- Adding the run-benchmark label (if your uxarray repo permissions allow it) will run ASV benchmarks.
    If you need benchmarks to be run but don't have permissions, leave this item unchecked for now. -->

**Documentation and Examples**
- [X] Docstrings updated with any function changes, and included in all new functions
- [X] User (public) functions added to `docs/api.rst`; internal (private) function names start with an underscore (`_`)
- [N/A] If touched any notebook files, cleared the output of all cells before committing
- [N/A] If added new notebook files, put into appropriate directories and referenced in appropriate files
<!-- For appropriate directories/files for notebooks, see
    https://uxarray.readthedocs.io/en/latest/contributing.html#usage-examples -->

## AI Disclosure
<!-- Please specify all AI tools used. Optionally, include model and/or briefly describe usage. Examples:
    "AI Usage: Claude (Fable 5), Gemini"
    "AI Usage: ChatGPT (5.5 Instant) to help understand cause of this bug, but I wrote all updates myself."
    "AI Usage: just GitHub Copilot's inline code suggestions."
    If you did not use AI, please write "AI Usage: N/A" and remove these checklist items or mark as [N/A].-->

AI Usage: GitHub Copilot's inline code suggestions, and a brief Claude chat about docstring style.

- [X] I have tested and take responsibility for all AI-generated content in my PR.

<!-- **PR Etiquette Reminders**
- Please list as "draft PR" until ready for review.
- Please do NOT mark any review comment threads as resolved.
- Instead, please notify reviewers after addressing their comments, via @username or the "re-request review" button.
- (Reviewers: please mark your own threads as resolved after confirming your comments have been addressed.)
-->
