### PR TITLE
Avoid tiny numpy arrays in numba: optimize intersections.py (and refactor: "un-scalarize")

### DIFF
--- a/benchmarks/geometry_kernels.py
+++ b/benchmarks/geometry_kernels.py
@@ -159,16 +159,16 @@ class GCAGCAIntersection:
 
         self._accux_gca = _accux_gca
         self._try_gca_gca_intersection = _try_gca_gca_intersection
-        _accux_gca(*_W0, *_W1, *_V0, *_V1)
-        _try_gca_gca_intersection(*_W0, *_W1, *_V0, *_V1)
+        _accux_gca(_W0, _W1, _V0, _V1)
+        _try_gca_gca_intersection(_W0, _W1, _V0, _V1)
 
     def time_accux_gca_kernel(self):
         """Layer 1: pure numerical kernel."""
-        self._accux_gca(*_W0, *_W1, *_V0, *_V1)
+        self._accux_gca(_W0, _W1, _V0, _V1)
 
     def time_try_gca_gca_intersection(self):
         """Layer 2: batch/status layer."""
-        self._try_gca_gca_intersection(*_W0, *_W1, *_V0, *_V1)
+        self._try_gca_gca_intersection(_W0, _W1, _V0, _V1)
 
     def time_gca_gca_intersection(self):
         """Layer 3: dispatcher (full public API)."""

--- a/benchmarks/geometry_samebody.py
+++ b/benchmarks/geometry_samebody.py
@@ -53,22 +53,20 @@ import time
 import numpy as np
 from numba import njit
 
-from uxarray.grid.arcs import _on_minor_arc_xyz, on_minor_arc
+from uxarray.constants import ERROR_TOLERANCE
+from uxarray.grid.arcs import on_minor_arc
 from uxarray.grid.intersections import (
-    _accux_constlat_scalar,
-    _snap_const_lat_endpoint_xy,
+    _accux_constlat,
     gca_const_lat_intersection,
 )
-
-# ---------------------------------------------------------------------------
-# L1 (FP64 body) — direct double-precision kernel, verbatim from
-# fp64_GCAconstLat.hh. Scalar in / scalar out so Numba keeps it in registers,
-# mirroring _accux_constlat_scalar.
-# ---------------------------------------------------------------------------
 
 
 @njit(cache=True)
 def _fp64_constlat_scalar(a0, a1, a2, b0, b1, b2, const_z):
+    """
+    L1 (FP64 body) — direct double-precision kernel, verbatim from
+    fp64_GCAconstLat.hh.
+    """
     nx = a1 * b2 - a2 * b1
     ny = a2 * b0 - a0 * b2
     nz = a0 * b1 - a1 * b0
@@ -101,14 +99,15 @@ def _fp64_constlat(x1, x2, const_z):
     return pos, neg
 
 
-# ---------------------------------------------------------------------------
-# L2 (FP64 body) — identical logic to _try_gca_const_lat_intersection, only the
-# L1 call differs. Branchless integer masks; status codes 0/1/2 as in AccuSphGeom.
-# ---------------------------------------------------------------------------
-
-
 @njit(cache=True)
 def _fp64_try_gca_const_lat_intersection(gca_cart, const_z):
+    """
+    L2 (FP64 body) — identical logic to _try_gca_const_lat_intersection, only the
+    L1 call differs. Branchless integer masks; status codes 0/1/2 as in AccuSphGeom.
+
+    (Actually no longer identical; same operations but here allocates tiny numpy arrays,
+    while intersections.py avoids that for improved efficiency; see issue #1648.)
+    """
     x1 = gca_cart[0]
     x2 = gca_cart[1]
     pos, neg = _fp64_constlat(x1, x2, const_z)
@@ -135,14 +134,41 @@ def _fp64_try_gca_const_lat_intersection(gca_cart, const_z):
     return point, status, pos, neg
 
 
-# ---------------------------------------------------------------------------
-# L3 (FP64 body) — identical dispatcher to gca_const_lat_intersection, reusing
-# the production _snap_const_lat_endpoint so only the numerical body differs.
-# ---------------------------------------------------------------------------
+@njit(cache=True, inline="always")
+def _snap_const_lat_endpoint_xy(px, py, a0, a1, a2, b0, b1, b2, const_z):
+    """Scalar-argument form of :func:`_snap_const_lat_endpoint`.
+
+    Returns the (possibly snapped) x, y of the candidate; z is always ``const_z``
+    so it is not returned. (Legacy implementation included here after it was
+    removed while addressing issue #1648, for use in _fp64_gca_const_lat_intersection)
+    """
+    snap_sq = 1e-14
+    ox = px
+    oy = py
+    if abs(a2 - const_z) <= ERROR_TOLERANCE:
+        dx = ox - a0
+        dy = oy - a1
+        if dx * dx + dy * dy < snap_sq:
+            ox = a0
+            oy = a1
+    if abs(b2 - const_z) <= ERROR_TOLERANCE:
+        dx = ox - b0
+        dy = oy - b1
+        if dx * dx + dy * dy < snap_sq:
+            ox = b0
+            oy = b1
+    return ox, oy
 
 
 @njit(cache=True)
 def _fp64_gca_const_lat_intersection(gca_cart, const_z):
+    """
+    L3 (FP64 body) — identical dispatcher to gca_const_lat_intersection, reusing
+    the production _snap_const_lat_endpoint so only the numerical body differs.
+
+    (Actually no longer identical; same operations but here allocates tiny numpy arrays,
+    while intersections.py avoids that for improved efficiency; see issue #1648.)
+    """
     # Mirrors the production scalar dispatcher exactly (same allocation profile:
     # one (2, 3) array), only the L1 body differs. This keeps the same-body
     # comparison honest: any timing gap is the EFT math, not plumbing.
@@ -160,8 +186,8 @@ def _fp64_gca_const_lat_intersection(gca_cart, const_z):
 
     pos_fin = math.isfinite(px) and math.isfinite(py)
     neg_fin = math.isfinite(nx) and math.isfinite(ny)
-    pos_valid = pos_fin and _on_minor_arc_xyz(px, py, const_z, a0, a1, a2, b0, b1, b2)
-    neg_valid = neg_fin and _on_minor_arc_xyz(nx, ny, const_z, a0, a1, a2, b0, b1, b2)
+    pos_valid = pos_fin and on_minor_arc((px, py, const_z), (a0, a1, a2), (b0, b1, b2))
+    neg_valid = neg_fin and on_minor_arc((nx, ny, const_z), (a0, a1, a2), (b0, b1, b2))
 
     if pos_valid and not neg_valid:
         sx, sy = _snap_const_lat_endpoint_xy(px, py, a0, a1, a2, b0, b1, b2, const_z)
@@ -241,9 +267,7 @@ def _batch_accux_kernel(A, B, Z):
     """Real AccuX L1 (EFT) kernel over a batch; accumulate to defeat DCE."""
     acc = 0.0
     for i in range(A.shape[0]):
-        px, py, nxo, nyo = _accux_constlat_scalar(
-            A[i, 0], A[i, 1], A[i, 2], B[i, 0], B[i, 1], B[i, 2], Z[i]
-        )
+        px, py, nxo, nyo = _accux_constlat(A[i], B[i], Z[i])
         acc += px + py + nxo + nyo
     return acc
 

--- a/benchmarks/geometry_samebody.py
+++ b/benchmarks/geometry_samebody.py
@@ -267,8 +267,8 @@ def _batch_accux_kernel(A, B, Z):
     """Real AccuX L1 (EFT) kernel over a batch; accumulate to defeat DCE."""
     acc = 0.0
     for i in range(A.shape[0]):
-        px, py, nxo, nyo = _accux_constlat(A[i], B[i], Z[i])
-        acc += px + py + nxo + nyo
+        pos, neg = _accux_constlat(A[i], B[i], Z[i])
+        acc += pos[0] + pos[1] + neg[0] + neg[1]
     return acc
 
 
@@ -290,7 +290,7 @@ def _batch_accux_dispatch(gcas, Z):
     acc = 0.0
     for i in range(gcas.shape[0]):
         res = gca_const_lat_intersection(gcas[i], Z[i])
-        v = res[0, 0]
+        v = res[0][0]
         if v == v:  # not NaN
             acc += v
     return acc
@@ -344,8 +344,8 @@ def main():
         fp64_res = _fp64_gca_const_lat_intersection(gca, z)
         accux_res = gca_const_lat_intersection(gca, z)
         fp64_rows = int(np.isfinite(fp64_res[0, 0])) + int(np.isfinite(fp64_res[1, 0]))
-        accux_rows = int(np.isfinite(accux_res[0, 0])) + int(
-            np.isfinite(accux_res[1, 0])
+        accux_rows = int(np.isfinite(accux_res[0][0])) + int(
+            np.isfinite(accux_res[1][0])
         )
         if fp64_rows != accux_rows:
             status_mismatch += 1

--- a/benchmarks/geometry_samebody.py
+++ b/benchmarks/geometry_samebody.py
@@ -57,16 +57,25 @@ from uxarray.constants import ERROR_TOLERANCE
 from uxarray.grid.arcs import on_minor_arc
 from uxarray.grid.intersections import (
     _accux_constlat,
+    _snap_const_lat_endpoint,
     gca_const_lat_intersection,
+)
+from uxarray.utils.numba_math import (
+    _numba_add3,
+    _numba_allfinite3,
+    _numba_mul3_scalar,
 )
 
 
 @njit(cache=True)
-def _fp64_constlat_scalar(a0, a1, a2, b0, b1, b2, const_z):
+def _fp64_constlat(a, b, const_z):
     """
-    L1 (FP64 body) — direct double-precision kernel, verbatim from
+    L1 (FP64 body) — direct double-precision kernel, compare to
     fp64_GCAconstLat.hh.
+    Analogous to _accux_constlat, but uses FP64 math instead of AccuX.
     """
+    a0, a1, a2 = a
+    b0, b1, b2 = b
     nx = a1 * b2 - a2 * b1
     ny = a2 * b0 - a0 * b2
     nz = a0 * b1 - a1 * b0
@@ -80,23 +89,7 @@ def _fp64_constlat_scalar(a0, a1, a2, b0, b1, b2, const_z):
     py = -(const_z * ny * nz + s * nx) * inv_denom
     nxo = -(const_z * nx * nz + s * ny) * inv_denom
     nyo = -(const_z * ny * nz - s * nx) * inv_denom
-    return px, py, nxo, nyo
-
-
-@njit(cache=True, inline="always")
-def _fp64_constlat(x1, x2, const_z):
-    px, py, nxo, nyo = _fp64_constlat_scalar(
-        x1[0], x1[1], x1[2], x2[0], x2[1], x2[2], const_z
-    )
-    pos = np.empty(3)
-    pos[0] = px
-    pos[1] = py
-    pos[2] = const_z
-    neg = np.empty(3)
-    neg[0] = nxo
-    neg[1] = nyo
-    neg[2] = const_z
-    return pos, neg
+    return (px, py, const_z), (nxo, nyo, const_z)
 
 
 @njit(cache=True)
@@ -104,18 +97,15 @@ def _fp64_try_gca_const_lat_intersection(gca_cart, const_z):
     """
     L2 (FP64 body) — identical logic to _try_gca_const_lat_intersection, only the
     L1 call differs. Branchless integer masks; status codes 0/1/2 as in AccuSphGeom.
-
-    (Actually no longer identical; same operations but here allocates tiny numpy arrays,
-    while intersections.py avoids that for improved efficiency; see issue #1648.)
     """
     x1 = gca_cart[0]
     x2 = gca_cart[1]
     pos, neg = _fp64_constlat(x1, x2, const_z)
 
-    pos_fin = int(math.isfinite(pos[0]) and math.isfinite(pos[1]))
-    neg_fin = int(math.isfinite(neg[0]) and math.isfinite(neg[1]))
-    pos_on = pos_fin * int(on_minor_arc(pos, x1, x2)) if pos_fin else 0
-    neg_on = neg_fin * int(on_minor_arc(neg, x1, x2)) if neg_fin else 0
+    pos_fin = int(math.isfinite(pos[0])) * int(math.isfinite(pos[1]))
+    neg_fin = int(math.isfinite(neg[0])) * int(math.isfinite(neg[1]))
+    pos_on = pos_fin * on_minor_arc(pos, x1, x2)
+    neg_on = neg_fin * on_minor_arc(neg, x1, x2)
 
     pos_valid = pos_fin * pos_on
     neg_valid = neg_fin * neg_on
@@ -123,10 +113,9 @@ def _fp64_try_gca_const_lat_intersection(gca_cart, const_z):
     pos_mask = pos_valid * (1 - neg_valid)
     neg_mask = neg_valid * (1 - pos_valid)
 
-    point = np.empty(3)
-    point[0] = pos_mask * pos[0] + neg_mask * neg[0]
-    point[1] = pos_mask * pos[1] + neg_mask * neg[1]
-    point[2] = pos_mask * pos[2] + neg_mask * neg[2]
+    point = _numba_add3(
+        _numba_mul3_scalar(pos, pos_mask), _numba_mul3_scalar(neg, neg_mask)
+    )
 
     both = pos_valid * neg_valid
     none = (1 - pos_valid) * (1 - neg_valid)
@@ -134,88 +123,45 @@ def _fp64_try_gca_const_lat_intersection(gca_cart, const_z):
     return point, status, pos, neg
 
 
-@njit(cache=True, inline="always")
-def _snap_const_lat_endpoint_xy(px, py, a0, a1, a2, b0, b1, b2, const_z):
-    """Scalar-argument form of :func:`_snap_const_lat_endpoint`.
-
-    Returns the (possibly snapped) x, y of the candidate; z is always ``const_z``
-    so it is not returned. (Legacy implementation included here after it was
-    removed while addressing issue #1648, for use in _fp64_gca_const_lat_intersection)
-    """
-    snap_sq = 1e-14
-    ox = px
-    oy = py
-    if abs(a2 - const_z) <= ERROR_TOLERANCE:
-        dx = ox - a0
-        dy = oy - a1
-        if dx * dx + dy * dy < snap_sq:
-            ox = a0
-            oy = a1
-    if abs(b2 - const_z) <= ERROR_TOLERANCE:
-        dx = ox - b0
-        dy = oy - b1
-        if dx * dx + dy * dy < snap_sq:
-            ox = b0
-            oy = b1
-    return ox, oy
-
-
 @njit(cache=True)
 def _fp64_gca_const_lat_intersection(gca_cart, const_z):
     """
     L3 (FP64 body) — identical dispatcher to gca_const_lat_intersection, reusing
-    the production _snap_const_lat_endpoint so only the numerical body differs.
-
-    (Actually no longer identical; same operations but here allocates tiny numpy arrays,
-    while intersections.py avoids that for improved efficiency; see issue #1648.)
+    the production _snap_const_lat_endpoint so only the numerical body differs;
+    the only difference is using _fp64_constlat instead of _accux_constlat.
     """
-    # Mirrors the production scalar dispatcher exactly (same allocation profile:
-    # one (2, 3) array), only the L1 body differs. This keeps the same-body
-    # comparison honest: any timing gap is the EFT math, not plumbing.
-    res = np.empty((2, 3))
-    res.fill(np.nan)
+    a = gca_cart[0]
+    b = gca_cart[1]
 
-    a0 = gca_cart[0, 0]
-    a1 = gca_cart[0, 1]
-    a2 = gca_cart[0, 2]
-    b0 = gca_cart[1, 0]
-    b1 = gca_cart[1, 1]
-    b2 = gca_cart[1, 2]
+    pos, neg = _fp64_constlat(a, b, const_z)
 
-    px, py, nx, ny = _fp64_constlat_scalar(a0, a1, a2, b0, b1, b2, const_z)
+    pos_fin = int(math.isfinite(pos[0])) * int(math.isfinite(pos[1]))
+    neg_fin = int(math.isfinite(neg[0])) * int(math.isfinite(neg[1]))
+    pos_valid = pos_fin * on_minor_arc(pos, a, b)
+    neg_valid = neg_fin * on_minor_arc(neg, a, b)
 
-    pos_fin = math.isfinite(px) and math.isfinite(py)
-    neg_fin = math.isfinite(nx) and math.isfinite(ny)
-    pos_valid = pos_fin and on_minor_arc((px, py, const_z), (a0, a1, a2), (b0, b1, b2))
-    neg_valid = neg_fin and on_minor_arc((nx, ny, const_z), (a0, a1, a2), (b0, b1, b2))
-
-    if pos_valid and not neg_valid:
-        sx, sy = _snap_const_lat_endpoint_xy(px, py, a0, a1, a2, b0, b1, b2, const_z)
-        res[0, 0] = sx
-        res[0, 1] = sy
-        res[0, 2] = const_z
-    elif neg_valid and not pos_valid:
-        sx, sy = _snap_const_lat_endpoint_xy(nx, ny, a0, a1, a2, b0, b1, b2, const_z)
-        res[0, 0] = sx
-        res[0, 1] = sy
-        res[0, 2] = const_z
-    elif pos_valid and neg_valid:
-        psx, psy = _snap_const_lat_endpoint_xy(px, py, a0, a1, a2, b0, b1, b2, const_z)
-        nsx, nsy = _snap_const_lat_endpoint_xy(nx, ny, a0, a1, a2, b0, b1, b2, const_z)
-        dx = psx - nsx
-        dy = psy - nsy
-        if dx * dx + dy * dy < 1e-14:
-            res[0, 0] = psx
-            res[0, 1] = psy
-            res[0, 2] = const_z
+    if pos_valid ^ neg_valid:
+        # exactly 1 valid intersection point
+        if pos_valid:
+            point_snapped = _snap_const_lat_endpoint(pos, a, b, const_z)
         else:
-            res[0, 0] = psx
-            res[0, 1] = psy
-            res[0, 2] = const_z
-            res[1, 0] = nsx
-            res[1, 1] = nsy
-            res[1, 2] = const_z
-    return res
+            point_snapped = _snap_const_lat_endpoint(neg, a, b, const_z)
+        result = (point_snapped, (np.nan, np.nan, np.nan))
+    elif pos_valid and neg_valid:
+        # probably 2 valid intersection points
+        pos_snapped = _snap_const_lat_endpoint(pos, a, b, const_z)
+        neg_snapped = _snap_const_lat_endpoint(neg, a, b, const_z)
+        dx = pos_snapped[0] - neg_snapped[0]
+        dy = pos_snapped[1] - neg_snapped[1]
+        if dx * dx + dy * dy < 1e-14:
+            # (actually, they are the same point! --> Only 1 valid point.)
+            result = (pos_snapped, (np.nan, np.nan, np.nan))
+        else:
+            result = (pos_snapped, neg_snapped)
+    else:
+        # 0 valid intersection points
+        result = ((np.nan, np.nan, np.nan), (np.nan, np.nan, np.nan))
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -277,10 +223,8 @@ def _batch_fp64_kernel(A, B, Z):
     """Same-body FP64 L1 kernel over a batch; accumulate to defeat DCE."""
     acc = 0.0
     for i in range(A.shape[0]):
-        px, py, nxo, nyo = _fp64_constlat_scalar(
-            A[i, 0], A[i, 1], A[i, 2], B[i, 0], B[i, 1], B[i, 2], Z[i]
-        )
-        acc += px + py + nxo + nyo
+        pos, neg = _fp64_constlat(A[i], B[i], Z[i])
+        acc += pos[0] + pos[1] + neg[0] + neg[1]
     return acc
 
 
@@ -302,7 +246,7 @@ def _batch_fp64_dispatch(gcas, Z):
     acc = 0.0
     for i in range(gcas.shape[0]):
         res = _fp64_gca_const_lat_intersection(gcas[i], Z[i])
-        v = res[0, 0]
+        v = res[0][0]
         if v == v:  # not NaN
             acc += v
     return acc
@@ -343,15 +287,13 @@ def main():
     for gca, z in base_cases:
         fp64_res = _fp64_gca_const_lat_intersection(gca, z)
         accux_res = gca_const_lat_intersection(gca, z)
-        fp64_rows = int(np.isfinite(fp64_res[0, 0])) + int(np.isfinite(fp64_res[1, 0]))
-        accux_rows = int(np.isfinite(accux_res[0][0])) + int(
-            np.isfinite(accux_res[1][0])
-        )
+        fp64_rows = int(np.isfinite(fp64_res[0][0])) + int(np.isfinite(fp64_res[1][0]))
+        accux_rows = int(np.isfinite(accux_res[0][0])) + int(np.isfinite(accux_res[1][0]))
         if fp64_rows != accux_rows:
             status_mismatch += 1
         if fp64_rows > 0 and accux_rows > 0:
             n_with_result += 1
-            d = np.nanmax(np.abs(fp64_res - accux_res))
+            d = np.nanmax(np.abs(np.asarray(fp64_res) - np.asarray(accux_res)))
             if np.isfinite(d):
                 max_out_diff = max(max_out_diff, d)
 

--- a/benchmarks/geometry_samebody.py
+++ b/benchmarks/geometry_samebody.py
@@ -67,7 +67,7 @@ from uxarray.utils.numba_math import (
 )
 
 
-@njit(cache=True)
+@njit(cache=True, inline="always", error_model="numpy")
 def _fp64_constlat(a, b, const_z):
     """
     L1 (FP64 body) — direct double-precision kernel, compare to
@@ -92,7 +92,7 @@ def _fp64_constlat(a, b, const_z):
     return (px, py, const_z), (nxo, nyo, const_z)
 
 
-@njit(cache=True)
+@njit(cache=True, error_model="numpy")
 def _fp64_try_gca_const_lat_intersection(gca_cart, const_z):
     """
     L2 (FP64 body) — identical logic to _try_gca_const_lat_intersection, only the
@@ -123,7 +123,7 @@ def _fp64_try_gca_const_lat_intersection(gca_cart, const_z):
     return point, status, pos, neg
 
 
-@njit(cache=True)
+@njit(cache=True, error_model="numpy")
 def _fp64_gca_const_lat_intersection(gca_cart, const_z):
     """
     L3 (FP64 body) — identical dispatcher to gca_const_lat_intersection, reusing

--- a/benchmarks/geometry_samebody_gcagca.py
+++ b/benchmarks/geometry_samebody_gcagca.py
@@ -31,6 +31,9 @@ def _fp64_gca(w0, w1, v0, v1):
     analogue of _accux_gca (intersections.py) with accucross/accucross_pair
     replaced by naive FP64 cross products.  Same allocation shape (two np.empty(3))
     so the twin's allocation profile matches the real kernel exactly.
+
+    (Actually longer identical; same operations but here allocates tiny numpy arrays,
+    while intersections.py avoids that for improved efficiency; see issue #1648.)
     """
 
     n1x = w0[1] * w1[2] - w0[2] * w1[1]
@@ -62,6 +65,9 @@ def _fp64_try_gca_gca_intersection(w0, w1, v0, v1):
     """
     L2 (FP64 body) -- byte-for-byte identical logic to _try_gca_gca_intersection
     (intersections.py), only the L1 call differs.
+
+    (Actually longer identical; same operations but here allocates tiny numpy arrays,
+    while intersections.py avoids that for improved efficiency; see issue #1648.)
     """
     pos, neg = _fp64_gca(w0, w1, v0, v1)
 
@@ -102,6 +108,9 @@ def _fp64_gca_gca_intersection(gca_a_xyz, gca_b_xyz):
     """
     L3 (FP64 body) -- identical dispatcher to gca_gca_intersection
     (intersections.py), same np.empty((2, 3)) + res[:count] slice profile.
+
+    (Actually longer identical; same operations but here allocates tiny numpy arrays,
+    while intersections.py avoids that for improved efficiency; see issue #1648.)
     """
     if gca_a_xyz.shape[1] != 3 or gca_b_xyz.shape[1] != 3:
         raise ValueError("The two GCAs must be in the cartesian [x, y, z] format")
@@ -224,8 +233,8 @@ def _batch_accux_gca_dispatch(ga, gb):
     acc = 0.0
     for i in range(ga.shape[0]):
         res = gca_gca_intersection(ga[i], gb[i])
-        if res.shape[0] > 0:
-            acc += res[0, 0]
+        if math.isfinite(res[0][0]):
+            acc += res[0][0]
     return acc
 
 
@@ -265,7 +274,11 @@ def main(n_cases=100_000, seed=20251104):
     for i in range(n_check):
         r_fp = _fp64_gca_gca_intersection(ga[i], gb[i])
         r_ax = gca_gca_intersection(ga[i], gb[i])
-        if r_fp.shape[0] != r_ax.shape[0]:
+        # r_fp gives tiny numpy array result, with len(r_fp) == number of intersections,
+        # while r_ax always gives ((x1,y1,z1), (x2,y2,z2)) tuple result,
+        #   filling with nans if less than 2 intersections.
+        n_intersections = math.isfinite(r_ax[0][0]) + math.isfinite(r_ax[1][0])
+        if len(r_fp) != n_intersections:
             row_mismatch += 1
         elif r_fp.shape[0] > 0:
             max_out_diff = max(max_out_diff, float(np.max(np.abs(r_fp - r_ax))))

--- a/benchmarks/geometry_samebody_gcagca.py
+++ b/benchmarks/geometry_samebody_gcagca.py
@@ -1,7 +1,7 @@
 """Same-body FP64-vs-AccuX diagnostic for the GCA x GCA path.
 
 Companion to ``geometry_samebody.py``, which only covers the GCA/constant-latitude
-stack.  T
+stack. For more details, see description at top of that file.
 
 gca_gca is the kernel invoked per edge from the njit point-in-polygon crossing
 loop (``uxarray/grid/geometry.py`` ``_check_intersection``), so its allocation
@@ -20,8 +20,15 @@ import time
 import numpy as np
 from numba import njit
 
+from uxarray.errors import DimensionError
 from uxarray.grid.arcs import on_minor_arc
 from uxarray.grid.intersections import _accux_gca, gca_gca_intersection
+from uxarray.utils.numba_math import (
+    _numba_add3,
+    _numba_allfinite3,
+    _numba_mul3_scalar,
+    _numba_neg3,
+)
 
 
 @njit(cache=True, inline="always")
@@ -29,11 +36,7 @@ def _fp64_gca(w0, w1, v0, v1):
     """
     L1 (FP64 body) -- plain double-precision cross-product triple, the direct
     analogue of _accux_gca (intersections.py) with accucross/accucross_pair
-    replaced by naive FP64 cross products.  Same allocation shape (two np.empty(3))
-    so the twin's allocation profile matches the real kernel exactly.
-
-    (Actually no longer identical; same operations but here allocates tiny numpy arrays,
-    while intersections.py avoids that for improved efficiency; see issue #1648.)
+    replaced by naive FP64 cross products.
     """
 
     n1x = w0[1] * w1[2] - w0[2] * w1[1]
@@ -49,14 +52,8 @@ def _fp64_gca(w0, w1, v0, v1):
 
     vn = math.sqrt(vx * vx + vy * vy + vz * vz)
     inv = 1.0 / vn if vn != 0.0 else np.inf
-    pos = np.empty(3)
-    pos[0] = vx * inv
-    pos[1] = vy * inv
-    pos[2] = vz * inv
-    neg = np.empty(3)
-    neg[0] = -pos[0]
-    neg[1] = -pos[1]
-    neg[2] = -pos[2]
+    pos = _numba_mul3_scalar((vx, vy, vz), inv)
+    neg = _numba_neg3(pos)
     return pos, neg
 
 
@@ -64,27 +61,16 @@ def _fp64_gca(w0, w1, v0, v1):
 def _fp64_try_gca_gca_intersection(w0, w1, v0, v1):
     """
     L2 (FP64 body) -- byte-for-byte identical logic to _try_gca_gca_intersection
-    (intersections.py), only the L1 call differs.
-
-    (Actually no longer identical; same operations but here allocates tiny numpy arrays,
-    while intersections.py avoids that for improved efficiency; see issue #1648.)
+    (intersections.py), only the L1 call differs (_fp64_gca vs _accux_gca).
     """
     pos, neg = _fp64_gca(w0, w1, v0, v1)
 
-    pos_fin = (
-        1
-        if math.isfinite(pos[0]) and math.isfinite(pos[1]) and math.isfinite(pos[2])
-        else 0
-    )
-    neg_fin = (
-        1
-        if math.isfinite(neg[0]) and math.isfinite(neg[1]) and math.isfinite(neg[2])
-        else 0
-    )
-    pos_on_a = 1 if (pos_fin and on_minor_arc(pos, w0, w1)) else 0
-    pos_on_b = 1 if (pos_fin and on_minor_arc(pos, v0, v1)) else 0
-    neg_on_a = 1 if (neg_fin and on_minor_arc(neg, w0, w1)) else 0
-    neg_on_b = 1 if (neg_fin and on_minor_arc(neg, v0, v1)) else 0
+    pos_fin = _numba_allfinite3(pos)
+    neg_fin = _numba_allfinite3(neg)
+    pos_on_a = pos_fin * on_minor_arc(pos, w0, w1)
+    pos_on_b = pos_fin * on_minor_arc(pos, v0, v1)
+    neg_on_a = neg_fin * on_minor_arc(neg, w0, w1)
+    neg_on_b = neg_fin * on_minor_arc(neg, v0, v1)
 
     pos_valid = pos_fin * pos_on_a * pos_on_b
     neg_valid = neg_fin * neg_on_a * neg_on_b
@@ -92,10 +78,9 @@ def _fp64_try_gca_gca_intersection(w0, w1, v0, v1):
     pos_mask = pos_valid * (1 - neg_valid)
     neg_mask = neg_valid * (1 - pos_valid)
 
-    point = np.empty(3)
-    point[0] = pos_mask * pos[0] + neg_mask * neg[0]
-    point[1] = pos_mask * pos[1] + neg_mask * neg[1]
-    point[2] = pos_mask * pos[2] + neg_mask * neg[2]
+    point = _numba_add3(
+        _numba_mul3_scalar(pos, pos_mask), _numba_mul3_scalar(neg, neg_mask)
+    )
 
     both = pos_valid * neg_valid
     none = (1 - pos_valid) * (1 - neg_valid)
@@ -107,13 +92,21 @@ def _fp64_try_gca_gca_intersection(w0, w1, v0, v1):
 def _fp64_gca_gca_intersection(gca_a_xyz, gca_b_xyz):
     """
     L3 (FP64 body) -- identical dispatcher to gca_gca_intersection
-    (intersections.py), same np.empty((2, 3)) + res[:count] slice profile.
-
-    (Actually no longer identical; same operations but here allocates tiny numpy arrays,
-    while intersections.py avoids that for improved efficiency; see issue #1648.)
+    (intersections.py), except for using _fp64_try_gca_gca_intersection
+    instead of _try_gca_gca_intersection.
     """
-    if gca_a_xyz.shape[1] != 3 or gca_b_xyz.shape[1] != 3:
-        raise ValueError("The two GCAs must be in the cartesian [x, y, z] format")
+    if len(gca_a_xyz) != 2 or len(gca_b_xyz) != 2:
+        raise DimensionError("Each input to gca_gca_intersection must have length 2")
+    if len(gca_a_xyz[0]) != 3 or len(gca_a_xyz[1]) != 3:
+        raise DimensionError(
+            "gca_a points must be in cartesian format (x,y,z), but got len(gca_a[0]) != 3"
+            "or len(gca_a[1]) != 3, in gca_gca_intersection(gca_a, gca_b)"
+        )
+    if len(gca_b_xyz[0]) != 3 or len(gca_b_xyz[1]) != 3:
+        raise DimensionError(
+            "gca_b points must be in cartesian format (x,y,z), but got len(gca_b[0]) != 3"
+            "or len(gca_b[1]) != 3, in gca_gca_intersection(gca_a, gca_b)"
+        )
 
     w0 = gca_a_xyz[0]
     w1 = gca_a_xyz[1]
@@ -122,33 +115,32 @@ def _fp64_gca_gca_intersection(gca_a_xyz, gca_b_xyz):
 
     point, status, pos, neg = _fp64_try_gca_gca_intersection(w0, w1, v0, v1)
 
-    res = np.empty((2, 3))
-    count = 0
-    if status == 0:
-        res[0, 0] = point[0]
-        res[0, 1] = point[1]
-        res[0, 2] = point[2]
-        count = 1
+    # Always return two points; branching logic changing output shape while
+    # using tuple outputs causes numba crash like "Can't unify return type".
+    # (And, swapping to tiny numpy array outputs causes significant slowdown.)
+    if status == 0:  # one intersection point
+        result = (point, (np.nan, np.nan, np.nan))
     elif status == 1:
-        res[0, 0] = pos[0]
-        res[0, 1] = pos[1]
-        res[0, 2] = pos[2]
-        res[1, 0] = neg[0]
-        res[1, 1] = neg[1]
-        res[1, 2] = neg[2]
-        count = 2
+        result = (pos, neg)
     else:
-        if on_minor_arc(v0, w0, w1):
-            res[count, 0] = v0[0]
-            res[count, 1] = v0[1]
-            res[count, 2] = v0[2]
-            count += 1
-        if on_minor_arc(v1, w0, w1):
-            res[count, 0] = v1[0]
-            res[count, 1] = v1[1]
-            res[count, 2] = v1[2]
-            count += 1
-    return res[:count]
+        # status == 2: no candidate on both arcs.
+        # Check for coplanar overlap (shared endpoints) outside the kernel.
+        v0_on_w_arc = on_minor_arc(v0, w0, w1)
+        v1_on_w_arc = on_minor_arc(v1, w0, w1)
+        if v0_on_w_arc or v1_on_w_arc:
+            # Ensure result will be (tuple,tuple), to avoid "Can't unify return type",
+            # which occurs if there is any chance of (array,tuple) or (array,array).
+            v0 = (v0[0], v0[1], v0[2])
+            v1 = (v1[0], v1[1], v1[2])
+            if v0_on_w_arc and v1_on_w_arc:
+                result = (v0, v1)
+            elif v0_on_w_arc:
+                result = (v0, (np.nan, np.nan, np.nan))
+            elif v1_on_w_arc:
+                result = (v1, (np.nan, np.nan, np.nan))
+        else:
+            result = ((np.nan, np.nan, np.nan), (np.nan, np.nan, np.nan))
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -243,8 +235,8 @@ def _batch_fp64_gca_dispatch(ga, gb):
     acc = 0.0
     for i in range(ga.shape[0]):
         res = _fp64_gca_gca_intersection(ga[i], gb[i])
-        if res.shape[0] > 0:
-            acc += res[0, 0]
+        if math.isfinite(res[0][0]):
+            acc += res[0][0]
     return acc
 
 
@@ -274,14 +266,12 @@ def main(n_cases=100_000, seed=20251104):
     for i in range(n_check):
         r_fp = _fp64_gca_gca_intersection(ga[i], gb[i])
         r_ax = gca_gca_intersection(ga[i], gb[i])
-        # r_fp gives tiny numpy array result, with len(r_fp) == number of intersections,
-        # while r_ax always gives ((x1,y1,z1), (x2,y2,z2)) tuple result,
-        #   filling with nans if less than 2 intersections.
-        n_intersections = math.isfinite(r_ax[0][0]) + math.isfinite(r_ax[1][0])
-        if len(r_fp) != n_intersections:
+        fp_intersections = math.isfinite(r_fp[0][0]) + math.isfinite(r_fp[1][0])
+        ax_intersections = math.isfinite(r_ax[0][0]) + math.isfinite(r_ax[1][0])
+        if fp_intersections != ax_intersections:
             row_mismatch += 1
-        elif r_fp.shape[0] > 0:
-            max_out_diff = max(max_out_diff, float(np.max(np.abs(r_fp - r_ax))))
+        elif fp_intersections > 0:
+            max_out_diff = max(max_out_diff, float(np.max(np.abs(np.array(r_fp) - np.array(r_ax)))))
 
     t_fp64_k = _time_batch(_batch_fp64_gca_kernel, (wa, wb, va, vb))
     t_accux_k = _time_batch(_batch_accux_gca_kernel, (wa, wb, va, vb))

--- a/benchmarks/geometry_samebody_gcagca.py
+++ b/benchmarks/geometry_samebody_gcagca.py
@@ -32,7 +32,7 @@ def _fp64_gca(w0, w1, v0, v1):
     replaced by naive FP64 cross products.  Same allocation shape (two np.empty(3))
     so the twin's allocation profile matches the real kernel exactly.
 
-    (Actually longer identical; same operations but here allocates tiny numpy arrays,
+    (Actually no longer identical; same operations but here allocates tiny numpy arrays,
     while intersections.py avoids that for improved efficiency; see issue #1648.)
     """
 
@@ -66,7 +66,7 @@ def _fp64_try_gca_gca_intersection(w0, w1, v0, v1):
     L2 (FP64 body) -- byte-for-byte identical logic to _try_gca_gca_intersection
     (intersections.py), only the L1 call differs.
 
-    (Actually longer identical; same operations but here allocates tiny numpy arrays,
+    (Actually no longer identical; same operations but here allocates tiny numpy arrays,
     while intersections.py avoids that for improved efficiency; see issue #1648.)
     """
     pos, neg = _fp64_gca(w0, w1, v0, v1)
@@ -109,7 +109,7 @@ def _fp64_gca_gca_intersection(gca_a_xyz, gca_b_xyz):
     L3 (FP64 body) -- identical dispatcher to gca_gca_intersection
     (intersections.py), same np.empty((2, 3)) + res[:count] slice profile.
 
-    (Actually longer identical; same operations but here allocates tiny numpy arrays,
+    (Actually no longer identical; same operations but here allocates tiny numpy arrays,
     while intersections.py avoids that for improved efficiency; see issue #1648.)
     """
     if gca_a_xyz.shape[1] != 3 or gca_b_xyz.shape[1] != 3:

--- a/benchmarks/geometry_samebody_gcagca.py
+++ b/benchmarks/geometry_samebody_gcagca.py
@@ -31,7 +31,7 @@ from uxarray.utils.numba_math import (
 )
 
 
-@njit(cache=True, inline="always")
+@njit(cache=True, inline="always", error_model="numpy")
 def _fp64_gca(w0, w1, v0, v1):
     """
     L1 (FP64 body) -- plain double-precision cross-product triple, the direct
@@ -57,7 +57,7 @@ def _fp64_gca(w0, w1, v0, v1):
     return pos, neg
 
 
-@njit(cache=True)
+@njit(cache=True, inline="always", error_model="numpy")
 def _fp64_try_gca_gca_intersection(w0, w1, v0, v1):
     """
     L2 (FP64 body) -- byte-for-byte identical logic to _try_gca_gca_intersection
@@ -88,7 +88,7 @@ def _fp64_try_gca_gca_intersection(w0, w1, v0, v1):
     return point, status, pos, neg
 
 
-@njit(cache=True)
+@njit(cache=True, error_model="numpy")
 def _fp64_gca_gca_intersection(gca_a_xyz, gca_b_xyz):
     """
     L3 (FP64 body) -- identical dispatcher to gca_gca_intersection
@@ -271,7 +271,7 @@ def main(n_cases=100_000, seed=20251104):
         if fp_intersections != ax_intersections:
             row_mismatch += 1
         elif fp_intersections > 0:
-            max_out_diff = max(max_out_diff, float(np.max(np.abs(np.array(r_fp) - np.array(r_ax)))))
+            max_out_diff = max(max_out_diff, float(np.nanmax(np.abs(np.array(r_fp) - np.array(r_ax)))))
 
     t_fp64_k = _time_batch(_batch_fp64_gca_kernel, (wa, wb, va, vb))
     t_accux_k = _time_batch(_batch_accux_gca_kernel, (wa, wb, va, vb))

--- a/test/grid/geometry/test_accusphgeom_baseline.py
+++ b/test/grid/geometry/test_accusphgeom_baseline.py
@@ -86,9 +86,9 @@ def test_gca_gca_row_count(gca_gca_rows):
 @pytest.mark.parametrize("idx", range(31))
 def test_gca_gca_intersection_baseline(gca_gca_rows, idx):
     pair_id, a0, a1, b0, b1, baseline = gca_gca_rows[idx]
-    result = gca_gca_intersection(np.stack([a0, a1]), np.stack([b0, b1]))
-    assert result.shape[0] >= 1, f"pair_id={pair_id}: expected intersection, got none"
-    err = float(np.linalg.norm(result[0] - baseline))
+    result = gca_gca_intersection((a0, a1), (b0, b1))
+    assert np.isfinite(result[0][0]), f"pair_id={pair_id}: expected intersection, got none"
+    err = float(np.linalg.norm(np.array(result[0]) - baseline))
     assert err < 1e-15, f"pair_id={pair_id}: err={err:.3e} ≥ 1e-15"
 
 

--- a/test/grid/geometry/test_accusphgeom_baseline.py
+++ b/test/grid/geometry/test_accusphgeom_baseline.py
@@ -129,7 +129,7 @@ def test_gca_constlat_intersection_baseline(gca_constlat_rows, idx):
     case_id, a0, a1, z0, bx, by = gca_constlat_rows[idx]
     result = gca_const_lat_intersection(np.stack([a0, a1]), z0)
     assert not np.all(np.isnan(result[0])), f"case_id={case_id}: no intersection returned"
-    dx = result[0, 0] - bx
-    dy = result[0, 1] - by
+    dx = result[0][0] - bx
+    dy = result[0][1] - by
     err = math.sqrt(dx * dx + dy * dy)
     assert err < 5e-15, f"case_id={case_id}: err_xy={err:.3e} ≥ 5e-15"

--- a/test/grid/geometry/test_intersections.py
+++ b/test/grid/geometry/test_intersections.py
@@ -231,7 +231,7 @@ def test_GCA_constLat_intersections_antimeridian():
     ])
 
     res = gca_const_lat_intersection(GCR1_cart, np.sin(np.deg2rad(60.0)))
-    res_lonlat_rad = _xyz_to_lonlat_rad(*(res[0].tolist()))
+    res_lonlat_rad = _xyz_to_lonlat_rad(*res[0])
     assert np.allclose(res_lonlat_rad, np.array([np.deg2rad(170.0), np.deg2rad(60.0)]))
 
 def test_GCA_constLat_intersections_empty():
@@ -253,7 +253,7 @@ def test_GCA_constLat_intersections_two_pts():
     query_lat = (np.deg2rad(10.0) + max_lat) / 2.0
 
     res = gca_const_lat_intersection(GCR1_cart, np.sin(query_lat))
-    assert res.shape[0] == 2
+    assert np.all(np.isfinite(res))  # 2 intersection points
 
 def test_on_minor_arc_near_antipodal_degeneracy():
     # Endpoints computed via independent (lon, lat) and (lon + pi, -lat) trig

--- a/test/grid/geometry/test_intersections.py
+++ b/test/grid/geometry/test_intersections.py
@@ -18,7 +18,7 @@ def test_get_GCA_GCA_intersections_antimeridian():
     ])
     res_cart = gca_gca_intersection(GCR1_cart, GCR2_cart)
 
-    assert len(res_cart) == 0
+    assert np.all(~np.isfinite(res_cart))
 
     GCR1_cart = np.array([
         _lonlat_rad_to_xyz(np.deg2rad(170.0), np.deg2rad(89.0)),
@@ -67,8 +67,8 @@ def test_get_GCA_GCA_intersections_perpendicular():
     ])
     res_cart = gca_gca_intersection(GCR1_cart, GCR2_cart)
 
-    # rest_cart should be empty since these two GCAs are not intersecting
-    assert(len(res_cart) == 0)
+    # rest_cart should be all NaNs because these two GCAs are not intersecting
+    assert np.all(~np.isfinite(res_cart))
 
     # def test_GCA_GCA_single_edge_to_pole(self):
     #     # GCA_a - Face Center connected to South Pole
@@ -115,7 +115,7 @@ def test_GCA_GCA_south_pole():
     gca_b_xyz = np.array([edge_a_xyz, edge_b_xyz])
 
     # The edge should intersect
-    assert(len(gca_gca_intersection(gca_a_xyz, gca_b_xyz)))
+    assert np.all(np.isfinite(gca_gca_intersection(gca_a_xyz, gca_b_xyz)[0]))
 
 def test_GCA_GCA_north_pole():
     # GCA_a - Face Center connected to South Pole
@@ -134,7 +134,7 @@ def test_GCA_GCA_north_pole():
     gca_b_xyz = np.array([edge_a_xyz, edge_b_xyz])
 
     # The edge should intersect
-    assert(len(gca_gca_intersection(gca_a_xyz, gca_b_xyz)))
+    assert np.all(np.isfinite(gca_gca_intersection(gca_a_xyz, gca_b_xyz)[0]))
 
 def test_GCA_GCA_north_pole_angled():
     # GCA_a
@@ -154,7 +154,7 @@ def test_GCA_GCA_north_pole_angled():
     gca_b_xyz = np.array([edge_a_xyz, edge_b_xyz])
 
     # The edge should intersect
-    assert(len(gca_gca_intersection(gca_a_xyz, gca_b_xyz)))
+    assert np.all(np.isfinite(gca_gca_intersection(gca_a_xyz, gca_b_xyz)[0]))
 
 def test_GCA_edge_intersection_count():
 
@@ -187,9 +187,9 @@ def test_GCA_edge_intersection_count():
         res1 = gca_gca_intersection(edge, gca_face_center_north_pole)
         res2 = gca_gca_intersection(edge, gca_face_center_south_pole)
 
-        if len(res1):
+        if np.isfinite(res1[0][0]):
             intersect_north_pole_count += 1
-        if len(res2):
+        if np.isfinite(res2[0][0]):
             intersect_south_pole_count += 1
 
     print(intersect_north_pole_count, intersect_south_pole_count)
@@ -221,8 +221,8 @@ def test_GCA_GCA_single_edge_to_pole():
     gca_b_xyz = np.array([edge_a_xyz, edge_b_xyz])
 
     # The edge should intersect
-    assert(len(gca_gca_intersection(gca_a_xyz_close, gca_b_xyz)))
-    assert(len(gca_gca_intersection(gca_a_xyz_exact, gca_b_xyz)))
+    assert np.all(np.isfinite(gca_gca_intersection(gca_a_xyz_close, gca_b_xyz)[0]))
+    assert np.all(np.isfinite(gca_gca_intersection(gca_a_xyz_exact, gca_b_xyz)[0]))
 
 def test_GCA_constLat_intersections_antimeridian():
     GCR1_cart = np.array([
@@ -313,4 +313,4 @@ def test_GCA_GCA_intersection_near_antipodal_arc_no_false_positive():
     gca_unrelated = np.array([c0, c1])
 
     res = gca_gca_intersection(gca_near_antipodal, gca_unrelated)
-    assert len(res) == 0
+    assert np.all(~np.isfinite(res))

--- a/uxarray/grid/arcs.py
+++ b/uxarray/grid/arcs.py
@@ -499,10 +499,10 @@ def on_minor_arc(q, a, b, tol=_ON_MINOR_ARC_TOL):
 
     Parameters
     ----------
-    q : np.ndarray, shape (3,)
+    q : iterable of length 3
         Query point (unit vector).
-    a, b : np.ndarray, shape (3,)
-        Endpoints of the great-circle arc (unit vectors).
+    a, b : iterable of length 3
+        (x,y,z) coordinates of endpoints of the great-circle arc (unit vectors).
     tol : float, optional
         Tolerance for the collinearity and interval checks.
 
@@ -519,16 +519,6 @@ def on_minor_arc(q, a, b, tol=_ON_MINOR_ARC_TOL):
     Shewchuk, J. R. (1997). Adaptive precision floating-point arithmetic and
     fast robust geometric predicates. Discrete & Computational Geometry, 18,
     305-363. https://doi.org/10.1007/PL00009321
-    """
-    return _on_minor_arc_xyz(q[0], q[1], q[2], a[0], a[1], a[2], b[0], b[1], b[2], tol)
-
-
-@njit(cache=True, inline="always")
-def _on_minor_arc_xyz(q0, q1, q2, a0, a1, a2, b0, b1, b2, tol=_ON_MINOR_ARC_TOL):
-    """Scalar-argument form of :func:`on_minor_arc`, returning a 0/1 int mask.
-
-    Same logic, but takes the nine vector components directly so hot loops can
-    test arc membership without allocating ``(3,)`` arrays for the query point.
     """
     # An attempt to implement a similar Python function that provides the
     # same functionality as AccuSphGeom's on_minor_arc_tol_ptr: the result is
@@ -551,6 +541,9 @@ def _on_minor_arc_xyz(q0, q1, q2, a0, a1, a2, b0, b1, b2, tol=_ON_MINOR_ARC_TOL)
     # implement. The C++ reference's ``on_minor_arc_tol_ptr`` only guards
     # exact coincidence and assumes non-antipodal mesh edges, so this
     # widening is a UXarray-side addition, not a port of the reference.
+    a0, a1, a2 = a
+    b0, b1, b2 = b
+    q0, q1, q2 = q
     cx = a1 * b2 - a2 * b1
     cy = a2 * b0 - a0 * b2
     cz = a0 * b1 - a1 * b0

--- a/uxarray/grid/geometry.py
+++ b/uxarray/grid/geometry.py
@@ -885,21 +885,21 @@ def _check_intersection(ref_edge_xyz, edges_xyz):
         edge_xyz = edges_xyz[i]
 
         # compute intersection
-        intersection_point = gca_gca_intersection(ref_edge_xyz, edge_xyz)
+        intersections_i = gca_gca_intersection(ref_edge_xyz, edge_xyz)
 
-        if intersection_point.size != 0:
-            if intersection_point.ndim == 1:
+        if math.isfinite(intersections_i[0][0]):  # at least 1 intersection point
+            if not math.isfinite(intersections_i[1][0]):  # only 1 intersection point
                 # Only one point
-                point = intersection_point
+                point = intersections_i[0]
                 if np.allclose(point, pole_point_xyz, atol=ERROR_TOLERANCE):
                     return True
                 intersection_points[intersection_count] = point
                 intersection_count += 1
             else:
-                # Multiple points
-                num_points = intersection_point.shape[0]
+                # Exactly 2 points (gca_gca_intersection always gives 0, 1, or 2 intersections)
+                num_points = 2
                 for j in range(num_points):
-                    point = intersection_point[j]
+                    point = intersections_i[j]
                     if np.allclose(point, pole_point_xyz, atol=ERROR_TOLERANCE):
                         return True
                     intersection_points[intersection_count] = point

--- a/uxarray/grid/intersections.py
+++ b/uxarray/grid/intersections.py
@@ -5,7 +5,7 @@ from numba import njit
 
 from uxarray.constants import ERROR_TOLERANCE, INT_DTYPE
 from uxarray.errors import DimensionError
-from uxarray.grid.arcs import _on_minor_arc_xyz, on_minor_arc
+from uxarray.grid.arcs import on_minor_arc
 from uxarray.utils.computing import (
     _cdp2,
     _cdp4,
@@ -453,24 +453,30 @@ def gca_gca_intersection(gca_a_xyz, gca_b_xyz):
 
 
 @njit(cache=True, inline="always", error_model="numpy")
-def _accux_constlat_scalar(a0, a1, a2, b0, b1, b2, const_z):
-    """Compute the constant-latitude intersection candidates, scalar in/out.
+def _accux_constlat(a, b, const_z):
+    """Compute the two constant-latitude intersection candidates as tuples
 
-    Allocation-free numerical kernel. Same compensated AccuSphGeom sequence as
-    :func:`_accux_constlat`, but takes the two arc endpoints as six scalars and
-    returns the two candidate points as six scalars (``pos`` xy and ``neg`` xy;
-    the z of both candidates is ``const_z``). Returning scalars instead of
-    ``np.empty(3)`` arrays lets Numba
-    keep everything in registers, so a batch loop over many edges does no
-    per-point heap allocation. This is the preferred entry point for hot loops.
+    Pure numerical kernel (mirrors AccuSphGeom ``accux_constlat``). Computes the
+    two candidate intersection points between the great-circle arc defined by
+    unit vectors *x1*, *x2* and the constant-latitude plane z = const_z. No
+    branching, no validity filtering.
+
+    Parameters
+    ----------
+    a, b : iterables of length 3
+        Cartesian endpoints of the great-circle arc.
+    const_z : float
+        Constant-latitude plane, given as the Cartesian z value ``sin(lat)``.
 
     Returns
     -------
-    px, py, nx_out, ny_out : float
+    pos, neg : tuples of length 3
         ``pos = (px, py, const_z)`` and ``neg = (nx_out, ny_out, const_z)``.
         Invalid inputs propagate as non-finite coordinates.
     """
-    nx_hi, ny_hi, nz_hi, nx_lo, ny_lo, nz_lo = accucross(a0, a1, a2, b0, b1, b2)
+    nx_hi, ny_hi, nz_hi, nx_lo, ny_lo, nz_lo = accucross(
+        a[0], a[1], a[2], b[0], b[1], b[2]
+    )
     s2_hi, s2_lo = _sum_of_squares_c((nx_hi, ny_hi), (nx_lo, ny_lo))
     denom = s2_hi + s2_lo
     s3_hi, s3_lo = _sum_of_squares_c((nx_hi, ny_hi, nz_hi), (nx_lo, ny_lo, nz_lo))
@@ -495,50 +501,13 @@ def _accux_constlat_scalar(a0, a1, a2, b0, b1, b2, const_z):
     py = -(yp_hi + yp_lo) * inv_denom
     nxo = -(xn_hi + xn_lo) * inv_denom
     nyo = -(yn_hi + yn_lo) * inv_denom
-    return px, py, nxo, nyo
-
-
-@njit(cache=True, inline="always")
-def _accux_constlat(x1, x2, const_z):
-    """Compute the two constant-latitude intersection candidates as arrays.
-
-    Pure numerical kernel (mirrors AccuSphGeom ``accux_constlat``). An
-    array-returning wrapper around :func:`_accux_constlat_scalar`. Computes the
-    two candidate intersection points between the great-circle arc defined by
-    unit vectors *x1*, *x2* and the constant-latitude plane z = const_z. No
-    branching, no validity filtering. For allocation-free hot loops call
-    :func:`_accux_constlat_scalar` directly.
-
-    Parameters
-    ----------
-    x1, x2 : np.ndarray, shape (3,)
-        Cartesian endpoints of the great-circle arc.
-    const_z : float
-        Constant-latitude plane, given as the Cartesian z value ``sin(lat)``.
-
-    Returns
-    -------
-    pos, neg : np.ndarray, shape (3,)
-        Two antipodal candidate points.  Invalid inputs propagate as non-finite
-        coordinates; the caller uses masks/status to identify validity.
-    """
-    px, py, nxo, nyo = _accux_constlat_scalar(
-        x1[0], x1[1], x1[2], x2[0], x2[1], x2[2], const_z
-    )
-    pos = np.empty(3)
-    pos[0] = px
-    pos[1] = py
-    pos[2] = const_z
-    neg = np.empty(3)
-    neg[0] = nxo
-    neg[1] = nyo
-    neg[2] = const_z
-    return pos, neg
+    return (px, py, const_z), (nxo, nyo, const_z)
 
 
 @njit(cache=True, error_model="numpy")
 def _try_gca_const_lat_intersection(gca_cart, const_z):
     """Select the valid constant-latitude intersection and report a status code.
+    Returns point, status, pos, neg.
 
     Batch/status layer (mirrors AccuSphGeom ``try_gca_constlat_intersection``).
 
@@ -546,10 +515,24 @@ def _try_gca_const_lat_intersection(gca_cart, const_z):
     for each candidate using finiteness and arc-membership tests, then selects
     the output point via integer arithmetic — no if/else branching in the hot path.
 
-    Status codes mirror AccuSphGeom:
-        0  exactly one candidate is valid  (normal case)
-        1  both candidates are valid
+    Parameters
+    ----------
+    gca_cart : iterable of 2 length-3 iterables
+        Cartesian endpoints of the first arc.
+    const_z : float
+        Constant-latitude plane, given as the Cartesian z value ``sin(lat)``.
+
+    Returns
+    -------
+    point : tuple of length 3
+        The single valid intersection point, if status == 0, else meaningless.
+    status : int
+        Status codes mirror AccuSphGeom:
+        0  exactly one candidate is valid (point) (this is the normal case)
+        1  both candidates are valid (pos and neg)
         2  neither candidate is valid
+    pos, neg : tuple of length 3
+        The candidate intersection points.
     """
     x1 = gca_cart[0]
     x2 = gca_cart[1]
@@ -566,10 +549,9 @@ def _try_gca_const_lat_intersection(gca_cart, const_z):
     pos_mask = pos_valid * (1 - neg_valid)
     neg_mask = neg_valid * (1 - pos_valid)
 
-    point = np.empty(3)
-    point[0] = pos_mask * pos[0] + neg_mask * neg[0]
-    point[1] = pos_mask * pos[1] + neg_mask * neg[1]
-    point[2] = pos_mask * pos[2] + neg_mask * neg[2]
+    point = _numba_add3(
+        _numba_mul3_scalar(pos, pos_mask), _numba_mul3_scalar(neg, neg_mask)
+    )
 
     both = pos_valid * neg_valid
     none = (1 - pos_valid) * (1 - neg_valid)
@@ -578,45 +560,35 @@ def _try_gca_const_lat_intersection(gca_cart, const_z):
 
 
 @njit(cache=True)
-def _snap_const_lat_endpoint(point, x1, x2, const_z):
-    """Snap a candidate point to an arc endpoint when the endpoint lies on the latitude."""
+def _snap_const_lat_endpoint(point, a, b, const_z):
+    """Snap a candidate point to an arc endpoint when the endpoint lies on the latitude.
+    Returns (x,y,z) of the possibly-snapped point.
+
+    point, a, b : iterables of length 3
+        Cartesian coordinates of the candidate point and the two arc endpoints.
+    const_z : float
+        Constant-latitude plane, given as the Cartesian z value ``sin(lat)``.
+    """
     # 1e-14 is distance² in Cartesian between candidate and endpoint; corresponds
     # to ~1e-7 in arc length (unit sphere). Candidates within this distance are
     # snapped to the exact endpoint to avoid sub-ulp drift when the arc ends
     # exactly on the latitude circle.
-    sx, sy = _snap_const_lat_endpoint_xy(
-        point[0], point[1], x1[0], x1[1], x1[2], x2[0], x2[1], x2[2], const_z
-    )
-    out = np.empty(3)
-    out[0] = sx
-    out[1] = sy
-    out[2] = point[2]
-    return out
-
-
-@njit(cache=True, inline="always")
-def _snap_const_lat_endpoint_xy(px, py, a0, a1, a2, b0, b1, b2, const_z):
-    """Scalar-argument form of :func:`_snap_const_lat_endpoint`.
-
-    Returns the (possibly snapped) x, y of the candidate; z is always ``const_z``
-    so it is not returned. Allocation-free for use in hot loops.
-    """
     snap_sq = 1e-14
-    ox = px
-    oy = py
-    if abs(a2 - const_z) <= ERROR_TOLERANCE:
-        dx = ox - a0
-        dy = oy - a1
+    ox = point[0]
+    oy = point[1]
+    if abs(a[2] - const_z) <= ERROR_TOLERANCE:
+        dx = ox - a[0]
+        dy = oy - a[1]
         if dx * dx + dy * dy < snap_sq:
-            ox = a0
-            oy = a1
-    if abs(b2 - const_z) <= ERROR_TOLERANCE:
-        dx = ox - b0
-        dy = oy - b1
+            ox = a[0]
+            oy = a[1]
+    if abs(b[2] - const_z) <= ERROR_TOLERANCE:
+        dx = ox - b[0]
+        dy = oy - b[1]
         if dx * dx + dy * dy < snap_sq:
-            ox = b0
-            oy = b1
-    return ox, oy
+            ox = b[0]
+            oy = b[1]
+    return (ox, oy, point[2])
 
 
 @njit(cache=True, error_model="numpy")
@@ -624,24 +596,23 @@ def gca_const_lat_intersection(gca_cart, const_z):
     """Return the intersection points of a great-circle arc and a latitude.
 
     Dispatcher / convenience API. Runs the numerical kernel, validity masks,
-    endpoint snapping, and packaging into UXarray's NaN-filled (2, 3) format
-    entirely on scalars, so the only heap allocation is the returned array. All
-    UXarray-specific branching lives here so the numerical core stays uniform.
-    See ``_try_gca_const_lat_intersection`` for the array-returning form used by
-    the layer benchmarks.
+    endpoint snapping, and packaging into UXarray's NaN-filled (2,3) format.
+    All UXarray-specific branching lives here so the numerical core stays uniform.
+    See also: ``_try_gca_const_lat_intersection``.
 
     Parameters
     ----------
-    gca_cart : numpy.ndarray
-        Great-circle arc as two Cartesian endpoints, shape ``(2, 3)``.
+    gca_cart : iterable of 2 length-3 iterables
+        Great-circle arc as two Cartesian endpoints.
+        (If numpy array, has shape (2,3). If tuple, contains two length-3 tuples.)
     const_z : float
         Constant-latitude plane, given as the Cartesian z value ``sin(lat)``.
 
     Returns
     -------
-    numpy.ndarray
-        Intersection points, shape ``(2, 3)``, with unused rows filled with NaN
-        (0, 1, or 2 valid rows).
+    intersections : tuple of 2 length-3 tuples
+        The (x,y,z) coordinates of the intersections, filling with NaNs as needed.
+        E.g. if there is one intersection, returns ((x1,y1,z1),(nan,nan,nan)).
 
     References
     ----------
@@ -654,63 +625,51 @@ def gca_const_lat_intersection(gca_cart, const_z):
     intersections on a sphere. SIAM Journal on Scientific Computing, 48(2),
     B208-B232. https://doi.org/10.1137/25M1737614
     """
-    res = np.empty((2, 3))
-    res.fill(np.nan)
+    a = gca_cart[0]
+    b = gca_cart[1]
 
-    a0 = gca_cart[0, 0]
-    a1 = gca_cart[0, 1]
-    a2 = gca_cart[0, 2]
-    b0 = gca_cart[1, 0]
-    b1 = gca_cart[1, 1]
-    b2 = gca_cart[1, 2]
+    pos, neg = _accux_constlat(a, b, const_z)
 
-    px, py, nx, ny = _accux_constlat_scalar(a0, a1, a2, b0, b1, b2, const_z)
-
-    pos_fin = int(math.isfinite(px)) * int(math.isfinite(py))
-    neg_fin = int(math.isfinite(nx)) * int(math.isfinite(ny))
-    pos_valid = pos_fin * _on_minor_arc_xyz(px, py, const_z, a0, a1, a2, b0, b1, b2)
-    neg_valid = neg_fin * _on_minor_arc_xyz(nx, ny, const_z, a0, a1, a2, b0, b1, b2)
+    pos_fin = int(math.isfinite(pos[0])) * int(math.isfinite(pos[1]))
+    neg_fin = int(math.isfinite(neg[0])) * int(math.isfinite(neg[1]))
+    pos_valid = pos_fin * on_minor_arc(pos, a, b)
+    neg_valid = neg_fin * on_minor_arc(neg, a, b)
 
     if pos_valid ^ neg_valid:
+        # exactly 1 valid intersection point
         if pos_valid:
-            sx, sy = _snap_const_lat_endpoint_xy(
-                px, py, a0, a1, a2, b0, b1, b2, const_z
-            )
+            point_snapped = _snap_const_lat_endpoint(pos, a, b, const_z)
         else:
-            sx, sy = _snap_const_lat_endpoint_xy(
-                nx, ny, a0, a1, a2, b0, b1, b2, const_z
-            )
-        res[0, 0] = sx
-        res[0, 1] = sy
-        res[0, 2] = const_z
+            point_snapped = _snap_const_lat_endpoint(neg, a, b, const_z)
+        result = (point_snapped, (np.nan, np.nan, np.nan))
     elif pos_valid and neg_valid:
-        psx, psy = _snap_const_lat_endpoint_xy(px, py, a0, a1, a2, b0, b1, b2, const_z)
-        nsx, nsy = _snap_const_lat_endpoint_xy(nx, ny, a0, a1, a2, b0, b1, b2, const_z)
-        dx = psx - nsx
-        dy = psy - nsy
+        # probably 2 valid intersection points
+        pos_snapped = _snap_const_lat_endpoint(pos, a, b, const_z)
+        neg_snapped = _snap_const_lat_endpoint(neg, a, b, const_z)
+        dx = pos_snapped[0] - neg_snapped[0]
+        dy = pos_snapped[1] - neg_snapped[1]
         if dx * dx + dy * dy < 1e-14:
-            res[0, 0] = psx
-            res[0, 1] = psy
-            res[0, 2] = const_z
+            # (actually, they are the same point! --> Only 1 valid point.)
+            result = (pos_snapped, (np.nan, np.nan, np.nan))
         else:
-            res[0, 0] = psx
-            res[0, 1] = psy
-            res[0, 2] = const_z
-            res[1, 0] = nsx
-            res[1, 1] = nsy
-            res[1, 2] = const_z
-    return res
+            result = (pos_snapped, neg_snapped)
+    else:
+        # 0 valid intersection points
+        result = ((np.nan, np.nan, np.nan), (np.nan, np.nan, np.nan))
+    return result
 
 
 @njit(cache=True)
 def get_number_of_intersections(arr):
-    """Return the number of intersection points in a gca-const-lat result.
+    """Return the number of intersection points in a gca intersections result.
 
     Parameters
     ----------
-    arr : numpy.ndarray
-        Output of :func:`gca_const_lat_intersection`, shape ``(2, 3)`` with
-        unused rows filled with NaN.
+    arr : iterable of 2 length-3 iterables
+        Intersection points from a gca intersections function, e.g. one of:
+        :func:`gca_gca_intersection` or :func:`gca_const_lat_intersection`.
+        (If numpy array, has shape (2,3). If tuple, contains two length-3 tuples.)
+        NaN values indicate no intersection at that point.
 
     Returns
     -------
@@ -728,8 +687,8 @@ def get_number_of_intersections(arr):
     intersections on a sphere. SIAM Journal on Scientific Computing, 48(2),
     B208-B232. https://doi.org/10.1137/25M1737614
     """
-    row1_is_nan = np.all(np.isnan(arr[0]))
-    row2_is_nan = np.all(np.isnan(arr[1]))
+    row1_is_nan = np.isnan(arr[0][0]) * np.isnan(arr[0][1]) * np.isnan(arr[0][2])
+    row2_is_nan = np.isnan(arr[1][0]) * np.isnan(arr[1][1]) * np.isnan(arr[1][2])
 
     if row1_is_nan and row2_is_nan:
         return 0

--- a/uxarray/grid/intersections.py
+++ b/uxarray/grid/intersections.py
@@ -16,6 +16,12 @@ from uxarray.utils.computing import (
     two_prod,
     two_sum,
 )
+from uxarray.utils.numba_math import (
+    _numba_add3,
+    _numba_allfinite3,
+    _numba_mul3_scalar,
+    _numba_neg3,
+)
 
 # Edge screeners: fast O(n) passes used by Grid.get_edges_at_constant_* to
 # identify candidate edges before the expensive GCA intersection. "no_extreme"
@@ -252,7 +258,7 @@ def faces_within_lat_bounds(lats, face_bounds_lat):
 
 
 @njit(cache=True, inline="always", error_model="numpy")
-def _accux_gca(w00, w01, w02, w10, w11, w12, v00, v01, v02, v10, v11, v12):
+def _accux_gca(w0, w1, v0, v1):
     """Compute the candidate intersection points of two great-circle arcs.
 
     Pure numerical kernel (mirrors AccuSphGeom ``accux_gca``).
@@ -262,21 +268,21 @@ def _accux_gca(w00, w01, w02, w10, w11, w12, v00, v01, v02, v10, v11, v12):
 
     Parameters
     ----------
-    w00, w01, w02, w10, w11, w12 : float
+    w0, w1 : iterables of length 3
         Cartesian endpoints of the first arc.
-    v00, v01, v02, v10, v11, v12 : float
+    v0, v1 : iterables of length 3
         Cartesian endpoints of the second arc.
 
     Returns
     -------
-    pos_x, pos_y, pos_z, neg_x, neg_y, neg_z : float
+    pos, neg : tuples of length 3
         Two antipodal candidate unit vectors.
     """
     n1x_hi, n1y_hi, n1z_hi, n1x_lo, n1y_lo, n1z_lo = accucross(
-        w00, w01, w02, w10, w11, w12
+        w0[0], w0[1], w0[2], w1[0], w1[1], w1[2]
     )
     n2x_hi, n2y_hi, n2z_hi, n2x_lo, n2y_lo, n2z_lo = accucross(
-        v00, v01, v02, v10, v11, v12
+        v0[0], v0[1], v0[2], v1[0], v1[1], v1[2]
     )
     vx_hi, vy_hi, vz_hi, vx_lo, vy_lo, vz_lo = accucross_pair(
         n1x_hi,
@@ -300,42 +306,53 @@ def _accux_gca(w00, w01, w02, w10, w11, w12, v00, v01, v02, v10, v11, v12):
     sum_hi, sum_lo = _sum_of_squares_c((vx_hi, vy_hi, vz_hi), (vx_lo, vy_lo, vz_lo))
     vn, _ = acc_sqrt_re(sum_hi, sum_lo)
     # vn==0 (coplanar arcs) yields inf via IEEE division under error_model="numpy",
-    # so the candidates become non-finite and the status layer masks them out.
+    # so pos/neg become non-finite and the status layer masks them out.
     inv = 1.0 / vn
-    pos_x = vx * inv
-    pos_y = vy * inv
-    pos_z = vz * inv
-    return pos_x, pos_y, pos_z, -pos_x, -pos_y, -pos_z
+    pos = _numba_mul3_scalar((vx, vy, vz), inv)
+    neg = _numba_neg3(pos)
+    return pos, neg
 
 
 @njit(cache=True, inline="always", error_model="numpy")
-def _try_gca_gca_intersection(
-    w00, w01, w02, w10, w11, w12, v00, v01, v02, v10, v11, v12
-):
+def _try_gca_gca_intersection(w0, w1, v0, v1):
     """Select the valid great-circle intersection and report a status code.
+    Returns point, status, pos, neg.
 
     Batch/status layer (mirrors AccuSphGeom ``try_gca_gca_intersection``).
 
     Calls the pure numerical kernel, applies integer mask arithmetic to determine
     validity, selects the output point without if/else branching in the hot path.
 
-    Status codes mirror AccuSphGeom:
-        0  exactly one candidate is valid
-        1  both candidates are valid
-        2  neither candidate is valid  (includes coplanar/parallel case)
-    """
-    px, py, pz, ngx, ngy, ngz = _accux_gca(
-        w00, w01, w02, w10, w11, w12, v00, v01, v02, v10, v11, v12
-    )
+    Parameters
+    ----------
+    w0, w1 : iterables of length 3
+        Cartesian endpoints of the first arc.
+    v0, v1 : iterables of length 3
+        Cartesian endpoints of the second arc.
 
-    pos_fin = int(math.isfinite(px)) * int(math.isfinite(py)) * int(math.isfinite(pz))
-    neg_fin = (
-        int(math.isfinite(ngx)) * int(math.isfinite(ngy)) * int(math.isfinite(ngz))
-    )
-    pos_on_a = pos_fin * _on_minor_arc_xyz(px, py, pz, w00, w01, w02, w10, w11, w12)
-    pos_on_b = pos_fin * _on_minor_arc_xyz(px, py, pz, v00, v01, v02, v10, v11, v12)
-    neg_on_a = neg_fin * _on_minor_arc_xyz(ngx, ngy, ngz, w00, w01, w02, w10, w11, w12)
-    neg_on_b = neg_fin * _on_minor_arc_xyz(ngx, ngy, ngz, v00, v01, v02, v10, v11, v12)
+    Returns
+    -------
+    point : tuple of length 3
+        The single valid intersection point, if status == 0, else meaningless.
+    status : int
+        Status codes mirror AccuSphGeom:
+        0  exactly one candidate is valid (point)
+        1  both candidates are valid (pos and neg)
+        2  neither candidate is valid  (includes coplanar/parallel case)
+    pos : tuple of length 3
+        The positive candidate intersection point (antipodal to neg).
+    neg : tuple of length 3
+        The negative candidate intersection point (antipodal to pos).
+    """
+    pos, neg = _accux_gca(w0, w1, v0, v1)
+    _numba_allfinite3(pos)
+
+    pos_fin = _numba_allfinite3(pos)
+    neg_fin = _numba_allfinite3(neg)
+    pos_on_a = pos_fin * on_minor_arc(pos, w0, w1)
+    pos_on_b = pos_fin * on_minor_arc(pos, v0, v1)
+    neg_on_a = neg_fin * on_minor_arc(neg, w0, w1)
+    neg_on_b = neg_fin * on_minor_arc(neg, v0, v1)
 
     pos_valid = pos_fin * pos_on_a * pos_on_b
     neg_valid = neg_fin * neg_on_a * neg_on_b
@@ -343,14 +360,14 @@ def _try_gca_gca_intersection(
     pos_mask = pos_valid * (1 - neg_valid)
     neg_mask = neg_valid * (1 - pos_valid)
 
-    point_x = pos_mask * px + neg_mask * ngx
-    point_y = pos_mask * py + neg_mask * ngy
-    point_z = pos_mask * pz + neg_mask * ngz
+    point = _numba_add3(
+        _numba_mul3_scalar(pos, pos_mask), _numba_mul3_scalar(neg, neg_mask)
+    )
 
     both = pos_valid * neg_valid
     none = (1 - pos_valid) * (1 - neg_valid)
     status = both + none * 2
-    return point_x, point_y, point_z, status, px, py, pz, ngx, ngy, ngz
+    return point, status, pos, neg
 
 
 @njit(cache=True, error_model="numpy")
@@ -363,16 +380,18 @@ def gca_gca_intersection(gca_a_xyz, gca_b_xyz):
 
     Parameters
     ----------
-    gca_a_xyz : numpy.ndarray
-        First great-circle arc as two Cartesian endpoints, shape ``(2, 3)``.
-    gca_b_xyz : numpy.ndarray
-        Second great-circle arc as two Cartesian endpoints, shape ``(2, 3)``.
+    gca_a_xyz : iterable of 2 length-3 iterables
+        First great-circle arc as two Cartesian endpoints.
+        (If numpy array, has shape (2,3). If tuple, contains two length-3 tuples.)
+    gca_b_xyz : iterable of 2 length-3 iterables
+        Second great-circle arc as two Cartesian endpoints.
+        (If numpy array, has shape (2,3). If tuple, contains two length-3 tuples.)
 
     Returns
     -------
-    numpy.ndarray
-        Intersection points, shape ``(2, 3)``, with unused rows filled with NaN
-        (0, 1, or 2 valid rows).
+    intersections : tuple of 2 length-3 tuples
+        The (x,y,z) coordinates of the intersections, filling with NaNs as needed.
+        E.g. if there is one intersection, returns ((x1,y1,z1) (nan,nan,nan)).
 
     References
     ----------
@@ -385,67 +404,52 @@ def gca_gca_intersection(gca_a_xyz, gca_b_xyz):
     intersections on a sphere. SIAM Journal on Scientific Computing, 48(2),
     B208-B232. https://doi.org/10.1137/25M1737614
     """
-    if gca_a_xyz.shape[1] != 3 or gca_b_xyz.shape[1] != 3:
-        raise DimensionError("The two GCAs must be in the cartesian [x, y, z] format")
+    if len(gca_a_xyz) != 2 or len(gca_b_xyz) != 2:
+        raise DimensionError("Each input to gca_gca_intersection must have length 2")
+    if len(gca_a_xyz[0]) != 3 or len(gca_a_xyz[1]) != 3:
+        raise DimensionError(
+            "gca_a points must be in cartesian format (x,y,z), but got len(gca_a[0]) != 3"
+            "or len(gca_a[1]) != 3, in gca_gca_intersection(gca_a, gca_b)"
+        )
+    if len(gca_b_xyz[0]) != 3 or len(gca_b_xyz[1]) != 3:
+        raise DimensionError(
+            "gca_b points must be in cartesian format (x,y,z), but got len(gca_b[0]) != 3"
+            "or len(gca_b[1]) != 3, in gca_gca_intersection(gca_a, gca_b)"
+        )
 
-    # Unpack to scalars and run the allocation-free scalar chain.
-    w00 = gca_a_xyz[0, 0]
-    w01 = gca_a_xyz[0, 1]
-    w02 = gca_a_xyz[0, 2]
-    w10 = gca_a_xyz[1, 0]
-    w11 = gca_a_xyz[1, 1]
-    w12 = gca_a_xyz[1, 2]
-    v00 = gca_b_xyz[0, 0]
-    v01 = gca_b_xyz[0, 1]
-    v02 = gca_b_xyz[0, 2]
-    v10 = gca_b_xyz[1, 0]
-    v11 = gca_b_xyz[1, 1]
-    v12 = gca_b_xyz[1, 2]
+    w0 = gca_a_xyz[0]
+    w1 = gca_a_xyz[1]
+    v0 = gca_b_xyz[0]
+    v1 = gca_b_xyz[1]
 
-    (
-        point_x,
-        point_y,
-        point_z,
-        status,
-        pos_x,
-        pos_y,
-        pos_z,
-        neg_x,
-        neg_y,
-        neg_z,
-    ) = _try_gca_gca_intersection(
-        w00, w01, w02, w10, w11, w12, v00, v01, v02, v10, v11, v12
-    )
+    point, status, pos, neg = _try_gca_gca_intersection(w0, w1, v0, v1)
 
-    res = np.empty((2, 3))
-    count = 0
-    if status == 0:
-        res[0, 0] = point_x
-        res[0, 1] = point_y
-        res[0, 2] = point_z
-        count = 1
+    # Always return two points; branching logic changing output shape while
+    # using tuple outputs causes numba crash like "Can't unify return type".
+    # (And, swapping to tiny numpy array outputs causes significant slowdown.)
+    if status == 0:  # one intersection point
+        result = (point, (np.nan, np.nan, np.nan))
     elif status == 1:
-        res[0, 0] = pos_x
-        res[0, 1] = pos_y
-        res[0, 2] = pos_z
-        res[1, 0] = neg_x
-        res[1, 1] = neg_y
-        res[1, 2] = neg_z
-        count = 2
+        result = (pos, neg)
     else:
         # status == 2: no candidate on both arcs.
         # Check for coplanar overlap (shared endpoints) outside the kernel.
-        if _on_minor_arc_xyz(v00, v01, v02, w00, w01, w02, w10, w11, w12):
-            res[count, 0] = v00
-            res[count, 1] = v01
-            res[count, 2] = v02
-            count += 1
-        if _on_minor_arc_xyz(v10, v11, v12, w00, w01, w02, w10, w11, w12):
-            res[count, 0] = v10
-            res[count, 1] = v11
-            res[count, 2] = v12
-            count += 1
-    return res[:count]
+        v0_on_w_arc = on_minor_arc(v0, w0, w1)
+        v1_on_w_arc = on_minor_arc(v1, w0, w1)
+        if v0_on_w_arc or v1_on_w_arc:
+            # Ensure result will be (tuple,tuple), to avoid "Can't unify return type",
+            # which occurs if there is any chance of (array,tuple) or (array,array).
+            v0 = (v0[0], v0[1], v0[2])
+            v1 = (v1[0], v1[1], v1[2])
+            if v0_on_w_arc and v1_on_w_arc:
+                result = (v0, v1)
+            elif v0_on_w_arc:
+                result = (v0, (np.nan, np.nan, np.nan))
+            elif v1_on_w_arc:
+                result = (v1, (np.nan, np.nan, np.nan))
+        else:
+            result = ((np.nan, np.nan, np.nan), (np.nan, np.nan, np.nan))
+    return result
 
 
 @njit(cache=True, inline="always", error_model="numpy")

--- a/uxarray/grid/intersections.py
+++ b/uxarray/grid/intersections.py
@@ -345,7 +345,6 @@ def _try_gca_gca_intersection(w0, w1, v0, v1):
         The negative candidate intersection point (antipodal to pos).
     """
     pos, neg = _accux_gca(w0, w1, v0, v1)
-    _numba_allfinite3(pos)
 
     pos_fin = _numba_allfinite3(pos)
     neg_fin = _numba_allfinite3(neg)

--- a/uxarray/utils/numba_math.py
+++ b/uxarray/utils/numba_math.py
@@ -10,6 +10,8 @@ Creating lots of tiny numpy arrays (or lists) costs a lot in numba;
     See issue #1648 for more details.
 """
 
+import math
+
 import numpy as np
 from numba import njit
 
@@ -35,6 +37,12 @@ def _numba_sub3(u, v):
 
 
 # _numba_sub3_scalar not provided; just use _numba_add3_scalar with negative scalar
+
+
+@njit(cache=True)
+def _numba_neg3(u):
+    """component-wise negation of 3-vector; returns (-u[0], -u[1], -u[2])"""
+    return -u[0], -u[1], -u[2]
 
 
 @njit(cache=True)
@@ -104,3 +112,15 @@ def _numba_cross3(u, v):
     cy = u[2] * v[0] - u[0] * v[2]
     cz = u[0] * v[1] - u[1] * v[0]
     return (cx, cy, cz)
+
+
+# ------- convenience functions / helpers ------- #
+
+
+@njit(cache=True)
+def _numba_allfinite3(u):
+    """Return (as 1 or 0) whether all components of a 3-vector are finite (not NaN or Inf)."""
+    return (
+        int(math.isfinite(u[0])) * int(math.isfinite(u[1])) * int(math.isfinite(u[2]))
+    )
+    # (use `*` instead of `and` to avoid branching logic)


### PR DESCRIPTION
<!--  Thank you for opening a PR! To help us review your contribution, please follow instructions below
      while filling out this form, and read the etiquette reminders at the bottom. -->

<!--  Please ensure the PR title summarizes the changes, e.g. "Adds `Grid._build_face_dimension` function".
      Avoid non-descriptive titles such as "Addresses issue #229". -->

Closes #1726 (sub-issue of #1648)
<!--  Replace XXX with the issue number resolved by this PR, if this PR fully resolves an issue.
      If it resolves multiple issues, repeat "closes" for each, like "Closes #XXX, closes #YYY."
      If it does not fully resolve any issues, replace with something like "Related to #XXX",
          or "Fixes part of #YYY but does not fully close it." -->

## Overview
<!--  Please summarize the changes in this PR. How does it solve the original issue? -->
Optimizes numba routines in `uxarray/grid/intersections.py` to avoid constructing many tiny numpy arrays inside numba routines, as discussed in #1648. ASV benchmarks seem to show roughly 2x speedup of intersections algorithms, and no performance degradations. Hard to know for sure how gca_gca intersection performance has been affected because those benchmarks are failing on `main` right now (see discussion on #1688 for details), but the results here at least seem to be the right order of magnitude (roughly 1 μs; latest successes of these benchmarks on main were roughly 1 to 1.5μs).

Additionally, refactors the intersections.py routines to restore prior behavior (from before #1688 merged) of using 3-vector inputs and outputs where possible. To maintain performance improvements, just use tuples instead of allocating tiny numpy arrays. The discussion in PR 1688 clarified the intent was to restore to the pre-scalarized function interfaces where possible without sacrificing performance.

<!--  Does the scope of this PR do anything aside from just solving the original issue?
      And/or, does it not fully solve the issue as originally reported? If so, please clarify. -->
A few changes are within scope of the original issue but the reasoning is not necessarily obvious directly from inspecting the code diff; clarifying here:
- Previously, `gca_gca_intersection` output (len(result) == number of intersections) did not match its docstring, which promised shape (2,3) result but filling unused rows with NaNs. This PR updates the implementation to fill unused rows with NaNs, and _always_ return a tuple of 2 length-3 tuples, like ((x1,y1,z1),(x2,y2,z2)), filling with NaNs to represent nonexistent intersection points. (The consistent shape is necessary for the performance optimization here. Numba complains that it "Can't unify return type" if the output length depends on the number of intersections.) The test suite has been updated accordingly, to check for nans instead of len(result).
  - Also updated the docstring of `get_number_of_intersections` to clarify that it could now be applied to results from `gca_gca_intersection` too.
- Removes scalarized versions of methods where non-scalarized versions now suffice. I.e., removed `_accux_constlat_scalar` (use `_accux_constlat` instead), and `_snap_const_lat_endpoint_xy` (use `_snap_const_lat_endpoint` instead).  By using tuples instead of tiny numpy arrays, the "non-scalar" versions also avoid allocation costs, so there is no performance-related need to continue maintaining the scalarized versions.
- Similarly, updated arcs.py, removing `_on_minor_arc_xyz` by moving its logic into `on_minor_arc`, since the scalarized version wasn't being used anywhere anymore (except in benchmarking suite, which has been updated appropriately to use `on_minor_arc`). Updated `on_minor_arc` docstring to clarify inputs don't need to be numpy arrays; tuples of length 3 also work just fine.
- Improved various docstrings, updating docstrings where needed to explain new behavior, but also adding to existing docstrings to clarify meanings and expectations about inputs and outputs, and removing now-obsolete notes about preferring scalarized versions.


EDIT: discussions below revealed the need to incorporate the following changes, too:
- update the geometry_samebody.py and geometry_samebody_gcagca.py benchmarks files to keep the fp64 function performance in line with the optimizations to the corresponding functions from uxarray.
  - While doing that change, I also noticed and fixed: `_fp64_try_gca_gca_intersection` was using "and" instead of multiplying together 0s and 1s, so fp64 vs accux wasn't actually the only difference between it and intersections.py's `_try_gca_gca_intersection`.

EDIT: **minor expansions of scope** (requested in [comment below](https://github.com/UXARRAY/uxarray/pull/1727#pullrequestreview-5118426007)):
- Swapped np.max to np.nanmax in geometry_samebody_gcagca.py:274, to match the const-lat sibling at geometry_samebody.py:296.
- Swapped njit decorators for all _fp64 methods in geometry_samebody and geometry_samebody_gcagca benchmarks to exactly match decorators from intersections.py. This fix may help to resolve #1587(?)


## PR Checklist
<!-- Please mark each item as [X] when completed, or [N/A] if not applicable to this PR. -->

**General**
- [X] An issue is created and linked
- [X] Added appropriate labels (if your uxarray repo permissions allow it)
- [X] Filled out Overview and Expected Usage (if applicable) sections

**Testing & Benchmarking**
- [X] There is adequate test coverage of changes from this PR (add new tests if needed)
- [X] If this PR could affect performance, ran ASV benchmarks and confirmed they show expected behavior (add a new benchmark if necessary)
<!-- Adding the run-benchmark label (if your uxarray repo permissions allow it) will run ASV benchmarks.
    If you need benchmarks to be run but don't have permissions, leave this item unchecked for now. -->

**Documentation and Examples**
- [X] Docstrings updated with any function changes, and included in all new functions
- [X] User (public) functions added to `docs/api.rst`; internal (private) function names start with an underscore (`_`)
- [N/A] If touched any notebook files, cleared the output of all cells before committing
- [N/A] If added new notebook files, put into appropriate directories and referenced in appropriate files
<!-- For appropriate directories/files for notebooks, see
    https://uxarray.readthedocs.io/en/latest/contributing.html#usage-examples -->

## AI Disclosure
<!-- Please specify all AI tools used. Optionally, include model and/or briefly describe usage. Examples:
    "AI Usage: Claude (Fable 5), Gemini"
    "AI Usage: ChatGPT (5.5 Instant) to help understand cause of this bug, but I wrote all updates myself."
    "AI Usage: just GitHub Copilot's inline code suggestions."
    If you did not use AI, please write "AI Usage: N/A" and remove these checklist items or mark as [N/A].-->

AI Usage: GitHub Copilot's inline code suggestions, plus some Claude for numba debugging questions

- [X] I have tested and take responsibility for all AI-generated content in my PR.

<!-- **PR Etiquette Reminders**
- Please list as "draft PR" until ready for review.
- Please do NOT mark any review comment threads as resolved.
- Instead, please notify reviewers after addressing their comments, via @username or the "re-request review" button.
- (Reviewers: please mark your own threads as resolved after confirming your comments have been addressed.)
-->
