### PR TITLE
Fix ESMF read casting `elementConn` before checking for padding

### DIFF
--- a/test/io/test_esmf.py
+++ b/test/io/test_esmf.py
@@ -3,7 +3,7 @@ import os
 import pytest
 import xarray as xr
 import numpy as np
-from uxarray.constants import ERROR_TOLERANCE
+from uxarray.constants import ERROR_TOLERANCE, INT_FILL_VALUE
 
 
 def test_read_esmf(gridpath):
@@ -34,6 +34,58 @@ def test_read_esmf_dataset(gridpath, datasetpath):
 
     for dim in dims:
         assert dim in uxds.dims
+
+@pytest.mark.parametrize("mask_and_scale", [True, False])
+def test_read_esmf_padding_independent_of_cf_decoding(mask_and_scale, tmp_path):
+    """Padding is recognized whether or not xarray decoded the fill value.
+
+    ESMF pads a short face in `elementConn` with that variable's `_FillValue`.
+    With CF decoding on, xarray replaces it with NaN and promotes the array to
+    float; with decoding off, the raw -1 comes through. Casting first and checking
+    for INT_FILL_VALUE afterwards recognizes neither: the raw -1 becomes the index
+    -2, and the NaN cast is platform-dependent -- arm64 gives 0, so the padding
+    decodes to -1, a negative index that silently wraps to the last node.
+
+    So the padding has to be located before the cast, from `numElementConn`.
+    """
+    node_lon = np.array([0.0, 10.0, 10.0, 0.0, 20.0])
+    node_lat = np.array([0.0, 0.0, 10.0, 10.0, 0.0])
+
+    # 1-based and -1 padded, as ESMF specifies: one quad and two triangles
+    in_ds = xr.Dataset(
+        {
+            "nodeCoords": xr.DataArray(
+                np.column_stack([node_lon, node_lat]),
+                dims=("nodeCount", "coordDim"),
+                attrs={"units": "degrees"},
+            ),
+            "elementConn": xr.DataArray(
+                np.array([[1, 2, 3, 4], [2, 5, 3, -1], [1, 4, 5, -1]], dtype=np.int32),
+                dims=("elementCount", "maxNodePElement"),
+                attrs={"_FillValue": np.int32(-1)},
+            ),
+            "numElementConn": xr.DataArray(
+                np.array([4, 3, 3], dtype=np.byte), dims="elementCount"
+            ),
+        }
+    )
+
+    path = tmp_path / "esmf_ragged.nc"
+    in_ds.to_netcdf(path)
+
+    with xr.open_dataset(path, mask_and_scale=mask_and_scale) as raw:
+        uxgrid = ux.open_grid(raw)
+
+    np.testing.assert_array_equal(
+        uxgrid.face_node_connectivity.values,
+        np.array([
+            [0, 1, 2, 3],
+            [1, 4, 2, INT_FILL_VALUE],
+            [0, 3, 4, INT_FILL_VALUE],
+        ]),
+    )
+    np.testing.assert_array_equal(uxgrid.n_nodes_per_face.values, [4, 3, 3])
+    assert uxgrid.n_node == 5
 
 def test_esmf_round_trip_consistency(gridpath):
     """Test round-trip serialization of grid objects through ESMF xarray format.

--- a/uxarray/io/_esmf.py
+++ b/uxarray/io/_esmf.py
@@ -93,12 +93,22 @@ def _read_esmf(in_ds):
         # assume start index is 1 if one is not provided
         start_index = 1
 
-    face_node_connectivity = in_ds["elementConn"].astype(INT_DTYPE)
-    face_node_connectivity = xr.where(
-        face_node_connectivity != INT_FILL_VALUE,
-        face_node_connectivity - start_index,
-        face_node_connectivity,
+    element_conn = in_ds["elementConn"]
+    face_dim, node_dim = element_conn.dims
+
+    # "numElementConn" gives the face size, so locate the padding positionally.
+    # Matching the sentinel means guessing: CF decoding turns it into NaN, and the
+    # cast below preserves neither NaN nor the raw value as INT_FILL_VALUE.
+    positions = xr.DataArray(
+        np.arange(element_conn.sizes[node_dim], dtype=INT_DTYPE), dims=node_dim
     )
+    fill_mask = (positions >= n_nodes_per_face).transpose(face_dim, node_dim)
+
+    # NaN is never a usable index, whatever "numElementConn" claims
+    fill_mask = fill_mask | element_conn.isnull()
+
+    face_node_connectivity = element_conn.fillna(0).astype(INT_DTYPE) - start_index
+    face_node_connectivity = xr.where(fill_mask, INT_FILL_VALUE, face_node_connectivity)
 
     out_ds["face_node_connectivity"] = xr.DataArray(
         data=face_node_connectivity,


### PR DESCRIPTION
<!--  Thank you for opening a PR! To help us review your contribution, please follow instructions below
      while filling out this form, and read the etiquette reminders at the bottom. -->

<!--  Please ensure the PR title summarizes the changes, e.g. "Adds `Grid._build_face_dimension` function".
      Avoid non-descriptive titles such as "Addresses issue #229". -->

Closes #1747 
<!--  Replace XXX with the issue number resolved by this PR, if this PR fully resolves an issue.
      If it resolves multiple issues, repeat "closes" for each, like "Closes #XXX, closes #YYY."
      If it does not fully resolve any issues, replace with something like "Related to #XXX",
          or "Fixes part of #YYY but does not fully close it." -->

## Overview
<!--  Please summarize the changes in this PR. How does it solve the original issue? -->

`_read_esmf` casts `elementConn` to `INT_DTYPE` and only then compares against `INT_FILL_VALUE`, so the padding is recognized in neither of the two ways xarray can hand it over. With CF decoding on (`mask_and_scale=True`, the default), xarray replaces ESMF's -1 with NaN and promotes the array to float; casting NaN to an integer dtype is platform-dependent, and on arm64 it yields 0, so the padding decodes to -1. With decoding off, the raw -1 survives the cast and decodes to -2. Both are negative indices that silently wrap to the end of the coordinate arrays instead of being treated as fill.

The fix locates the padding before the cast, from `numElementConn` — the format's own statement of each face's node count — and additionally treats NaN as padding whatever that count claims.

The test builds the ESMF dataset by hand instead of going through `_encode_esmf`, so it exercises the reader in isolation and covers third-party ESMF files rather than only our own output. It is parametrized over `mask_and_scale` to pin both decoding paths.

<!--  Does the scope of this PR do anything aside from just solving the original issue?
      And/or, does it not fully solve the issue as originally reported? If so, please clarify. -->


## PR Checklist
<!-- Please mark each item as [X] when completed, or [N/A] if not applicable to this PR. -->

**General**
- [x] An issue is created and linked
- [x] Added appropriate labels (if your uxarray repo permissions allow it)
- [x] Filled out Overview and Expected Usage (if applicable) sections

**Testing & Benchmarking**
- [ ] There is adequate test coverage of changes from this PR (add new tests if needed)
<!-- Adding the run-benchmark label (if your uxarray repo permissions allow it) will run ASV benchmarks.
    If you need benchmarks to be run but don't have permissions, leave this item unchecked for now. -->

**Documentation and Examples**
- [ ] Docstrings updated with any function changes, and included in all new functions
- [ ] User (public) functions added to `docs/api.rst`; internal (private) function names start with an underscore (`_`)

## AI Disclosure
<!-- Please specify all AI tools used. Optionally, include model and/or briefly describe usage. Examples:
    "AI Usage: Claude (Fable 5), Gemini"
    "AI Usage: ChatGPT (5.5 Instant) to help understand cause of this bug, but I wrote all updates myself."
    "AI Usage: just GitHub Copilot's inline code suggestions."
    If you did not use AI, please write "AI Usage: N/A" and remove these checklist items or mark as [N/A].-->

AI Usage: Claude Opus 5

- [x] I have tested and take responsibility for all AI-generated content in my PR.

<!-- **PR Etiquette Reminders**
- Please list as "draft PR" until ready for review.
- Please do NOT mark any review comment threads as resolved.
- Instead, please notify reviewers after addressing their comments, via @username or the "re-request review" button.
- (Reviewers: please mark your own threads as resolved after confirming your comments have been addressed.)
-->
