### PR TITLE
Add Python 3.14 to the CI test matrix, and officially drop support for Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: [ "3.11", "3.12", "3.13"]
+        python-version: [ "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.13.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ classifiers=[
   "Topic :: Scientific/Engineering",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
@@ -18,7 +17,7 @@ description = "Xarray extension for unstructured climate and global weather data
 license = {file = "LICENSE"}
 name = "uxarray"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 
 # minimal dependencies start
 dependencies = [


### PR DESCRIPTION
Closes #1561

## Overview

Adds 3.14 to the CI matrix, which was the last open sub-task of #1561. #1563 already landed the classifier and the `numba>=0.63` floor, and the docs sub-task turned out to be a no-op since RTD builds from `ci/docs.yml` with an unpinned python.

Full test suite passes locally on Python 3.14.6 with numba 0.65.1 and numpy 2.4.6: 927 passed, 1 skipped. `ci/environment.yml` also solves on 3.14, including the pins most likely to block it (`matplotlib-base<3.11` from #1542, cartopy, scikit-learn, pyarrow).

Also drops the Python 3.10 claim from `requires-python` and the classifiers. The matrix has never tested 3.10, so that was an unverified claim. It is also no longer testable against the same stack as the other jobs: numpy and scipy now require >=3.12, and xarray, pandas, matplotlib, pyproj, and scikit-learn require >=3.11, so a 3.10 job would resolve pandas 2.x and a 14-month-old xarray. @Sevans711, this is the part worth pushing back on if you still want 3.10 kept until its October CPython EOL.

Job count goes from 9 to 12.

## PR Checklist

**General**
- [X] An issue is created and linked
- [X] Added appropriate labels (if your uxarray repo permissions allow it)
- [X] Filled out Overview and Expected Usage (if applicable) sections

**Testing & Benchmarking**
- [X] There is adequate test coverage of changes from this PR (add new tests if needed)
- [N/A] If this PR could affect performance, ran ASV benchmarks and confirmed they show expected behavior

**Documentation and Examples**
- [N/A] Docstrings updated with any function changes, and included in all new functions
- [N/A] User (public) functions added to `docs/api.rst`
- [N/A] If touched any notebook files, cleared the output of all cells before committing
- [N/A] If added new notebook files, put into appropriate directories and referenced in appropriate files

## AI Disclosure

AI Usage:

- [X] I have tested and take responsibility for all AI-generated content in my PR.

