### PR TITLE
Fix isel() bugs: accept slices and boolean arrays, and do not smash input dict

### DIFF
--- a/test/core/test_indexing.py
+++ b/test/core/test_indexing.py
@@ -154,9 +154,11 @@ def test_isel_can_use_bool():
 def test_indexing_by_dataarray():
     """ensure isel() and sel() with indexer=xr.DataArray(...) both work as expected.
     The dims/coords of the Grid object should never incorporate indexer's dims/coords.
-    The dims/coords of the data object (UxDataArray or UxDataset)
-    should not incorporate the indexer's dims (this is already true),
+    The dims/coords of the data object (UxDataArray or UxDataset) should not incorporate
+    the indexer's dims when indexing along a grid dim (e.g. 'n_face') (this is already true),
     but should probably incorporate its coords (this isn't true yet; see issue #1712).
+
+    Regression test for bug in branch (fixed before merging to main) for PR 1729.
     """
     # ensure grid's dims/coords do not incorporate indexer's dims/coords:
     indexer0 = xr.DataArray(0, coords={"newcoord": 7})

--- a/test/core/test_indexing.py
+++ b/test/core/test_indexing.py
@@ -133,6 +133,23 @@ def test_sel_can_use_slice():
     # result = labeled_ds.sel(n_face=slice(0, 2))
     # assert result.n_face.size == result.uxgrid.n_face == 3
 
+def test_isel_can_use_bool():
+    """ensure isel() supports indexing by a boolean indexer array.
+    Regression test for #1728.
+    """
+    ds = ux.tutorial.open_dataset("quad-hexagon")
+    assert ds.isel(n_face=[True, False, False, False]).equals(ds.isel(n_face=0))
+    assert ds.isel(n_face=[False, True, False, True]).equals(ds.isel(n_face=[1,3]))
+    result = ds.isel(n_face=[False, False, False, False])
+    assert result.sizes['n_face'] == result.uxgrid.n_face == 0
+
+    # repeat tests but with UxDataArray:
+    arr = ds['t2m']
+    assert arr.isel(n_face=[True, False, False, False]).equals(arr.isel(n_face=0))
+    assert arr.isel(n_face=[False, True, False, True]).equals(arr.isel(n_face=[1,3]))
+    result = arr.isel(n_face=[False, False, False, False])
+    assert result.sizes['n_face'] == result.uxgrid.n_face == 0
+
 def test_sel_crash_if_provided_selection_options_with_coordless_dims():
     """ensure sel() crashes if providing `tolerance` and/or `method` options
     whenever any of the indexed dims have no associated coordinates.

--- a/test/core/test_indexing.py
+++ b/test/core/test_indexing.py
@@ -151,6 +151,53 @@ def test_isel_can_use_bool():
     result = arr.isel(n_face=[False, False, False, False])
     assert result.sizes['n_face'] == result.uxgrid.n_face == 0
 
+def test_indexing_by_dataarray():
+    """ensure isel() and sel() with indexer=xr.DataArray(...) both work as expected.
+    The dims/coords of the Grid object should never incorporate indexer's dims/coords.
+    The dims/coords of the data object (UxDataArray or UxDataset)
+    should not incorporate the indexer's dims (this is already true),
+    but should probably incorporate its coords (this isn't true yet; see issue #1712).
+    """
+    # ensure grid's dims/coords do not incorporate indexer's dims/coords:
+    indexer0 = xr.DataArray(0, coords={"newcoord": 7})
+    indexer1 = xr.DataArray([1,2], dims="newdim", coords={"newdim": [7,8]})
+    ds = ux.tutorial.open_dataset("quad-hexagon")
+    result0_isel = ds.isel(n_face=indexer0)
+    assert "newcoord" not in result0_isel.uxgrid._ds.coords
+    # assert "newcoord" in result0_isel.coords   # uncomment after fixing #1712
+    result0_sel = ds.sel(n_face=indexer0)
+    assert "newcoord" not in result0_sel.uxgrid._ds.coords
+    # assert "newcoord" in result0_sel.coords   # uncomment after fixing #1712
+    result1_isel = ds.isel(n_face=indexer1)
+    assert "newdim" not in result1_isel.uxgrid._ds.dims
+    assert "newdim" not in result1_isel.uxgrid._ds.coords
+    assert "newdim" not in result1_isel.dims and "n_face" in result1_isel.dims  # didn't rename 'n_face'.
+    # assert "newdim" in result1_isel.coords   # uncomment after fixing #1712
+    result1_sel = ds.sel(n_face=indexer1)
+    assert "newdim" not in result1_sel.uxgrid._ds.dims
+    assert "newdim" not in result1_sel.uxgrid._ds.coords
+    assert "newdim" not in result1_sel.dims and "n_face" in result1_sel.dims
+    # assert "newdim" in result1_sel.coords   # uncomment after fixing #1712
+
+    # repeat tests but with UxDataArray:
+    arr = ds['t2m']
+    result0_isel = arr.isel(n_face=indexer0)
+    assert "newcoord" not in result0_isel.uxgrid._ds.coords
+    # assert "newcoord" in result0_isel.coords
+    result0_sel = arr.sel(n_face=indexer0)
+    assert "newcoord" not in result0_sel.uxgrid._ds.coords
+    # assert "newcoord" in result0_sel.coords
+    result1_isel = arr.isel(n_face=indexer1)
+    assert "newdim" not in result1_isel.uxgrid._ds.dims
+    assert "newdim" not in result1_isel.uxgrid._ds.coords
+    assert "newdim" not in result1_isel.dims and "n_face" in result1_isel.dims
+    # assert "newdim" in result1_isel.coords
+    result1_sel = arr.sel(n_face=indexer1)
+    assert "newdim" not in result1_sel.uxgrid._ds.dims
+    assert "newdim" not in result1_sel.uxgrid._ds.coords
+    assert "newdim" not in result1_sel.dims and "n_face" in result1_sel.dims
+    # assert "newdim" in result1_sel.coords
+
 def test_indexing_does_not_edit_indexers_dict():
     """ensure isel() and sel() do not edit the provided indexers dict.
     Regression test for #1711.

--- a/test/core/test_indexing.py
+++ b/test/core/test_indexing.py
@@ -151,6 +151,36 @@ def test_isel_can_use_bool():
     result = arr.isel(n_face=[False, False, False, False])
     assert result.sizes['n_face'] == result.uxgrid.n_face == 0
 
+def test_indexing_does_not_edit_indexers_dict():
+    """ensure isel() and sel() do not edit the provided indexers dict.
+    Regression test for #1711.
+    """
+    ds = ux.tutorial.open_dataset('quad-hexagon')
+    choices = {'n_face': 0}
+    resultA = ds.isel(choices)
+    assert choices == {'n_face': 0}   # calling isel() should not modify the inputs!
+    resultB = ds.isel(choices)
+    assert resultA.equals(resultB)
+    resultA_sel = ds.sel(choices)
+    assert choices == {'n_face': 0}   # calling sel() should not modify the inputs!
+    resultB_sel = ds.sel(choices)
+    assert resultA_sel.equals(resultB_sel)
+
+    # repeat tests but with UxDataArray:
+    arr = ds['t2m']
+    choices = {'n_face': 0}
+    resultA = arr.isel(choices)
+    assert choices == {'n_face': 0}
+    resultB = arr.isel(choices)
+    assert resultA.equals(resultB)
+    resultA_sel = arr.sel(choices)
+    assert choices == {'n_face': 0}
+    resultB_sel = arr.sel(choices)
+    assert resultA_sel.equals(resultB_sel)
+
+
+# ------- tests related to error handling ------- #
+
 def test_isel_crash_if_2d_indexer():
     """ensure isel() crashes if an indexer along a grid dimension is 2D (or more)."""
     ds = ux.tutorial.open_dataset("quad-hexagon")

--- a/test/core/test_indexing.py
+++ b/test/core/test_indexing.py
@@ -9,6 +9,7 @@ to ensure consistency between UxDataArray and UxDataset indexing.)
 import numpy as np
 import pytest
 import uxarray as ux
+import xarray as xr
 
 def test_sel_indexes_grid():
     """ensure obj.sel({grid_dim: ...}) actually indexes the result.uxgrid, too,
@@ -149,6 +150,24 @@ def test_isel_can_use_bool():
     assert arr.isel(n_face=[False, True, False, True]).equals(arr.isel(n_face=[1,3]))
     result = arr.isel(n_face=[False, False, False, False])
     assert result.sizes['n_face'] == result.uxgrid.n_face == 0
+
+def test_isel_crash_if_2d_indexer():
+    """ensure isel() crashes if an indexer along a grid dimension is 2D (or more)."""
+    ds = ux.tutorial.open_dataset("quad-hexagon")
+    clever_indexer = xr.DataArray([[0,1,1],[2,3,3]], dims=["newdimA","newdimB"])
+    # (ensure clever_indexer is actually valid for xarray indexing purposes,
+    # otherwise the uxarray test would not be particularly meaningful.)
+    _tmp = ds.to_xarray().isel(n_face=clever_indexer)
+    assert _tmp.sizes == {'newdimA': 2, 'newdimB': 3}
+    assert _tmp.isel(newdimA=1, newdimB=0).equals(ds.to_xarray().isel(n_face=2))
+    # (now actually make sure that uxarray crashes with the same indexer)
+    with pytest.raises(ux.errors.DimensionError):
+        ds.isel(n_face=clever_indexer)
+
+    # repeat tests but with UxDataArray (no need to repeat the indexer check though)
+    arr = ds['t2m']
+    with pytest.raises(ux.errors.DimensionError):
+        arr.isel(n_face=clever_indexer)
 
 def test_sel_crash_if_provided_selection_options_with_coordless_dims():
     """ensure sel() crashes if providing `tolerance` and/or `method` options

--- a/test/core/test_indexing.py
+++ b/test/core/test_indexing.py
@@ -85,10 +85,30 @@ def test_can_index_grid_dim_not_in_data():
     result = arr.sel(n_edge=7)
     assert result.sizes["n_face"] == result.uxgrid.n_face == 2
 
+def test_isel_can_use_slice():
+    """ensure isel() can use slice() objects as indexers, and provides expected results,
+    with expected sizes, for UxDataArrays and UxDatasets.
+    Regression test for #1639.
+    """
+    ds = ux.tutorial.open_dataset("outCSne30-vortex")
+    result = ds.isel(n_face=slice(None, None, 10))  # should get every 10th face.
+    assert result.sizes['n_face'] == result.uxgrid.n_face == ds.sizes['n_face'] // 10
+    result = ds.isel(n_face=slice(2, 15, 3))  # should get faces 2, 5, 8, 11, 14
+    assert result.sizes['n_face'] == result.uxgrid.n_face == 5
+    assert result.equals(ds.isel(n_face=[2,5,8,11,14]))
+
+    # repeat tests but with UxDataArray:
+    arr = ds['psi']
+    result = arr.isel(n_face=slice(None, None, 10))  # should get every 10th face.
+    assert result.sizes['n_face'] == result.uxgrid.n_face == arr.sizes['n_face'] // 10
+    result = arr.isel(n_face=slice(2, 15, 3))
+    assert result.sizes['n_face'] == result.uxgrid.n_face == 5
+    assert result.equals(arr.isel(n_face=[2,5,8,11,14]))
+
 def test_sel_can_use_slice():
     """ensure sel() can use slice() objects as indexers, and provides expected results,
     with expected sizes, for UxDataArrays and UxDatasets.
-    Regression test inspired by reviewer comment in #1641.
+    Regression test inspired by reviewer comment in #1641, also related to #1639.
     TODO: fix #1714 then uncomment the relevant UxDataset tests below
     """
     grid = ux.Grid.from_healpix(zoom=0)  # 12 faces

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -1981,11 +1981,13 @@ class UxDataArray(xr.DataArray):
         The data is indexed, as well as the underlying grid when applicable.
 
         Grid dimensions ('n_node', 'n_edge', 'n_face') are treated specially
-        when `ignore_grid=False`. Providing one of them will slice to the specified
-        nodes, edges, or faces, regardless of data location. If the data does not
-        contain the specified dimension, the result will have the minimal grid
-        region containing everything specified. For example, using n_edge=7 for data
-        on 'n_face' makes a result with 'n_face' with just the two faces on edge 7.
+        when `ignore_grid=False` (this is the default). Any one of them can be indexed,
+        regardless of data location, and the result will be sliced to form the minimal grid
+        of faces containing all the nodes, edges, or faces specified. For example,
+        using n_edge=7 selects just the two faces touching edge 7. For data on 'n_face',
+        the result would have 'n_face' with just those two faces. For data on 'n_edge',
+        the result would have 'n_edge' with all edges located on either of those two faces.
+        Grid dimension indexers cannot have more than 1 dimension (such as a 2D DataArray).
 
         Parameters
         ----------
@@ -2078,12 +2080,13 @@ class UxDataArray(xr.DataArray):
     ):
         """Returns a new array indexed by labels, instead of indices, along the specified dimension(s).
 
-        Grid dimensions ('n_node', 'n_edge', 'n_face') are treated specially.
-        Providing one of them will slice to the specified nodes, edges, or faces,
-        regardless of data location. If the data does not contain the specified dimension,
-        the result will have the minimal grid region containing everything specified.
-        For example, using n_edge=7 for data on 'n_face' makes a result with 'n_face'
-        with just the two faces on edge 7.
+        Grid dimensions ('n_node', 'n_edge', 'n_face') are treated specially. Any one of them
+        can be indexed, regardless of data location, and the result will be sliced to form the
+        minimal grid of faces containing all the nodes, edges, or faces specified. For example,
+        using n_edge=7 selects just the two faces touching edge 7. For data on 'n_face',
+        the result would have 'n_face' with just those two faces. For data on 'n_edge',
+        the result would have 'n_edge' with all edges located on either of those two faces.
+        Grid dimension indexers cannot have more than 1 dimension (such as a 2D DataArray).
 
         By default, grid dims do not have coordinates assigned. But, if they have
         been assigned, `.sel()` respects them in the intuitive way. For example,
@@ -2284,17 +2287,17 @@ class UxDataArray(xr.DataArray):
 
         if self._face_centered():
             da_sliced = self.isel(
-                n_face=sliced_grid._ds["subgrid_face_indices"], ignore_grid=True
+                n_face=sliced_grid._ds["_subgrid_face_indices"], ignore_grid=True
             )
 
         elif self._edge_centered():
             da_sliced = self.isel(
-                n_edge=sliced_grid._ds["subgrid_edge_indices"], ignore_grid=True
+                n_edge=sliced_grid._ds["_subgrid_edge_indices"], ignore_grid=True
             )
 
         elif self._node_centered():
             da_sliced = self.isel(
-                n_node=sliced_grid._ds["subgrid_node_indices"], ignore_grid=True
+                n_node=sliced_grid._ds["_subgrid_node_indices"], ignore_grid=True
             )
 
         else:

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -2049,6 +2049,7 @@ class UxDataArray(xr.DataArray):
         elif len(grid_dims) == 1:
             # pop off the one grid‐dim indexer
             grid_dim = grid_dims.pop()
+            indexers = indexers.copy()  # don't modify the original dict
             grid_indexer = indexers.pop(grid_dim)
 
             sliced_grid = self.uxgrid.isel(

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -2189,10 +2189,6 @@ class UxDataArray(xr.DataArray):
                         f"for dimension {grid_dim!r} that has no associated coordinate or index"
                     )
                 grid_indices = grid_indexer
-                # temporary workaround for "isel fails with slice";
-                # remove the next two lines once issue #1639 gets fixed.
-                if isinstance(grid_indices, slice):
-                    grid_indices = range(*grid_indices.indices(self.sizes[grid_dim]))
 
             # offload the grid-indexing work to isel():
             result = self.isel({grid_dim: grid_indices}, drop=drop)

--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -641,10 +641,6 @@ class UxDataset(xr.Dataset):
                         f"for dimension {grid_dim!r} that has no associated coordinate or index"
                     )
                 grid_indices = grid_indexer
-                # temporary workaround for "isel fails with slice";
-                # remove the next two lines once issue #1639 gets fixed.
-                if isinstance(grid_indices, slice):
-                    grid_indices = range(*grid_indices.indices(self.sizes[grid_dim]))
 
             # offload the grid-indexing work to isel():
             result = self.isel({grid_dim: grid_indices}, drop=drop)

--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -429,11 +429,13 @@ class UxDataset(xr.Dataset):
         along with the underlying grid when applicable.
 
         Grid dimensions ('n_node', 'n_edge', 'n_face') are treated specially
-        when `ignore_grid=False`. Providing one of them will slice to the specified
-        nodes, edges, or faces, regardless of data location. If the data does not
-        contain the specified dimension, the result will have the minimal grid
-        region containing everything specified. For example, using n_edge=7 for data
-        on 'n_face' makes a result with 'n_face' with just the two faces on edge 7.
+        when `ignore_grid=False` (this is the default). Any one of them can be indexed,
+        regardless of data location, and the result will be sliced to form the minimal grid
+        of faces containing all the nodes, edges, or faces specified. For example,
+        using n_edge=7 selects just the two faces touching edge 7. For data on 'n_face',
+        the result would have 'n_face' with just those two faces. For data on 'n_edge',
+        the result would have 'n_edge' with all edges located on either of those two faces.
+        Grid dimension indexers cannot have more than 1 dimension (such as a 2D DataArray).
 
         Parameters
         ----------
@@ -528,12 +530,13 @@ class UxDataset(xr.Dataset):
         """Returns a new dataset with each array indexed by labels, instead of indices,
         along the specified dimension(s).
 
-        Grid dimensions ('n_node', 'n_edge', 'n_face') are treated specially.
-        Providing one of them will slice to the specified nodes, edges, or faces,
-        regardless of data location. If the data does not contain the specified dimension,
-        the result will have the minimal grid region containing everything specified.
-        For example, using n_edge=7 for data on 'n_face' makes a result with 'n_face'
-        with just the two faces on edge 7.
+        Grid dimensions ('n_node', 'n_edge', 'n_face') are treated specially. Any one of them
+        can be indexed, regardless of data location, and the result will be sliced to form the
+        minimal grid of faces containing all the nodes, edges, or faces specified. For example,
+        using n_edge=7 selects just the two faces touching edge 7. For data on 'n_face',
+        the result would have 'n_face' with just those two faces. For data on 'n_edge',
+        the result would have 'n_edge' with all edges located on either of those two faces.
+        Grid dimension indexers cannot have more than 1 dimension (such as a 2D DataArray).
 
         By default, grid dims do not have coordinates assigned. But, if they have
         been assigned, `.sel()` respects them in the intuitive way. For example,

--- a/uxarray/core/dataset.py
+++ b/uxarray/core/dataset.py
@@ -497,6 +497,7 @@ class UxDataset(xr.Dataset):
         elif len(grid_dims) == 1:
             # pop off the one grid‐dim indexer
             grid_dim = grid_dims.pop()
+            indexers = indexers.copy()  # don't modify the original dict
             grid_indexer = indexers.pop(grid_dim)
 
             # slice the grid

--- a/uxarray/grid/grid.py
+++ b/uxarray/grid/grid.py
@@ -2703,10 +2703,10 @@ class Grid:
         """Indexes an unstructured grid along a given dimension (``n_node``,
         ``n_edge``, or ``n_face``) and returns a new grid.
 
-        Currently only supports inclusive selection, meaning that for cases where node or edge indices are provided,
-        any face that contains that element is included in the resulting subset. This means that additional elements
-        beyond those that were initially provided in the indices will be included. Support for more methods, such as
-        exclusive and clipped indexing is in the works.
+        The indexing method is inclusive: for cases where node or edge indices are provided,
+        the result is formed by the subset of all faces which contain any of the indicated nodes or edges
+        (together with all nodes and edges which are present on any of those faces), which means
+        that the result may include additional elements beyond those explicitly requested.
 
         Parameters
         ----------

--- a/uxarray/grid/slice.py
+++ b/uxarray/grid/slice.py
@@ -139,7 +139,7 @@ def _slice_face_indices(
         face_indexer = np.array([indices])
     else:
         face_indexer = indices
-    # bookeeping: if 2D+, raise an error (the rest of this function assumes 1D)
+    # bookkeeping: if 2D+, raise an error (the rest of this function assumes 1D)
     if getattr(face_indexer, "ndim", 0) > 1:
         raise DimensionError(
             "Only 1D indexers are supported when slicing a grid. "
@@ -180,7 +180,7 @@ def _slice_face_indices(
 
     ds["_subgrid_node_indices"] = xr.DataArray(node_indices, dims=["n_node"])
     ds["_subgrid_face_indices"] = xr.DataArray(face_indices, dims=["n_face"])
-    # _subgrid_..._indices are used internaly in _slice_from_grid.
+    # _subgrid_..._indices are used internally in _slice_from_grid.
     # Caution: if performing multiple isel() operations, these indices map from the
     # latest operation only, not all the way back to the original grid.
     # E.g. grid.isel(n_face=[7,8,9]).isel(n_face=[0]) --> _subgrid_face_indices=[0], not [7].

--- a/uxarray/grid/slice.py
+++ b/uxarray/grid/slice.py
@@ -134,16 +134,21 @@ def _slice_face_indices(
     from uxarray.grid import Grid
 
     ds = grid._ds
+    # bookkeeping: convert scalar indexers to 1D arrays
     if _is_scalar_indexer(indices):
         face_indexer = np.array([indices])
     else:
         face_indexer = indices
-
+    # bookeeping: if 2D+, raise an error (the rest of this function assumes 1D)
     if getattr(face_indexer, "ndim", 0) > 1:
         raise DimensionError(
             "Only 1D indexers are supported when slicing a grid. "
             f"Got indexer.ndim={face_indexer.ndim} for indexer of type {type(face_indexer)}."
         )
+    # bookkeeping: convert DataArray indexers to their underlying data,
+    # to avoid altering dims/coords of grid._ds due to fancy xarray isel() behavior.
+    if isinstance(face_indexer, xr.DataArray):
+        face_indexer = face_indexer.data
 
     # face_indices from the original ds
     # (but still use face_indexer inside isel() below, for efficiency)

--- a/uxarray/grid/slice.py
+++ b/uxarray/grid/slice.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import numpy as np
 import xarray as xr
 
 from uxarray.constants import INT_DTYPE, INT_FILL_VALUE
-
-if TYPE_CHECKING:
-    pass
+from uxarray.errors import DimensionError
+from uxarray.utils.coords import _indices1d_from_indexing, _is_scalar_indexer
 
 # A dense lookup table remaps in O(1) per element, but costs O(n_node) / O(n_edge)
 # memory that is also captured by the Dask graph. It is only built when it stays
@@ -72,11 +69,7 @@ def _remap_kernel(orig_indices, size):
     return _remap_searchsorted, {"orig_indices": orig_indices}
 
 
-def _slice_node_indices(
-    grid,
-    indices,
-    inclusive=True,
-):
+def _slice_node_indices(grid, indices):
     """Slices (indexes) an unstructured grid given a list/array of node
     indices, returning a new Grid composed of elements that contain the nodes
     specified in the indices.
@@ -85,16 +78,9 @@ def _slice_node_indices(
     ----------
     grid : ux.Grid
         Source unstructured grid
-    indices: array-like
-        A list or 1-D array of node indices
-    inclusive: bool
-        Whether to perform inclusive (i.e. elements must contain at least one desired feature from a slice) as opposed
-        to exclusive (i.e elements be made up all desired features from a slice)
+    indices: integer, slice, array-like or DataArray
+        Indicates which node(s) to select. 2D+ indexers are not supported.
     """
-
-    if inclusive is False:
-        raise NotImplementedError("Exclusive slicing is not yet supported.")
-
     # faces that saddle nodes given in 'indices'
     face_indices = np.unique(
         grid.node_face_connectivity.isel(n_node=indices).values.ravel()
@@ -104,11 +90,7 @@ def _slice_node_indices(
     return _slice_face_indices(grid, face_indices)
 
 
-def _slice_edge_indices(
-    grid,
-    indices,
-    inclusive=True,
-):
+def _slice_edge_indices(grid, indices):
     """Slices (indexes) an unstructured grid given a list/array of edge
     indices, returning a new Grid composed of elements that contain the edges
     specified in the indices.
@@ -117,16 +99,9 @@ def _slice_edge_indices(
     ----------
     grid : ux.Grid
         Source unstructured grid
-    indices: array-like
-        A list or 1-D array of edge indices
-    inclusive: bool
-        Whether to perform inclusive (i.e. elements must contain at least one desired feature from a slice) as opposed
-        to exclusive (i.e elements be made up all desired features from a slice)
+    indices: integer, slice, array-like or DataArray
+        Indicates which edge(s) to select. 2D+ indexers are not supported.
     """
-
-    if inclusive is False:
-        raise NotImplementedError("Exclusive slicing is not yet supported.")
-
     # faces that saddle nodes given in 'indices'
     face_indices = np.unique(
         grid.edge_face_connectivity.isel(n_edge=indices).values.ravel()
@@ -139,7 +114,7 @@ def _slice_edge_indices(
 def _slice_face_indices(
     grid,
     indices,
-    inclusive=True,
+    *,
     inverse_indices: list[str] | set[str] | bool = False,
 ):
     """Slices (indexes) an unstructured grid given a list/array of face
@@ -150,49 +125,60 @@ def _slice_face_indices(
     ----------
     grid : ux.Grid
         Source unstructured grid
-    indices: array-like
-        A list or 1-D array of face indices
-    inclusive: bool
-        Whether to perform inclusive (i.e. elements must contain at least one desired feature from a slice) as opposed
-        to exclusive (i.e elements be made up all desired features from a slice)
+    indices: integer, slice, array-like or DataArray
+        Indicates which face(s) to select. 2D+ indexers are not supported.
     inverse_indices : list[str] | set[str] | bool, optional
         Indicates whether to store the original grids indices. Passing `True` stores the original face centers,
         other reverse indices can be stored by passing any or all of the following: (["face", "edge", "node"], True)
     """
     from uxarray.grid import Grid
 
-    if inclusive is False:
-        raise ValueError("Exclusive slicing is not yet supported.")
-
     ds = grid._ds
-    face_indices = np.atleast_1d(np.asarray(indices, dtype=INT_DTYPE))
+    if _is_scalar_indexer(indices):
+        face_indexer = np.array([indices])
+    else:
+        face_indexer = indices
+
+    if getattr(face_indexer, "ndim", 0) > 1:
+        raise DimensionError(
+            "Only 1D indexers are supported when slicing a grid. "
+            f"Got indexer.ndim={face_indexer.ndim} for indexer of type {type(face_indexer)}."
+        )
+
+    # face_indices from the original ds
+    # (but still use face_indexer inside isel() below, for efficiency)
+    face_indices = _indices1d_from_indexing(ds, "n_face", face_indexer)
 
     # nodes of each face (inclusive)
     node_indices = np.unique(
-        grid.face_node_connectivity.isel(n_face=face_indices).values.ravel()
+        grid.face_node_connectivity.isel(n_face=face_indexer).values.ravel()
     )
     node_indices = node_indices[node_indices != INT_FILL_VALUE]
 
     # Index Node and Face variables
     ds = ds.isel(n_node=node_indices)
-    ds = ds.isel(n_face=face_indices)
+    ds = ds.isel(n_face=face_indexer)
 
     # Only slice edge dimension if we have the face edge connectivity
     if "face_edge_connectivity" in ds:
         edge_indices = np.unique(
-            grid.face_edge_connectivity.isel(n_face=face_indices).values.ravel()
+            grid.face_edge_connectivity.isel(n_face=face_indexer).values.ravel()
         )
         edge_indices = edge_indices[edge_indices != INT_FILL_VALUE]
         ds = ds.isel(n_edge=edge_indices)
-        ds["subgrid_edge_indices"] = xr.DataArray(edge_indices, dims=["n_edge"])
+        ds["_subgrid_edge_indices"] = xr.DataArray(edge_indices, dims=["n_edge"])
     # Otherwise, drop any edge variables
     else:
         if "n_edge" in ds.dims:
             ds = ds.drop_dims(["n_edge"])
         edge_indices = None
 
-    ds["subgrid_node_indices"] = xr.DataArray(node_indices, dims=["n_node"])
-    ds["subgrid_face_indices"] = xr.DataArray(face_indices, dims=["n_face"])
+    ds["_subgrid_node_indices"] = xr.DataArray(node_indices, dims=["n_node"])
+    ds["_subgrid_face_indices"] = xr.DataArray(face_indices, dims=["n_face"])
+    # _subgrid_..._indices are used internaly in _slice_from_grid.
+    # Caution: if performing multiple isel() operations, these indices map from the
+    # latest operation only, not all the way back to the original grid.
+    # E.g. grid.isel(n_face=[7,8,9]).isel(n_face=[0]) --> _subgrid_face_indices=[0], not [7].
 
     # `node_indices` and `edge_indices` come out of `np.unique`, so both kernels
     # can rely on them being sorted and free of duplicates

--- a/uxarray/utils/coords.py
+++ b/uxarray/utils/coords.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import Hashable, Iterable, Mapping
 
+import numpy as np
 import xarray as xr
+import xarray.core.utils as xr_core_utils
 
 
 def _preserve_valid_coords(
@@ -52,3 +54,33 @@ def _preserve_valid_coords(
         and (dropped_dim is None or dropped_dim not in coord.dims)
         and (output_dims is None or set(coord.dims).issubset(output_dims))
     }
+
+
+def _is_scalar_indexer(ii):
+    """returns whether ii is a scalar indexer, e.g. a single integer.
+    (Usefulness, e.g.: help to ensure result of isel() will not drop any dims,
+    by using something like isel(dim=[ii] if _is_scalar_indexer(ii) else ii).
+    """
+    if isinstance(ii, slice):
+        return False
+    else:
+        return xr_core_utils.is_scalar(ii)
+
+
+def _indices1d_from_indexing(xarray_obj, dim, indexer):
+    """returns 1D numpy array of indices from applying `indexer` along `dim` of `xarray_obj`
+    (which can be a DataArray or Dataset).
+
+    Equivalent: np.arange(xarray_obj.sizes[dim])[indexer].
+    But, more efficient, especially for large dim sizes and small indexers.
+    (E.g. with size 1e7, indexer=[0,1,2,3], this method is ~20x faster than
+    the naive implementation using np.arange (~0.7ms versus ~15ms).)
+
+    `indexer` can be an integer, slice, array-like or DataArray.
+    (If scalar, it will be converted to 1D array.)
+    """
+    if _is_scalar_indexer(indexer):
+        indexer = np.array([indexer])
+    if dim in xarray_obj.coords:
+        xarray_obj = xarray_obj.drop_vars(dim)
+    return xarray_obj[dim].isel({dim: indexer}).values


### PR DESCRIPTION
<!--  Thank you for opening a PR! To help us review your contribution, please follow instructions below
      while filling out this form, and read the etiquette reminders at the bottom. -->

<!--  Please ensure the PR title summarizes the changes, e.g. "Adds `Grid._build_face_dimension` function".
      Avoid non-descriptive titles such as "Addresses issue #229". -->

Closes #1639, closes #1728
Closes #1711
<!--  Replace XXX with the issue number resolved by this PR, if this PR fully resolves an issue.
      If it resolves multiple issues, repeat "closes" for each, like "Closes #XXX, closes #YYY."
      If it does not fully resolve any issues, replace with something like "Related to #XXX",
          or "Fixes part of #YYY but does not fully close it." -->

## Overview
<!--  Please summarize the changes in this PR. How does it solve the original issue? -->
Mapping from changes in this PR to solved issues:
- The majority of the (non-docstring) code changes here contribute directly towards solving both issues #1728 and #1639; both were ultimately caused by the `_slice_face_indices` function in `uxarray/grid/slice.py` incorrectly attempting to convert all `indices` inputs via `np.atleast_1d(np.asarray(indices, dtype=INT_DTYPE))`. The `np.asarray` doesn't make sense for `slice` objects, while the `dtype=INT_DTYPE` doesn't make sense for boolean inputs.
- The fix for #1711 was simply to add the line `indexers = indexers.copy()  # don't modify the original dict` in the appropriate locations in UxDataArray.isel() and UxDataset.isel().

This PR also updates isel() and sel() docstrings to clarify something I previously misunderstood. Indexing grid dimensions does not actually care about data location at all; it instead always selects the minimal grid containing all nodes, edges, or faces specified. For example, if your data lives on "n_edge", indexing by n_edge=7 will not lead to a result with only edge 7. Instead, the result would be on the minimal grid containing edge 7, which is just the two faces touching edge 7 along with all of their edges and nodes. So, the result from selecting n_edge=7 will actually contain all edges from both of those two faces. The previous docstrings were not technically wrong, they were just maybe a bit misleading about this.

Added regression tests for all issues solved in this PR, and confirmed that all new regression tests fail on main but pass here.

<!--  Does the scope of this PR do anything aside from just solving the original issue?
      And/or, does it not fully solve the issue as originally reported? If so, please clarify. -->
**Minor expansions of PR scope:**
- Clarified in isel() and sel() docstrings that grid dimension indexers cannot have more than 1 dimension (such as a 2D DataArray). Using multi-dimensional indexers is supported along other dimensions, and can be a powerful xarray feature (toy example: `selected = data.isel(timesteps=xr.DataArray([[1,3,5],[4,5,6]], dims=['experiment_name', 't_index'], coords={'timestep_group_name': ['odd_timesteps_only', 'just_4_5_6']}; selected.mean('t_index')` gets the mean value of the data for each timestep group). However, supporting it for grid dimensions is not possible, due to the limit of only one Grid object attached to a given UxDataset or UxDataArray.
- Also created a clear DimensionError error message which occurs in case of 2D+ indexers (previously was getting `IndexError: Unlabeled multi-dimensional array cannot be used for indexing: n_face` but that was particularly misleading if providing a well-labeled xarray.DataArray). Added a test to ensure this case raises DimensionError.
- Removed the promise from Grid.isel docstring of "Support for more methods, such as exclusive and clipped indexing is in the works." Git blame shows this promise is more than 2.5 years old. Searching uxarray github issues with the word "inclusive" reveals no open (or closed!) issues about this topic.
- Similarly, removed the `inclusive=True` kwargs from the internal `_slice_node_indices`, `_slice_edge_indices`, and `_slice_face_indices` functions. Passing `inclusive=False` was never actually supported (it just raised NotImplementedError). This could be restored if `inclusive=False` indexing ever gets implemented, or maybe would implement entirely separate functions instead, but in the meantime there doesn't seem to be a compelling reason to keep it.

**Tiny expansion of PR scope:**
- Added leading underscore for values being cached to the grid's `_ds`: `_subgrid_node_indices`, `_subgrid_face_indices`, and `_subgrid_edge_indices`, along with comment to clarify these are only being used by `_slice_from_grid`, and that if multiple isel() operations are performed then these only reflect the indices from the latest one, not the indices relative to the original Grid.

## PR Checklist
<!-- Please mark each item as [X] when completed, or [N/A] if not applicable to this PR. -->

**General**
- [X] An issue is created and linked
- [X] Added appropriate labels (if your uxarray repo permissions allow it)
- [X] Filled out Overview and Expected Usage (if applicable) sections

**Testing & Benchmarking**
- [X] There is adequate test coverage of changes from this PR (add new tests if needed)
- [N/A] If this PR could affect performance, ran ASV benchmarks and confirmed they show expected behavior (add a new benchmark if necessary)
<!-- Adding the run-benchmark label (if your uxarray repo permissions allow it) will run ASV benchmarks.
    If you need benchmarks to be run but don't have permissions, leave this item unchecked for now. -->

**Documentation and Examples**
- [X] Docstrings updated with any function changes, and included in all new functions
- [X] User (public) functions added to `docs/api.rst`; internal (private) function names start with an underscore (`_`)
- [N/A] If touched any notebook files, cleared the output of all cells before committing
- [N/A] If added new notebook files, put into appropriate directories and referenced in appropriate files
<!-- For appropriate directories/files for notebooks, see
    https://uxarray.readthedocs.io/en/latest/contributing.html#usage-examples -->

## AI Disclosure
<!-- Please specify all AI tools used. Optionally, include model and/or briefly describe usage. Examples:
    "AI Usage: Claude (Fable 5), Gemini"
    "AI Usage: ChatGPT (5.5 Instant) to help understand cause of this bug, but I wrote all updates myself."
    "AI Usage: just GitHub Copilot's inline code suggestions."
    If you did not use AI, please write "AI Usage: N/A" and remove these checklist items or mark as [N/A].-->

AI Usage: Some Claude chats, plus GitHub Copilot's inline code suggestions

- [X] I have tested and take responsibility for all AI-generated content in my PR.

<!-- **PR Etiquette Reminders**
- Please list as "draft PR" until ready for review.
- Please do NOT mark any review comment threads as resolved.
- Instead, please notify reviewers after addressing their comments, via @username or the "re-request review" button.
- (Reviewers: please mark your own threads as resolved after confirming your comments have been addressed.)
-->
