### PR TITLE
Fix ESMF encode truncating the fill value into a valid node index

### DIFF
--- a/test/io/test_esmf.py
+++ b/test/io/test_esmf.py
@@ -3,7 +3,7 @@ import os
 import pytest
 import xarray as xr
 import numpy as np
-from uxarray.constants import ERROR_TOLERANCE
+from uxarray.constants import ERROR_TOLERANCE, INT_FILL_VALUE
 
 
 def test_read_esmf(gridpath):
@@ -103,3 +103,48 @@ def test_esmf_round_trip_consistency(gridpath):
         # Clean up temporary test file
         if os.path.exists(esmf_filepath):
             os.remove(esmf_filepath)
+
+
+def test_encode_esmf_ragged_indices_are_usable(tmp_path):
+    """Every index written to elementConn names a real node or is the fill value.
+
+    `elementConn` is encoded as int32. Offsetting INT_FILL_VALUE along with the
+    valid indices leaves `-2**63 + 1` in the padded slots, which the narrowing
+    truncates to `1` -- node 0, indistinguishable from a real vertex to any
+    reader. Nothing raises, so check the encoded output rather than a round trip.
+    """
+    uxgrid = ux.Grid.from_topology(
+        node_lon=np.array([0.0, 10.0, 10.0, 0.0, 20.0]),
+        node_lat=np.array([0.0, 0.0, 10.0, 10.0, 0.0]),
+        face_node_connectivity=np.array([
+            [0, 1, 2, 3],
+            [1, 4, 2, INT_FILL_VALUE],
+            [0, 3, 4, INT_FILL_VALUE],
+        ]),
+        fill_value=INT_FILL_VALUE,
+    )
+
+    # The padded slots are exactly the ones numElementConn reports as unused
+    is_padding = np.array([
+        [False, False, False, False],
+        [False, False, False, True],
+        [False, False, False, True],
+    ])
+
+    encoded = uxgrid.to_xarray("ESMF")
+    assert encoded["elementConn"].attrs["_FillValue"] == -1
+    np.testing.assert_array_equal(encoded["elementConn"].values == -1, is_padding)
+    np.testing.assert_array_equal(encoded["numElementConn"].values, [4, 3, 3])
+
+    # Check what actually lands on disk: the fill value has to survive int32
+    path = tmp_path / "esmf_ragged.nc"
+    encoded.to_netcdf(path)
+    with xr.open_dataset(path, mask_and_scale=False) as ds:
+        on_disk = ds["elementConn"].values
+
+    assert on_disk.dtype == np.int32
+    np.testing.assert_array_equal(on_disk == -1, is_padding)
+
+    valid = on_disk[~is_padding]
+    assert valid.min() >= 1, "elementConn holds an index below 1"
+    assert valid.max() <= uxgrid.n_node, "elementConn indexes a node that does not exist"

--- a/uxarray/io/_esmf.py
+++ b/uxarray/io/_esmf.py
@@ -144,8 +144,17 @@ def _encode_esmf(ds: xr.Dataset) -> xr.Dataset:
     # Face Node Connectivity (elementConn)
     if "face_node_connectivity" in ds:
         # ESMF elementConn is 1-based, with -1 for unused; UGRID is 0-based
+        face_node_conn = ds["face_node_connectivity"]
+
+        # Only offset the valid indices. Applying the offset to INT_FILL_VALUE and
+        # letting it fall through to the int32 encoding below truncates it into a
+        # small, valid node index, silently turning padding into real vertices.
+        element_conn = xr.where(
+            face_node_conn == INT_FILL_VALUE, -1, face_node_conn + 1
+        )
+
         out_ds["elementConn"] = xr.DataArray(
-            ds["face_node_connectivity"] + 1,
+            element_conn,
             dims=("elementCount", "maxNodePElement"),
             attrs={
                 "long_name": "Node Indices that define the element connectivity",


### PR DESCRIPTION
<!--  Thank you for opening a PR! To help us review your contribution, please follow instructions below
      while filling out this form, and read the etiquette reminders at the bottom. -->

<!--  Please ensure the PR title summarizes the changes, e.g. "Adds `Grid._build_face_dimension` function".
      Avoid non-descriptive titles such as "Addresses issue #229". -->

Closes #1745
<!--  Replace XXX with the issue number resolved by this PR, if this PR fully resolves an issue.
      If it resolves multiple issues, repeat "closes" for each, like "Closes #XXX, closes #YYY."
      If it does not fully resolve any issues, replace with something like "Related to #XXX",
          or "Fixes part of #YYY but does not fully close it." -->

## Overview
<!--  Please summarize the changes in this PR. How does it solve the original issue? -->

_encode_esmf applies the UGRID→ESMF index offset to the whole face_node_connectivity array, padding included, and then encodes elementConn as int32. INT_FILL_VALUE + 1 is -2**63 + 1, and narrowing that to int32 truncates it to 1, so every padded slot of a ragged mesh is written to disk as node 0.

Nothing raises, and the resulting file is structurally valid, so any reader — including uxarray's own — takes those slots for real vertices. Faces gain spurious extra nodes and produce incorrect polygons. This is the case that originally surfaced this family of bugs.

The fix offsets only the valid indices and writes ESMF's own -1 into the padding, which is what the variable's _FillValue attribute already advertises. The test asserts on the encoded array and on what lands on disk after the int32 narrowing, rather than on a round trip: a round trip can hide an encode bug when the reader's inverse offset happens to cancel it.



<!--  Does the scope of this PR do anything aside from just solving the original issue?
      And/or, does it not fully solve the issue as originally reported? If so, please clarify. -->



## PR Checklist
<!-- Please mark each item as [X] when completed, or [N/A] if not applicable to this PR. -->

**General**
- [x] An issue is created and linked
- [x] Added appropriate labels (if your uxarray repo permissions allow it)
- [x] Filled out Overview and Expected Usage (if applicable) sections

**Testing & Benchmarking**
- [x] There is adequate test coverage of changes from this PR (add new tests if needed)

**Documentation and Examples**
- [x] Docstrings updated with any function changes, and included in all new functions

## AI Disclosure
<!-- Please specify all AI tools used. Optionally, include model and/or briefly describe usage. Examples:
    "AI Usage: Claude (Fable 5), Gemini"
    "AI Usage: ChatGPT (5.5 Instant) to help understand cause of this bug, but I wrote all updates myself."
    "AI Usage: just GitHub Copilot's inline code suggestions."
    If you did not use AI, please write "AI Usage: N/A" and remove these checklist items or mark as [N/A].-->

AI Usage: Claude Opus 5

- [x] I have tested and take responsibility for all AI-generated content in my PR.

<!-- **PR Etiquette Reminders**
- Please list as "draft PR" until ready for review.
- Please do NOT mark any review comment threads as resolved.
- Instead, please notify reviewers after addressing their comments, via @username or the "re-request review" button.
- (Reviewers: please mark your own threads as resolved after confirming your comments have been addressed.)
-->
