### PR TITLE
Assigning connectivities based on UGRID conventions

### DIFF
--- a/test/io/test_ugrid.py
+++ b/test/io/test_ugrid.py
@@ -1,6 +1,5 @@
 import os
 import warnings
-import numpy as np
 import numpy.testing as nt
 import pytest
 import xarray as xr
@@ -10,76 +9,56 @@ from uxarray.constants import INT_DTYPE, INT_FILL_VALUE
 from uxarray.conventions import ugrid
 
 
-def test_edge_connectivity_dims_renamed_to_ugrid(gridpath):
-    """The trailing dimension of the edge connectivities is renamed to 'two'.
+def test_connectivity_dims_renamed_to_ugrid(gridpath):
+    """Every connectivity gets the trailing dimension the conventions give it.
 
-    FESOM2 mesh diagnostics are the UGRID file in the test suite that ships edge
-    connectivity, and it stores that dimension as 'n2'.
+    FESOM2 mesh diagnostics store that axis as 'n2' for the edge connectivities,
+    and share one size-3 dimension across all three face connectivities.
     """
     uxgrid = ux.open_grid(gridpath("ugrid", "fesom", "fesom.mesh.diag.nc"))
 
-    for conn_name in ("edge_node_connectivity", "edge_face_connectivity"):
-        assert conn_name in uxgrid._ds
+    present = [name for name in ugrid.CONNECTIVITY_NAMES if name in uxgrid._ds]
+    assert "edge_node_connectivity" in present
+    assert "face_edge_connectivity" in present
+
+    for conn_name in present:
         assert list(uxgrid._ds[conn_name].dims) == ugrid.CONNECTIVITY[conn_name]["dims"]
 
     assert "n2" not in uxgrid._ds.dims
     assert uxgrid._source_dims_dict["n2"] == "two"
 
-    # Out of scope on purpose: the face connectivities keep sharing the source
-    # file's single size-3 dimension, which is named after face_node_connectivity.
-    assert uxgrid._ds["face_edge_connectivity"].dims == ("n_face", "n_max_face_nodes")
 
+def test_shared_source_dim_split_per_connectivity(gridpath):
+    """One source dimension shared by several connectivities becomes several.
 
-def test_edge_connectivity_dims_renamed_for_any_source_name(tmp_path):
-    """The rename keys off the connectivity, not off a known set of dimension names.
-
-    UGRID does not prescribe dimension names, and the spec's own examples call
-    this axis 'Two'. Built here rather than added as a fixture so the test cannot
-    be mistaken for something FESOM-specific.
+    fesom.mesh.diag.nc stores face_nodes, face_edges and face_links all on a
+    single size-3 dimension 'n3'. Each has a different UGRID name, which one
+    swap_dims call cannot express, so the extras are renamed per variable.
     """
-    edge_nodes = np.array([[0, 1], [1, 2], [2, 0], [2, 3], [3, 0]], dtype=INT_DTYPE)
-    ds = xr.Dataset(
-        {
-            "Mesh2": xr.DataArray(
-                np.int32(-1),
-                attrs={
-                    "cf_role": "mesh_topology",
-                    "topology_dimension": np.int32(2),
-                    "node_coordinates": "Mesh2_node_x Mesh2_node_y",
-                    "face_node_connectivity": "Mesh2_face_nodes",
-                    "edge_node_connectivity": "Mesh2_edge_nodes",
-                    "face_dimension": "nMesh2_face",
-                    "edge_dimension": "nMesh2_edge",
-                },
-            ),
-            "Mesh2_node_x": xr.DataArray(
-                np.array([0.0, 1.0, 1.0, 0.0]), dims="nMesh2_node"
-            ),
-            "Mesh2_node_y": xr.DataArray(
-                np.array([0.0, 0.0, 1.0, 1.0]), dims="nMesh2_node"
-            ),
-            "Mesh2_face_nodes": xr.DataArray(
-                np.array([[0, 1, 2], [0, 2, 3]], dtype=INT_DTYPE),
-                dims=("nMesh2_face", "nMaxMesh2_face_nodes"),
-                attrs={"cf_role": "face_node_connectivity", "start_index": 0},
-            ),
-            "Mesh2_edge_nodes": xr.DataArray(
-                edge_nodes,
-                dims=("nMesh2_edge", "Two"),
-                attrs={"cf_role": "edge_node_connectivity", "start_index": 0},
-            ),
-        },
-        attrs={"Conventions": "UGRID-1.0"},
-    )
+    uxgrid = ux.open_grid(gridpath("ugrid", "fesom", "fesom.mesh.diag.nc"))
 
-    path = tmp_path / "spec_ugrid_mesh.nc"
-    ds.to_netcdf(path)
+    assert uxgrid._ds["face_node_connectivity"].dims == ("n_face", "n_max_face_nodes")
+    assert uxgrid._ds["face_edge_connectivity"].dims == ("n_face", "n_max_face_edges")
+    assert uxgrid._ds["face_face_connectivity"].dims == ("n_face", "n_max_face_faces")
 
-    uxgrid = ux.open_grid(path)
+    assert "n3" not in uxgrid._ds.dims
+    for dim in ("n_max_face_nodes", "n_max_face_edges", "n_max_face_faces"):
+        assert uxgrid._ds.sizes[dim] == 3
 
-    assert uxgrid._ds["edge_node_connectivity"].dims == ("n_edge", "two")
-    assert "Two" not in uxgrid._ds.dims
-    nt.assert_array_equal(uxgrid._ds["edge_node_connectivity"].values, edge_nodes)
+
+def test_shared_source_dim_claimed_by_face_node_connectivity(gridpath):
+    """Variables that are not connectivity keep the face_node name they had.
+
+    'n3' is also used by gradient_sca_x/y, which are ordinary data variables.
+    face_node_connectivity claims the dataset-wide rename so those keep
+    n_max_face_nodes rather than following whichever connectivity came first.
+    """
+    uxgrid = ux.open_grid(gridpath("ugrid", "fesom", "fesom.mesh.diag.nc"))
+
+    for var_name in ("gradient_sca_x", "gradient_sca_y"):
+        assert uxgrid._ds[var_name].dims == ("n_max_face_nodes", "n_face")
+
+    assert uxgrid._source_dims_dict["n3"] == "n_max_face_nodes"
 
 
 def test_read_ugrid(gridpath, mesh_constants):

--- a/test/io/test_ugrid.py
+++ b/test/io/test_ugrid.py
@@ -1,11 +1,85 @@
 import os
 import warnings
+import numpy as np
 import numpy.testing as nt
 import pytest
 import xarray as xr
 
 import uxarray as ux
 from uxarray.constants import INT_DTYPE, INT_FILL_VALUE
+from uxarray.conventions import ugrid
+
+
+def test_edge_connectivity_dims_renamed_to_ugrid(gridpath):
+    """The trailing dimension of the edge connectivities is renamed to 'two'.
+
+    FESOM2 mesh diagnostics are the UGRID file in the test suite that ships edge
+    connectivity, and it stores that dimension as 'n2'.
+    """
+    uxgrid = ux.open_grid(gridpath("ugrid", "fesom", "fesom.mesh.diag.nc"))
+
+    for conn_name in ("edge_node_connectivity", "edge_face_connectivity"):
+        assert conn_name in uxgrid._ds
+        assert list(uxgrid._ds[conn_name].dims) == ugrid.CONNECTIVITY[conn_name]["dims"]
+
+    assert "n2" not in uxgrid._ds.dims
+    assert uxgrid._source_dims_dict["n2"] == "two"
+
+    # Out of scope on purpose: the face connectivities keep sharing the source
+    # file's single size-3 dimension, which is named after face_node_connectivity.
+    assert uxgrid._ds["face_edge_connectivity"].dims == ("n_face", "n_max_face_nodes")
+
+
+def test_edge_connectivity_dims_renamed_for_any_source_name(tmp_path):
+    """The rename keys off the connectivity, not off a known set of dimension names.
+
+    UGRID does not prescribe dimension names, and the spec's own examples call
+    this axis 'Two'. Built here rather than added as a fixture so the test cannot
+    be mistaken for something FESOM-specific.
+    """
+    edge_nodes = np.array([[0, 1], [1, 2], [2, 0], [2, 3], [3, 0]], dtype=INT_DTYPE)
+    ds = xr.Dataset(
+        {
+            "Mesh2": xr.DataArray(
+                np.int32(-1),
+                attrs={
+                    "cf_role": "mesh_topology",
+                    "topology_dimension": np.int32(2),
+                    "node_coordinates": "Mesh2_node_x Mesh2_node_y",
+                    "face_node_connectivity": "Mesh2_face_nodes",
+                    "edge_node_connectivity": "Mesh2_edge_nodes",
+                    "face_dimension": "nMesh2_face",
+                    "edge_dimension": "nMesh2_edge",
+                },
+            ),
+            "Mesh2_node_x": xr.DataArray(
+                np.array([0.0, 1.0, 1.0, 0.0]), dims="nMesh2_node"
+            ),
+            "Mesh2_node_y": xr.DataArray(
+                np.array([0.0, 0.0, 1.0, 1.0]), dims="nMesh2_node"
+            ),
+            "Mesh2_face_nodes": xr.DataArray(
+                np.array([[0, 1, 2], [0, 2, 3]], dtype=INT_DTYPE),
+                dims=("nMesh2_face", "nMaxMesh2_face_nodes"),
+                attrs={"cf_role": "face_node_connectivity", "start_index": 0},
+            ),
+            "Mesh2_edge_nodes": xr.DataArray(
+                edge_nodes,
+                dims=("nMesh2_edge", "Two"),
+                attrs={"cf_role": "edge_node_connectivity", "start_index": 0},
+            ),
+        },
+        attrs={"Conventions": "UGRID-1.0"},
+    )
+
+    path = tmp_path / "spec_ugrid_mesh.nc"
+    ds.to_netcdf(path)
+
+    uxgrid = ux.open_grid(path)
+
+    assert uxgrid._ds["edge_node_connectivity"].dims == ("n_edge", "two")
+    assert "Two" not in uxgrid._ds.dims
+    nt.assert_array_equal(uxgrid._ds["edge_node_connectivity"].values, edge_nodes)
 
 
 def test_read_ugrid(gridpath, mesh_constants):

--- a/uxarray/io/_ugrid.py
+++ b/uxarray/io/_ugrid.py
@@ -80,6 +80,18 @@ def _read_ugrid(ds):
 
     dim_dict[ds["face_node_connectivity"].dims[1]] = ugrid.N_MAX_FACE_NODES_DIM
 
+    # The core dims above do not cover the trailing dimension of the edge
+    # connectivities, so a source file keeps whatever it called that axis unless
+    # it is mapped here. edge_node_connectivity and edge_face_connectivity both
+    # assign that dimension the name "two".
+    for conn_name in ("edge_node_connectivity", "edge_face_connectivity"):
+        if conn_name in conn_dict.values():
+            # map this file's name for the axis onto "two", unless already mapped
+            dim_dict.setdefault(
+                ds[conn_name].dims[1], ugrid.CONNECTIVITY[conn_name]["dims"][1]
+            )
+
+    # rename every source dimension collected above to its UGRID name in one pass
     ds = ds.swap_dims(dim_dict)
 
     return ds, dim_dict

--- a/uxarray/io/_ugrid.py
+++ b/uxarray/io/_ugrid.py
@@ -78,21 +78,53 @@ def _read_ugrid(ds):
             if dims[1] == grid_dim:
                 ds[conn_name] = da.T
 
-    dim_dict[ds["face_node_connectivity"].dims[1]] = ugrid.N_MAX_FACE_NODES_DIM
+    # The core dims cover only each connectivity's grid element axis; the trailing
+    # axis still carries whatever the file called it. One source dimension can
+    # serve several connectivities that want different names (FESOM shares one
+    # size-3 dim across all three face connectivities), and dim_dict holds only
+    # one name per dimension, so the first claim renames it dataset-wide and the
+    # rest are renamed per variable below. face_node_connectivity claims first so
+    # that variables which are not connectivity keep n_max_face_nodes.
+    core_dims = set(dim_dict)  # snapshot before the loop starts adding to it
 
-    # The core dims above do not cover the trailing dimension of the edge
-    # connectivities, so a source file keeps whatever it called that axis unless
-    # it is mapped here. edge_node_connectivity and edge_face_connectivity both
-    # assign that dimension the name "two".
-    for conn_name in ("edge_node_connectivity", "edge_face_connectivity"):
-        if conn_name in conn_dict.values():
-            # map this file's name for the axis onto "two", unless already mapped
-            dim_dict.setdefault(
-                ds[conn_name].dims[1], ugrid.CONNECTIVITY[conn_name]["dims"][1]
-            )
+    # every connectivity, face_node first
+    claim_order = ["face_node_connectivity"] + [
+        name for name in ugrid.CONNECTIVITY_NAMES if name != "face_node_connectivity"
+    ]
 
-    # rename every source dimension collected above to its UGRID name in one pass
+    # the connectivities this file actually has
+    present_conn_names = set(conn_dict.values())
+
+    # conn name -> {current dim name: wanted dim name}, applied after swap_dims
+    per_var_dim_dict = {}
+    for conn_name in claim_order:
+        if conn_name not in present_conn_names:
+            continue
+
+        # the file's name for this connectivity's trailing axis, e.g. 'n2'
+        source_dim = ds[conn_name].dims[1]
+        if source_dim in core_dims:
+            continue  # malformed file: a core dim in the trailing slot
+
+        # the name the conventions give that axis, e.g. 'two'
+        ugrid_dim = ugrid.CONNECTIVITY[conn_name]["dims"][1]
+
+        if source_dim not in dim_dict:
+            dim_dict[source_dim] = ugrid_dim  # unclaimed, so rename dataset-wide
+        elif dim_dict[source_dim] != ugrid_dim:
+            # claimed by an earlier connectivity under a different name, so this
+            # one is renamed on its own. swap_dims runs first, hence the key is
+            # the name that claim already gave the dimension.
+            per_var_dim_dict[conn_name] = {dim_dict[source_dim]: ugrid_dim}
+
     ds = ds.swap_dims(dim_dict)
+
+    # the claims dim_dict had no room for: same dimension, a different name.
+    # swap_dims just renamed FESOM's n3 to n_max_face_nodes everywhere; this then
+    # gives face_edge_connectivity its own n_max_face_edges, and likewise
+    # face_face_connectivity its own n_max_face_faces.
+    for conn_name, rename_dict in per_var_dim_dict.items():
+        ds[conn_name] = ds[conn_name].rename(rename_dict)
 
     return ds, dim_dict
 


### PR DESCRIPTION
Closes #1717 
Closes #1725
**Why two in one?** The reason for closing both in one PR is due to them being caused by the same problem. Having 3 dimensions in pre-existing connectivities results in `swap_dims` quietly breaking, causing both the issues seen above. By applying some cleaning both before and after `swap_dims` is called, both issues are solved together. As far as I can see, there is no evidence we would see one of the above errors without the other, and since the solution is in the same location, we may as well solve it once and here. Originally I solved the first one alone, but solving the 2nd would basically require deleting the whole original solution, and replacing it with a more general one. So rather than pushing 1 solution to main, deleting it, and pushing another, I say we just push this single refined solution (assuming it works as intended)

## Overview

`_read_ugrid` renamed the trailing dimension of `face_node_connectivity` to `n_max_face_nodes` and left every other connectivity's equivalent dimension as whatever the source file called it. Reading `fesom.mesh.diag.nc`, which names those axes `n3` and `n2`:

| Connectivity | File's name for the axis | dims Before | dims After |
|---|---|---|---|
| `face_node_connectivity` | `n3` | `('n_face', 'n_max_face_nodes')` | unchanged |
| `face_edge_connectivity` | `n3` | `('n_face', 'n_max_face_nodes')` | `('n_face', 'n_max_face_edges')` |
| `face_face_connectivity` | `n3` | `('n_face', 'n_max_face_nodes')` | `('n_face', 'n_max_face_faces')` |
| `edge_node_connectivity` | `n2` | `('n_edge', 'n2')` | `('n_edge', 'two')` |
| `edge_face_connectivity` | `n2` | `('n_edge', 'n2')` | `('n_edge', 'two')` |

Each connectivity's trailing dimension is now mapped to the name `ugrid.CONNECTIVITY` gives it, rather than one being hardcoded and the rest left alone. In this FESOM file (which is read in through the UGRID path) it uses one size-3 `n3` for all three face connectivities. `swap_dims` call cannot express all 3, so the first connectivity renames it for the whole dataset and the remainder are renamed per variable. `face_node_connectivity` is first, so variables that are not connectivity all get `n_max_face_nodes`

## Expected Usage

```Python
import uxarray as ux

uxgrid = ux.open_grid("fesom.mesh.diag.nc")

# the edge connectivities carried the file's own name for the trailing axis
uxgrid.edge_node_connectivity.dims
# before: ('n_edge', 'n2')
# after:  ('n_edge', 'two')

uxgrid.edge_face_connectivity.dims
# before: ('n_edge', 'n2')
# after:  ('n_edge', 'two')

# the face connectivities all shared one size-3 dimension
uxgrid.face_edge_connectivity.dims
# before: ('n_face', 'n_max_face_nodes')
# after:  ('n_face', 'n_max_face_edges')

# so indexing those axes by name now works
uxgrid.edge_node_connectivity.isel(two=0)
# before: ValueError: Dimensions {'two'} do not exist
# after:  the first node of every edge
```

## PR Checklist

**General**
- [X] An issue is created and linked
- [X] Added appropriate labels (if your uxarray repo permissions allow it)
- [X] Filled out Overview and Expected Usage (if applicable) sections

**Testing & Benchmarking**
- [X] There is adequate test coverage of changes from this PR (add new tests if needed)
- [X] If this PR could affect performance, ran ASV benchmarks and confirmed they show expected behavior (add a new benchmark if necessary)

**Documentation and Examples**
- [N/A] Docstrings updated with any function changes, and included in all new functions
- [N/A] User (public) functions added to `docs/api.rst`; internal (private) function names start with an underscore (`_`)
- [N/A] If touched any notebook files, cleared the output of all cells before committing
- [N/A] If added new notebook files, put into appropriate directories and referenced in appropriate files

## AI Disclosure

AI Usage: Claude

- [X] I have tested and take responsibility for all AI-generated content in my PR.

