### PR TITLE
Remove UxDataArray.data_location

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -257,7 +257,6 @@ Grid Accessor
 
    UxDataArray.uxgrid
    UxDataArray.data_mapping
-   UxDataArray.data_location
 
 
 UxDataset

--- a/test/core/test_dataarray.py
+++ b/test/core/test_dataarray.py
@@ -138,8 +138,8 @@ def test_isel_invalid_dim(gridpath, datasetpath):
         uxda.isel(level=0)
 
 
-def test_data_location():
-    """Tests data_location for face/node/edge centered data and non-grid data."""
+def test_data_mapping():
+    """Tests data_mapping for face/node/edge mapped data and non-grid data."""
     uxgrid = ux.Grid.from_healpix(zoom=1)
 
     face_da = UxDataArray(
@@ -155,16 +155,19 @@ def test_data_location():
         np.ones(5), dims=["other_dim"], uxgrid=uxgrid
     )
 
-    assert face_da.data_location == "face_centered"
-    assert node_da.data_location == "node_centered"
-    assert edge_da.data_location == "edge_centered"
-    assert other_da.data_location is None
+    assert face_da.data_mapping == "faces"
+    assert node_da.data_mapping == "nodes"
+    assert edge_da.data_mapping == "edges"
+    assert other_da.data_mapping is None
 
     # Works when an extra (non-grid) dimension is present
     face_time = UxDataArray(
         np.ones((3, uxgrid.n_face)), dims=["time", "n_face"], uxgrid=uxgrid
     )
-    assert face_time.data_location == "face_centered"
+    assert face_time.data_mapping == "faces"
+
+    # data_location was folded into data_mapping
+    assert not hasattr(face_da, "data_location")
 
 
 class TestNeighborhood:
@@ -243,7 +246,7 @@ class TestNeighborhood:
         assert filtered.shape == uxda_time.shape
         np.testing.assert_allclose(filtered.values, data)
 
-    def test_invalid_data_location(self):
+    def test_invalid_data_mapping(self):
         """Data that is not mapped to a grid element should raise an error."""
         uxgrid = ux.Grid.from_healpix(zoom=1)
         uxda = UxDataArray(np.ones(5), dims=["other_dim"], uxgrid=uxgrid)

--- a/uxarray/core/dataarray.py
+++ b/uxarray/core/dataarray.py
@@ -183,26 +183,14 @@ class UxDataArray(xr.DataArray):
 
     @property
     def data_mapping(self):
-        """Returns which unstructured grid a data variable is mapped to."""
-        if self._face_centered():
-            return "faces"
-        elif self._edge_centered():
-            return "edges"
-        elif self._node_centered():
-            return "nodes"
-        else:
-            return None
+        """Returns which grid element a data variable is mapped to.
 
-    @property
-    def data_location(self):
-        """Returns where on the grid the data variable is stored.
+        The mapping is inferred from the grid dimension present in the data
+        variable:
 
-        The location is inferred from the grid dimension present in the data
-        variable, using UGRID-style names:
-
-        - ``"face_centered"`` if the data contains the ``n_face`` dimension
-        - ``"node_centered"`` if the data contains the ``n_node`` dimension
-        - ``"edge_centered"`` if the data contains the ``n_edge`` dimension
+        - ``"faces"`` if the data contains the ``n_face`` dimension
+        - ``"edges"`` if the data contains the ``n_edge`` dimension
+        - ``"nodes"`` if the data contains the ``n_node`` dimension
         - ``None`` if the data is not mapped to the grid
 
         Notes
@@ -215,15 +203,14 @@ class UxDataArray(xr.DataArray):
         Returns
         -------
         str or None
-            One of ``"face_centered"``, ``"node_centered"``,
-            ``"edge_centered"``, or ``None``.
+            One of ``"faces"``, ``"edges"``, ``"nodes"``, or ``None``.
         """
         if self._face_centered():
-            return "face_centered"
-        elif self._node_centered():
-            return "node_centered"
+            return "faces"
         elif self._edge_centered():
-            return "edge_centered"
+            return "edges"
+        elif self._node_centered():
+            return "nodes"
         else:
             return None
 
@@ -320,7 +307,7 @@ class UxDataArray(xr.DataArray):
 
         else:
             raise DataCenteringError(
-                f"to_geodataframe() expects face_centered data; got {self.data_location} data "
+                f"to_geodataframe() expects data mapped to faces; got data_mapping={self.data_mapping!r} "
                 f"(with sizes={dict(**self.sizes)}). Consider running "
                 "``UxDataArray.topological_mean(destination='face')`` to aggregate the data onto faces."
             )
@@ -645,8 +632,8 @@ class UxDataArray(xr.DataArray):
 
         elif not self._face_centered():
             raise DataCenteringError(
-                "Integration of non-face_centered data is not yet supported. "
-                f"(Got {self.data_location} data with sizes={dict(**self.sizes)})"
+                "Integration of data not mapped to faces is not yet supported. "
+                f"(Got data_mapping={self.data_mapping!r} with sizes={dict(**self.sizes)})"
             )
 
         else:


### PR DESCRIPTION
Closes #1748. `data_mapping` already returns the same information and is what `plot.points()` uses, so this drops `data_location`, moves its docstring onto `data_mapping`, and updates the two error messages that referenced it. Note `data_location` shipped in v2026.07.0 through v2026.09.0.