### PR TITLE
Fix Exodus encode treating every face as full width

### DIFF
--- a/test/grid/grid/test_io.py
+++ b/test/grid/grid/test_io.py
@@ -6,6 +6,11 @@ import uxarray as ux
 from uxarray.constants import ERROR_TOLERANCE
 
 
+def _face_rows(grid):
+    """Faces as a sorted list of node-index tuples, ignoring face order."""
+    return sorted(tuple(row.tolist()) for row in grid.face_node_connectivity.values)
+
+
 def test_normalize_existing_coordinates_non_norm_initial(gridpath):
     from uxarray.grid.validation import _check_normalization
     uxgrid = ux.open_grid(gridpath("mpas", "QU", "mesh.QU.1920km.151026.nc"))
@@ -131,10 +136,12 @@ def test_grid_ugrid_exodus_roundtrip(gridpath):
             reloaded_ugrid.face_node_connectivity.values,
             err_msg=f"UGRID face connectivity mismatch for {grid_name}"
         )
-        np.testing.assert_array_equal(
-            original_grid.face_node_connectivity.values,
-            reloaded_exodus.face_node_connectivity.values,
-            err_msg=f"Exodus face connectivity mismatch for {grid_name}"
+        # Exodus blocks are homogeneous, so a mixed mesh (RLL1deg has polar
+        # triangles among its quads) is regrouped by face size on write and comes
+        # back permuted. Compare the faces as a set for now; recording and
+        # restoring the original order is a separate fix.
+        assert _face_rows(reloaded_exodus) == _face_rows(original_grid), (
+            f"Exodus face connectivity mismatch for {grid_name}"
         )
 
         # Validate coordinate consistency with numerical tolerance

--- a/test/io/test_exodus.py
+++ b/test/io/test_exodus.py
@@ -5,6 +5,11 @@ import uxarray as ux
 from uxarray.constants import INT_DTYPE, INT_FILL_VALUE
 
 
+def _face_rows(grid):
+    """Faces as a sorted list of node-index tuples, ignoring face order."""
+    return sorted(tuple(row.tolist()) for row in grid.face_node_connectivity.values)
+
+
 def test_read_exodus(gridpath):
     """Read an exodus file and writes a exodus file."""
     uxgrid = ux.open_grid(gridpath("exodus", "outCSne8", "outCSne8.g"))
@@ -21,8 +26,50 @@ def test_init_verts():
 def test_encode_exodus(gridpath):
     """Read a UGRID dataset and encode that as an Exodus format."""
     uxgrid = ux.open_grid(gridpath("exodus", "outCSne8", "outCSne8.g"))
-    # Add encoding logic and assertions as needed
-    pass  # Placeholder for actual implementation
+    exo_ds = uxgrid.to_xarray("Exodus")
+
+    # A uniform quad mesh belongs in exactly one block, typed for a quad
+    blocks = [v for v in exo_ds.data_vars if v.startswith("connect")]
+    assert blocks == ["connect1"]
+    assert exo_ds["connect1"].attrs["elem_type"] == "SHELL4"
+    assert exo_ds["connect1"].shape == (uxgrid.n_face, 4)
+
+def test_encode_exodus_mixed_blocks():
+    """Faces of different sizes go into separate, correctly typed blocks.
+
+    Exodus element blocks are homogeneous, so a mixed mesh has to be split by
+    face size. Padding is stored as INT_FILL_VALUE, so matching it against -1
+    never fires: every face is treated as full width, collapsing the mesh into a
+    single max-width block with the wrong element type and writing the padding
+    out as a node index.
+    """
+    uxgrid = ux.Grid.from_topology(
+        node_lon=np.array([0.0, 10.0, 10.0, 0.0, 20.0]),
+        node_lat=np.array([0.0, 0.0, 10.0, 10.0, 0.0]),
+        face_node_connectivity=np.array([
+            [0, 1, 2, 3],
+            [1, 4, 2, INT_FILL_VALUE],
+            [0, 3, 4, INT_FILL_VALUE],
+        ]),
+        fill_value=INT_FILL_VALUE,
+    )
+
+    exo_ds = uxgrid.to_xarray("Exodus")
+
+    blocks = sorted(v for v in exo_ds.data_vars if v.startswith("connect"))
+    assert blocks == ["connect1", "connect2"]
+
+    by_type = {exo_ds[b].attrs["elem_type"]: exo_ds[b] for b in blocks}
+    assert set(by_type) == {"TRI", "SHELL4"}
+    assert by_type["TRI"].shape == (2, 3)
+    assert by_type["SHELL4"].shape == (1, 4)
+
+    # Exodus connectivity is 1-based, and every block is exactly as wide as its
+    # element type, so there is no padding left to write out.
+    for name in blocks:
+        values = exo_ds[name].values
+        assert values.min() >= 1, f"{name} holds an index below 1"
+        assert values.max() <= uxgrid.n_node, f"{name} indexes a node that does not exist"
 
 def test_mixed_exodus(gridpath):
     """Read/write an exodus file with two types of faces (triangle and quadrilaterals) and writes a ugrid file."""
@@ -39,7 +86,11 @@ def test_mixed_exodus(gridpath):
 
     # Face node connectivity comparison
     assert np.array_equal(ugrid_load_saved.face_node_connectivity.values, uxgrid.face_node_connectivity.values)
-    assert np.array_equal(uxgrid.face_node_connectivity.values, exodus_load_saved.face_node_connectivity.values)
+
+    # Exodus blocks are homogeneous, so a mixed mesh is regrouped by face size on
+    # write and comes back permuted. Compare the faces as a set for now; recording
+    # and restoring the original order is a separate fix.
+    assert _face_rows(exodus_load_saved) == _face_rows(uxgrid)
 
     # Node coordinates comparison
     assert np.array_equal(ugrid_load_saved.node_lon.values, uxgrid.node_lon.values)

--- a/uxarray/io/_exodus.py
+++ b/uxarray/io/_exodus.py
@@ -200,8 +200,10 @@ def _encode_exodus(ds, outfile=None):
     conn_nofill = []
 
     for row in ds["face_node_connectivity"].values:
-        # Find the index of the first fill value (-1)
-        fill_val_idx = np.where(row == -1)[0]
+        # Find the index of the first fill value. Padding is stored as
+        # INT_FILL_VALUE, not -1; matching on -1 never fires, so every face is
+        # treated as full width and the padding is written out as a node index.
+        fill_val_idx = np.where(row == INT_FILL_VALUE)[0]
 
         if fill_val_idx.size > 0:
             num_nodes = fill_val_idx[0]


### PR DESCRIPTION
<!--  Thank you for opening a PR! To help us review your contribution, please follow instructions below
      while filling out this form, and read the etiquette reminders at the bottom. -->

<!--  Please ensure the PR title summarizes the changes, e.g. "Adds `Grid._build_face_dimension` function".
      Avoid non-descriptive titles such as "Addresses issue #229". -->

Closes #1753
<!--  Replace XXX with the issue number resolved by this PR, if this PR fully resolves an issue.
      If it resolves multiple issues, repeat "closes" for each, like "Closes #XXX, closes #YYY."
      If it does not fully resolve any issues, replace with something like "Related to #XXX",
          or "Fixes part of #YYY but does not fully close it." -->

## Overview
<!--  Please summarize the changes in this PR. How does it solve the original issue? -->

`_encode_exodus` finds the end of each face with `np.where(row == -1)`, but connectivity padding is stored as `INT_FILL_VALUE`. The comparison never matches, so every face is counted at the maximum width. Two things follow: a mixed mesh collapses into a single element block carrying the wrong element type (triangles and quads all written as `SHELL4`), and the padding itself is written out as `INT_FILL_VALUE + 1` in a slot where a node index belongs.

The fix matches `INT_FILL_VALUE`. Element blocks then split by face size, which is what Exodus requires — blocks are homogeneous.

One note for reviewers: because blocks now genuinely split, a mixed mesh is regrouped by face size on write, and nothing yet records that permutation, so the mesh reloads reordered. Two existing round-trip tests therefore compare the Exodus faces as a set in this PR instead of element-wise — `test_mixed_exodus` (on the `mixed.exo` fixture) and `test_grid_ugrid_exodus_roundtrip` (on `outRLL1deg`, which has polar triangles among its quads). The follow-up (`cmd/exodus_block_reorder`) records the ordering and restores both strict comparisons. This PR is green on its own, but it does temporarily loosen those two assertions.

<!--  Does the scope of this PR do anything aside from just solving the original issue?
      And/or, does it not fully solve the issue as originally reported? If so, please clarify. -->


## Expected Usage
<!--  If this PR adds a new feature, please provide a short example of it in action.
      You may ignore this step if it is not applicable (delete this section). -->
```Python
import uxarray as ux

grid_path = "/path/to/grid.nc"
data_path = "/path/to/data.nc"

uxds = ux.open_dataset(grid_path, data_path)

# this is how you use this function
some_output = uxds.some_function()

# this is another way to use this function
other_output = uxds.some_function(some_param = True)
```

## PR Checklist
<!-- Please mark each item as [X] when completed, or [N/A] if not applicable to this PR. -->

**General**
- [ ] An issue is created and linked
- [ ] Added appropriate labels (if your uxarray repo permissions allow it)
- [ ] Filled out Overview and Expected Usage (if applicable) sections

**Testing & Benchmarking**
- [ ] There is adequate test coverage of changes from this PR (add new tests if needed)

**Documentation and Examples**
- [ ] Docstrings updated with any function changes, and included in all new functions
- [ ] User (public) functions added to `docs/api.rst`; internal (private) function names start with an underscore (`_`)

## AI Disclosure
<!-- Please specify all AI tools used. Optionally, include model and/or briefly describe usage. Examples:
    "AI Usage: Claude (Fable 5), Gemini"
    "AI Usage: ChatGPT (5.5 Instant) to help understand cause of this bug, but I wrote all updates myself."
    "AI Usage: just GitHub Copilot's inline code suggestions."
    If you did not use AI, please write "AI Usage: N/A" and remove these checklist items or mark as [N/A].-->

AI Usage: Claude Opus 5

- [ ] I have tested and take responsibility for all AI-generated content in my PR.

<!-- **PR Etiquette Reminders**
- Please list as "draft PR" until ready for review.
- Please do NOT mark any review comment threads as resolved.
- Instead, please notify reviewers after addressing their comments, via @username or the "re-request review" button.
- (Reviewers: please mark your own threads as resolved after confirming your comments have been addressed.)
-->
