### PR TITLE
Release the GIL in all numba kernels (nogil=True)

### DIFF
--- a/uxarray/core/gradient.py
+++ b/uxarray/core/gradient.py
@@ -350,7 +350,7 @@ def _dual_cell_area(sx, sy, sz, angles, n):
     return np.abs(area)
 
 
-@njit(cache=True, parallel=True)
+@njit(cache=True, parallel=True, nogil=True)
 def _compute_gradients_on_faces(
     data,
     n_face,

--- a/uxarray/grid/angles.py
+++ b/uxarray/grid/angles.py
@@ -8,7 +8,7 @@ from numba import njit, prange
 from uxarray.grid.utils import _numba_norm3, _small_angle_of_2_vectors
 
 
-@njit(cache=True, parallel=True)
+@njit(cache=True, parallel=True, nogil=True)
 def _compute_face_node_angles_convex(
     node_x,
     node_y,

--- a/uxarray/grid/bounds.py
+++ b/uxarray/grid/bounds.py
@@ -134,7 +134,7 @@ def _populate_face_bounds(
         grid._ds["bounds"] = bounds_da
 
 
-@njit(cache=True, parallel=True)
+@njit(cache=True, parallel=True, nogil=True)
 def _construct_face_bounds_array(
     face_node_connectivity,
     n_nodes_per_face,

--- a/uxarray/grid/connectivity.py
+++ b/uxarray/grid/connectivity.py
@@ -302,7 +302,7 @@ def _emit_bucket_edges(
         face_edge_flat[half_edge_slot[i]] = edge_idx
 
 
-@njit(cache=True, parallel=True)
+@njit(cache=True, parallel=True, nogil=True)
 def _build_edge_node_connectivity(face_node_connectivity, n_nodes_per_face, n_node):
     """Constructs the ``edge_node_connectivity`` variable, which represents the indices of the two nodes that make up
     each edge. Additionally, the ``face_edge_connectivity`` is derived during construction,  which represents the
@@ -403,7 +403,7 @@ def _populate_edge_face_connectivity(grid):
     )
 
 
-@njit(cache=True)
+@njit(cache=True, nogil=True)
 def _build_edge_face_connectivity(face_edges, n_nodes_per_face, n_edge):
     """Helper for (``edge_faces``) construction."""
     edge_faces = np.full((n_edge, 2), INT_FILL_VALUE, dtype=INT_DTYPE)
@@ -456,7 +456,7 @@ def _populate_face_edge_connectivity(grid):
     )
 
 
-@njit(cache=True, parallel=True)
+@njit(cache=True, parallel=True, nogil=True)
 def _build_face_edge_connectivity(
     face_node_connectivity, n_nodes_per_face, edge_node_connectivity, n_node
 ):
@@ -641,7 +641,7 @@ def _populate_face_face_connectivity(grid):
     )
 
 
-@njit(cache=True)
+@njit(cache=True, nogil=True)
 def _build_face_face_connectivity(edge_face_connectivity, n_face, n_max_face_nodes):
     face_face_connectivity = np.full(
         (n_face, n_max_face_nodes), INT_FILL_VALUE, INT_DTYPE
@@ -675,7 +675,7 @@ def _populate_node_edge_connectivity(grid):
     )
 
 
-@njit
+@njit(cache=True, nogil=True)
 def _build_node_edge_connectivity(edge_nodes, n_node):
     """Constructs the Node Edge Connectivity, which stores the indices of the edges that are shared by each node."""
     n_edge, nodes_per_edge = edge_nodes.shape

--- a/uxarray/grid/coordinates.py
+++ b/uxarray/grid/coordinates.py
@@ -14,7 +14,7 @@ from uxarray.utils.numba_math import (
 )
 
 
-@njit(cache=True)
+@njit(cache=True, nogil=True)
 def _lonlat_rad_to_xyz(
     lon: np.ndarray | float,
     lat: np.ndarray | float,
@@ -275,7 +275,7 @@ def _populate_face_centroids(grid, repopulate=False):
         )
 
 
-@njit(cache=True, parallel=True)
+@njit(cache=True, parallel=True, nogil=True)
 def _construct_face_centroids(node_x, node_y, node_z, face_nodes, n_nodes_per_face):
     """Constructs the xyz centroid coordinate for each face using Cartesian
     Averaging.
@@ -541,7 +541,7 @@ def _populate_face_centerpoints(grid, repopulate=False):
         )
 
 
-@njit(cache=True, parallel=True)
+@njit(cache=True, parallel=True, nogil=True)
 def _construct_face_centerpoints(node_lon, node_lat, face_nodes, n_nodes_per_face):
     """Constructs the face centerpoint using Welzl's algorithm.
 

--- a/uxarray/grid/dual.py
+++ b/uxarray/grid/dual.py
@@ -61,7 +61,7 @@ def construct_dual(grid):
     return new_node_face_connectivity
 
 
-@njit(cache=True, parallel=True)
+@njit(cache=True, parallel=True, nogil=True)
 def construct_faces(
     valid_node_indices,
     n_edges,

--- a/uxarray/grid/geometry.py
+++ b/uxarray/grid/geometry.py
@@ -83,7 +83,7 @@ def _unique_points(points, tolerance=ERROR_TOLERANCE):
     return unique_points[:unique_count]
 
 
-@njit(cache=True)
+@njit(cache=True, nogil=True)
 def _pad_closed_face_nodes(
     face_node_connectivity, n_face, n_max_face_nodes, n_nodes_per_face
 ):
@@ -1053,7 +1053,7 @@ def _populate_max_face_radius(grid):
     return max_distance
 
 
-@njit(cache=True, parallel=True)
+@njit(cache=True, parallel=True, nogil=True)
 def calculate_max_face_radius(
     face_node_connectivity: np.ndarray,
     node_x: np.ndarray,

--- a/uxarray/grid/integrate.py
+++ b/uxarray/grid/integrate.py
@@ -594,7 +594,7 @@ def _compute_face_arc_length(face_edges_xyz, z):
     return total_length
 
 
-@njit(cache=True, parallel=True)
+@njit(cache=True, parallel=True, nogil=True)
 def _zonal_face_weights_util_numba(
     face_edges_xyz: np.ndarray,
     n_edges_per_face: np.ndarray,

--- a/uxarray/grid/neighbors.py
+++ b/uxarray/grid/neighbors.py
@@ -1082,7 +1082,7 @@ def _populate_edge_node_distances(grid):
     )
 
 
-@njit(cache=True)
+@njit(cache=True, nogil=True)
 def _construct_edge_node_distances(node_lon, node_lat, edge_nodes):
     """Helper for computing the arc-distance between nodes compose each
     edge."""
@@ -1117,7 +1117,7 @@ def _populate_edge_face_distances(grid):
     )
 
 
-@njit(cache=True)
+@njit(cache=True, nogil=True)
 def _construct_edge_face_distances(face_lon, face_lat, edge_faces):
     """Helper for computing the arc-distance between faces that saddle a given
     edge."""

--- a/uxarray/grid/point_in_face.py
+++ b/uxarray/grid/point_in_face.py
@@ -120,7 +120,7 @@ def _get_faces_containing_point(
     return hit_buf[:count]
 
 
-@njit(cache=True, parallel=True)
+@njit(cache=True, parallel=True, nogil=True)
 def _batch_point_in_face(
     points: np.ndarray,
     flat_candidate_indices: np.ndarray,

--- a/uxarray/grid/utils.py
+++ b/uxarray/grid/utils.py
@@ -266,7 +266,7 @@ def _get_cartesian_face_edge_nodes_array(
     return face_edges_cartesian.reshape(n_face, n_max_face_edges, 2, 3)
 
 
-@njit(cache=True, parallel=True)
+@njit(cache=True, parallel=True, nogil=True)
 def _get_cartesian_face_edge_nodes_array_subset(
     face_indices,
     face_node_connectivity,

--- a/uxarray/remap/bilinear.py
+++ b/uxarray/remap/bilinear.py
@@ -158,7 +158,7 @@ def _barycentric_weights(point_xyz, dual, data_size, source_grid):
     return all_weights, all_indices
 
 
-@njit(cache=True, parallel=True)
+@njit(cache=True, parallel=True, nogil=True)
 def _calculate_weights(
     valid_idxs,
     point_xyz,


### PR DESCRIPTION


<!--  Thank you for opening a PR! To help us review your contribution, please follow instructions below
      while filling out this form, and read the etiquette reminders at the bottom. -->

<!--  Please ensure the PR title summarizes the changes, e.g. "Adds `Grid._build_face_dimension` function".
      Avoid non-descriptive titles such as "Addresses issue #229". -->

Closes #1756
<!--  Replace XXX with the issue number resolved by this PR, if this PR fully resolves an issue.
      If it resolves multiple issues, repeat "closes" for each, like "Closes #XXX, closes #YYY."
      If it does not fully resolve any issues, replace with something like "Related to #XXX",
          or "Fixes part of #YYY but does not fully close it." -->

## Overview
<!--  Please summarize the changes in this PR. How does it solve the original issue? -->

Only 2 of the 140 @njit sites in the package passed nogil=True (grid/connectivity.py, grid/area.py). Every other compiled kernel held the GIL for its whole execution, so calling them from dask's threaded scheduler as dask="parallelized" does serialized them completely, regardless of how many workers were configured.

Adds nogil=True to the 20 or so remaining top-level sites making @njit(cache=True, nogil=True) the default pattern. These are all nopython, allocation-light leaf kernels with no object-mode fallback.

Measured on _construct_edge_node_distances (2M edges, best of 3), the same kernel jitted with and without nogil:

    threads     GIL held        nogil   speedup
          1        95.0ms        95.3ms    1.00x
          2       191.5ms       101.1ms    1.89x
          4       381.0ms       104.1ms    3.66x
          8       762.8ms       115.1ms    6.63x

The GIL-held column scales linearly with thread count -- that is the signature of zero parallelism.

Two sites are deliberately left alone:

  * the guvectorize kernel in grid/neighbors.py -- numba rejects nogil as a @guvectorize option, and the gufunc machinery already drops the GIL around the loop.
  * the 15 parallel=True kernels keep parallel=True for now. Nested under dask's threadpool it oversubscribes; dropping it belongs with the work that gives dask the chunk loop.

_build_node_edge_connectivity in grid/connectivity.py is also the one kernel still missing cache=True; left as-is to keep this diff to nogil.

The `nogil_scaling.GILScaling.track_gil_scaling` is added to prove that `nogil` is working as expected.

## PR Checklist
<!-- Please mark each item as [X] when completed, or [N/A] if not applicable to this PR. -->

**General**
- [x] An issue is created and linked
- [x] Added appropriate labels (if your uxarray repo permissions allow it)
- [x] Filled out Overview and Expected Usage (if applicable) sections

**Testing & Benchmarking**
- [x] If this PR could affect performance, ran ASV benchmarks and confirmed they show expected behavior (add a new benchmark if necessary)
<!-- Adding the run-benchmark label (if your uxarray repo permissions allow it) will run ASV benchmarks.
    If you need benchmarks to be run but don't have permissions, leave this item unchecked for now. -->

## AI Disclosure
<!-- Please specify all AI tools used. Optionally, include model and/or briefly describe usage. Examples:
    "AI Usage: Claude (Fable 5), Gemini"
    "AI Usage: ChatGPT (5.5 Instant) to help understand cause of this bug, but I wrote all updates myself."
    "AI Usage: just GitHub Copilot's inline code suggestions."
    If you did not use AI, please write "AI Usage: N/A" and remove these checklist items or mark as [N/A].-->

AI Usage: Claude Opus 5

- [x] I have tested and take responsibility for all AI-generated content in my PR.

<!-- **PR Etiquette Reminders**
- Please list as "draft PR" until ready for review.
- Please do NOT mark any review comment threads as resolved.
- Instead, please notify reviewers after addressing their comments, via @username or the "re-request review" button.
- (Reviewers: please mark your own threads as resolved after confirming your comments have been addressed.)
-->
